### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Codex Meter is a **native Android client app** (`dev.bennett.codexmeter`). There is **no backend, server, or database** in this repo, so there is no long-running service to start — the dev workflow is build / test / lint, and the shippable artifact is a signed APK. Standard commands live in `README.md`, `build.sh`, `run-tests.sh`, and `lint.sh`; the notes below only cover the non-obvious environment caveats.
+
+### Toolchain / environment
+- **Android SDK** is installed at `~/android-sdk` (`platforms;android-36`, `build-tools;36.0.0`, `platform-tools`, `cmdline-tools`). `ANDROID_SDK_ROOT`, `ANDROID_HOME`, and the SDK `PATH` entries are exported from `~/.bashrc` and persist via the VM snapshot. The startup update script reinstalls the SDK only if `platforms/android-36` or `build-tools/36.0.0` are missing.
+- **JDK 21** is the system Java and satisfies the project's "JDK 17+" requirement; no separate JDK 17 install is needed. `build.sh`/`lint.sh` auto-detect `JAVA_HOME` only via macOS paths, so on this Linux VM ensure `JAVA_HOME` is set (e.g. `export JAVA_HOME="$(dirname "$(dirname "$(readlink -f "$(which java)")")")"`) before running them.
+
+### Tests / lint / build
+- `./run-tests.sh` runs **fully offline** on the JVM (parser/OAuth/PKCE/widget self-tests + source-integrity greps) with no device/emulator. It self-heals the `org.json` test jar by downloading it if `build/test-libs/` is empty (`build/` is gitignored). This is the primary fast verification loop — prefer it.
+- **`./build.sh` (`:app:assembleRelease`) and `./lint.sh` (`:app:lintRelease`) require a GitHub Packages token.** The `oneui-design` library's transitive `sesl.*` dependencies are published **only** to `maven.pkg.github.com/tribalfs/oneui-design` (they 404 on Maven Central and JitPack) and GitHub Packages returns **HTTP 401** without auth even though they are public. Set `GH_USERNAME` and `GH_ACCESS_TOKEN` (a PAT with the `read:packages` scope) — see `README.md`. The pre-provisioned `gh` CLI token does **not** have `read:packages` for the `tribalfs` org and cannot be used. Only the top-level `oneui-design` aar is cached in `vendor/m2`, not its transitive tree, so the token is required until those deps are vendored.
+- Running the app end-to-end additionally needs an Android emulator/device (API 26+) and a real ChatGPT account for the OAuth sign-in against OpenAI's servers — those are external to this repo.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the development environment setup for Cursor Cloud agents in a new `AGENTS.md`. No application code is changed.

This is a native Android client app (`dev.bennett.codexmeter`) with no backend/server/database, so the dev workflow is build / test / lint. The doc captures the non-obvious caveats future agents need:

- **Android SDK** lives at `~/android-sdk` (platform 36, build-tools 36.0.0); env vars are exported from `~/.bashrc` and persist via snapshot. The startup update script reinstalls the SDK only if it's missing.
- **JDK 21** is the system Java and satisfies "JDK 17+"; `build.sh`/`lint.sh` need `JAVA_HOME` set on Linux (they only auto-detect macOS paths).
- **`./run-tests.sh`** runs fully offline on the JVM (parser/OAuth/PKCE/widget self-tests + source checks) and is the primary fast verification loop.
- **`./build.sh` and `./lint.sh` require a GitHub Packages token** (`GH_USERNAME` + `GH_ACCESS_TOKEN` with `read:packages`): the `oneui-design` transitive `sesl.*` deps are published only to `maven.pkg.github.com/tribalfs/oneui-design` and return 401 without auth. The pre-provisioned `gh` CLI token lacks that scope.

## Testing

- `./run-tests.sh` passes (JVM parser/OAuth/widget self-tests + release source-integrity checks).

[run_tests_output.log](https://cursor.com/agents/bc-fcab5d5d-b242-4783-a5c2-186f3f6ecc80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frun_tests_output.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcab5d5d-b242-4783-a5c2-186f3f6ecc80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcab5d5d-b242-4783-a5c2-186f3f6ecc80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

