### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Codex Meter is a **single native Android app** (Gradle module `:app`, package `dev.bennett.codexmeter`). There is no backend, database, web frontend, or companion service — it talks directly to OpenAI/ChatGPT remote endpoints. Standard build/test/lint commands are in `README.md` (`./run-tests.sh`, `./build.sh`, `./lint.sh`).
+
+### Toolchain (pre-installed in the VM snapshot)
+- JDK 21 at `/usr/lib/jvm/java-21-openjdk-amd64` (project targets Java 17; JDK 21 builds fine with Gradle 9.6.1).
+- Android SDK at `~/android-sdk` with `platforms;android-36` + `build-tools;36.0.0` + `platform-tools`.
+- Gradle 9.6.1 via the committed wrapper (`./gradlew`); no system Gradle needed.
+- `JAVA_HOME`, `ANDROID_SDK_ROOT`, `ANDROID_HOME`, and `PATH` are exported from `~/.bashrc`. `build.sh`/`lint.sh` only auto-detect these on macOS paths, so on this Linux VM they rely on those env vars being present. In a non-login/non-interactive shell that did not source `~/.bashrc`, export them first:
+  `export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ANDROID_SDK_ROOT=$HOME/android-sdk ANDROID_HOME=$HOME/android-sdk`.
+
+### Blocker: GitHub Packages credentials required for the full build
+`build.sh` (`:app:assembleRelease`) and `lint.sh` (`:app:lintRelease`) resolve `io.github.tribalfs:oneui-design`'s transitive **SESL** dependencies from `https://maven.pkg.github.com/tribalfs/oneui-design`. GitHub Packages Maven **always requires authentication, even for public packages**, so without credentials every SESL artifact returns `401 Unauthorized` and the build fails. `vendor/m2` only caches the top-level `oneui-design` AAR, not its transitive deps.
+
+To build/lint, set repo secrets `GH_USERNAME` (a GitHub username) and `GH_ACCESS_TOKEN` (a PAT with `read:packages`); `settings.gradle.kts` reads them from the environment. `run-tests.sh` does **not** need these credentials.
+
+### Running / testing
+- `./run-tests.sh` compiles and runs the pure-Java core self-tests (usage-response parsing, PKCE/OAuth, JWT claims, widget options) — no Android SDK or GitHub creds required. Use this as the fast correctness check.
+- There is no Android emulator/GUI in this VM, and an APK cannot be installed/launched headlessly here. Validate changes with `run-tests.sh` and (once creds exist) a successful `build.sh`/`lint.sh`. The signed APK lands in `dist/` and is the product artifact.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Sets up the development environment for the Codex Meter Android app and documents durable, cloud-specific instructions in a new `AGENTS.md`.

This is a **single native Android app** (Gradle `:app`, `dev.bennett.codexmeter`) — no backend/DB/web service.

## Environment set up (in the VM snapshot, not committed)
- Installed **JDK 21** (project targets Java 17; builds fine under Gradle 9.6.1).
- Installed **Android SDK**: `platforms;android-36`, `build-tools;36.0.0`, `platform-tools` at `~/android-sdk`.
- Warmed **Gradle 9.6.1** via the committed wrapper.
- Exported `JAVA_HOME`/`ANDROID_SDK_ROOT`/`ANDROID_HOME` in `~/.bashrc` (`build.sh`/`lint.sh` only auto-detect these on macOS paths).

## Update script
`./gradlew --version` — minimal, idempotent warm/verify of the Gradle wrapper distribution (no GitHub creds or SDK env needed).

## Verified working (end-to-end)
- ✅ `./run-tests.sh` — core self-tests pass (usage-response parsing, PKCE/OAuth, JWT claims, widget options).
- ✅ `./build.sh` — **BUILD SUCCESSFUL**; produces signed `dist/CodexMeter-2.0.0.apk` (16.8 MB), APK Signature Scheme v2 verified, package `dev.bennett.codexmeter` v2.0.0.
- ✅ `./lint.sh` (`:app:lintRelease`) — BUILD SUCCESSFUL.
- ✅ `./gradlew --version` — Gradle 9.6.1 on JDK 21.

## Note on credentials
`build.sh`/`lint.sh` resolve `oneui-design`'s transitive **SESL** deps from `maven.pkg.github.com/tribalfs`, and GitHub Packages Maven **always requires auth**. With `GH_USERNAME` + `GH_ACCESS_TOKEN` (PAT, `read:packages`) provided, the build/lint succeed. Store these as repo secrets so future cloud agents can build without re-entering them. `run-tests.sh` does not need them.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-405bd8d4-68f6-458f-9918-aab699807432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-405bd8d4-68f6-458f-9918-aab699807432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

