### PR TITLE
Add surprise rate-limit reset celebrations

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/ExternalResetDetector.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ExternalResetDetector.java
@@ -13,11 +13,10 @@ public final class ExternalResetDetector {
     public static boolean isUnexpectedReset(int previousUsedPercent, long expectedResetAtMillis,
             UsageWindow current, long observedAtMillis, boolean manualResetPending) {
         if (manualResetPending || current == null || previousUsedPercent <= 0
-                || current.usedPercent != 0) {
+                || current.usedPercent != 0 || expectedResetAtMillis <= 0L) {
             return false;
         }
-        return expectedResetAtMillis <= 0L
-                || observedAtMillis < expectedResetAtMillis - NATURAL_RESET_TOLERANCE_MS;
+        return observedAtMillis < expectedResetAtMillis - NATURAL_RESET_TOLERANCE_MS;
     }
 
     public static long expectedResetAt(UsageWindow window, long fetchedAtMillis) {

--- a/app/src/main/java/dev/bennett/codexmeter/ExternalResetDetector.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ExternalResetDetector.java
@@ -1,0 +1,31 @@
+package dev.bennett.codexmeter;
+
+/** Classifies full-allowance jumps that are not explained by a local reset or countdown. */
+public final class ExternalResetDetector {
+    public static final int NONE = 0;
+    public static final int FIVE_HOUR = 1;
+    public static final int WEEKLY = 1 << 1;
+    static final long NATURAL_RESET_TOLERANCE_MS = 60_000L;
+
+    private ExternalResetDetector() {
+    }
+
+    public static boolean isUnexpectedReset(int previousUsedPercent, long expectedResetAtMillis,
+            UsageWindow current, long observedAtMillis, boolean manualResetPending) {
+        if (manualResetPending || current == null || previousUsedPercent <= 0
+                || current.usedPercent != 0) {
+            return false;
+        }
+        return expectedResetAtMillis <= 0L
+                || observedAtMillis < expectedResetAtMillis - NATURAL_RESET_TOLERANCE_MS;
+    }
+
+    public static long expectedResetAt(UsageWindow window, long fetchedAtMillis) {
+        if (window == null) return 0L;
+        long resetAt = window.resetAtMillis();
+        if (resetAt > 0L) return resetAt;
+        return window.resetAfterSeconds > 0L
+                ? fetchedAtMillis + window.resetAfterSeconds * 1000L
+                : 0L;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class ResetAlertPreferences {
+    private static final String KEY_EXTERNAL_RESET_ENABLED = "external_reset_enabled";
+    private static final String KEY_EXTERNAL_RESET_STYLE = "external_reset_style";
     private static final String KEY_METRIC = "metric";
     private static final String KEY_STYLE = "style";
     private static final String KEY_THRESHOLD = "threshold";
@@ -12,6 +14,9 @@ public final class ResetAlertPreferences {
     public static final String METRIC_FIVE_HOUR = "five_hour";
     public static final String METRIC_WEEKLY = "weekly";
     private static final String PREFS = "codex_meter_reset_alerts_v1";
+    public static final String EXTERNAL_STYLE_CELEBRATION = "celebration";
+    public static final String EXTERNAL_STYLE_NOTIFICATION = "notification";
+    public static final String EXTERNAL_STYLE_SILENT = "silent";
     public static final String STYLE_ALARM = "alarm";
     public static final String STYLE_NOTIFICATION = "notification";
     public static final String STYLE_OFF = "off";
@@ -42,6 +47,25 @@ public final class ResetAlertPreferences {
         return 25;
     }
 
+    public static boolean externalResetEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_EXTERNAL_RESET_ENABLED, true);
+    }
+
+    public static String getExternalResetStyle(Context context) {
+        String style = prefs(context).getString(KEY_EXTERNAL_RESET_STYLE,
+                EXTERNAL_STYLE_CELEBRATION);
+        return isValidExternalStyle(style) ? style : EXTERNAL_STYLE_CELEBRATION;
+    }
+
+    public static void setExternalResetEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_EXTERNAL_RESET_ENABLED, enabled).apply();
+    }
+
+    public static void setExternalResetStyle(Context context, String style) {
+        prefs(context).edit().putString(KEY_EXTERNAL_RESET_STYLE,
+                isValidExternalStyle(style) ? style : EXTERNAL_STYLE_CELEBRATION).apply();
+    }
+
     public static void save(Context context, String str, String str2, int i) {
         if (!STYLE_SILENT.equals(str) && !STYLE_NOTIFICATION.equals(str) && !STYLE_ALARM.equals(str)) {
             str = STYLE_OFF;
@@ -61,5 +85,11 @@ public final class ResetAlertPreferences {
 
     private static boolean isValidThreshold(int i) {
         return i == 10 || i == 25 || i == 50 || i == 75 || i == 100;
+    }
+
+    private static boolean isValidExternalStyle(String style) {
+        return EXTERNAL_STYLE_CELEBRATION.equals(style)
+                || EXTERNAL_STYLE_NOTIFICATION.equals(style)
+                || EXTERNAL_STYLE_SILENT.equals(style);
     }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/ResetCreditApi.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetCreditApi.java
@@ -89,6 +89,7 @@ public final class ResetCreditApi {
             String message = "";
 
             if (ResetConsumeResult.RESET.equals(code)) {
+                ResetNotificationManager.markManualReset(app, System.currentTimeMillis());
                 try {
                     UsageSnapshot snapshot = UsageApi.refreshAndCache(app);
                     RefreshScheduler.scheduleAtNextReset(app, snapshot);

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -15,13 +15,21 @@ import android.os.Build;
 /** Posts and deduplicates Codex usage, reset-time, and reset-credit notifications. */
 public final class ResetNotificationManager {
     private static final String CHANNEL_ALARM = "codex_reset_alarm";
+    private static final String CHANNEL_EXTERNAL_CELEBRATION = "codex_external_reset_celebration_v1";
     private static final String CHANNEL_NOTIFY = "codex_reset_notify";
     private static final String CHANNEL_SILENT = "codex_reset_silent";
     private static final String PREFS = "codex_meter_notification_state_v1";
+    private static final String KEY_FIVE_HOUR_LAST_RESET_AT = "five_hour_last_reset_at";
+    private static final String KEY_FIVE_HOUR_LAST_USED = "five_hour_last_used";
     private static final String KEY_FIVE_HOUR_WINDOW = "low_five_hour_window";
+    private static final String KEY_MANUAL_RESET_PENDING_UNTIL = "manual_reset_pending_until";
+    private static final String KEY_WEEKLY_LAST_RESET_AT = "weekly_last_reset_at";
+    private static final String KEY_WEEKLY_LAST_USED = "weekly_last_used";
     private static final String KEY_WEEKLY_WINDOW = "low_weekly_window";
     private static final String KEY_CREDIT_COUNT = "known_reset_credit_count";
+    private static final long MANUAL_RESET_SUPPRESSION_MS = 5 * 60_000L;
     private static final int NOTIFICATION_TEST = 74400;
+    private static final int NOTIFICATION_EXTERNAL_RESET = 74411;
     private static final int NOTIFICATION_RESET_FIVE_HOUR = 74405;
     private static final int NOTIFICATION_RESET_WEEKLY = 74407;
     private static final int NOTIFICATION_LOW_FIVE_HOUR = 74505;
@@ -33,15 +41,29 @@ public final class ResetNotificationManager {
 
     public static void onUsageUpdated(Context context, UsageSnapshot snapshot) {
         if (context == null || snapshot == null || !ResetAlertPreferences.enabled(context)) return;
+        int unexpectedResets = detectUnexpectedResets(context, snapshot);
+        int celebratedResets = ResetAlertPreferences.externalResetEnabled(context)
+                ? unexpectedResets : ExternalResetDetector.NONE;
+        if (celebratedResets != ExternalResetDetector.NONE) {
+            postExternalReset(context, celebratedResets, NOTIFICATION_EXTERNAL_RESET);
+        }
         String metric = ResetAlertPreferences.getMetric(context);
-        if (!ResetAlertPreferences.METRIC_WEEKLY.equals(metric)) {
+        if (!ResetAlertPreferences.METRIC_WEEKLY.equals(metric)
+                && (celebratedResets & ExternalResetDetector.FIVE_HOUR) == 0) {
             notifyLowWindow(context, snapshot.fiveHour, snapshot.fetchedAtMillis,
                     "5-hour", KEY_FIVE_HOUR_WINDOW, NOTIFICATION_LOW_FIVE_HOUR);
         }
-        if (!ResetAlertPreferences.METRIC_FIVE_HOUR.equals(metric)) {
+        if (!ResetAlertPreferences.METRIC_FIVE_HOUR.equals(metric)
+                && (celebratedResets & ExternalResetDetector.WEEKLY) == 0) {
             notifyLowWindow(context, snapshot.weekly, snapshot.fetchedAtMillis,
                     "Weekly", KEY_WEEKLY_WINDOW, NOTIFICATION_LOW_WEEKLY);
         }
+    }
+
+    public static void markManualReset(Context context, long resetAtMillis) {
+        if (context == null) return;
+        state(context).edit().putLong(KEY_MANUAL_RESET_PENDING_UNTIL,
+                resetAtMillis + MANUAL_RESET_SUPPRESSION_MS).apply();
     }
 
     public static void onResetCreditsUpdated(Context context, ResetCreditsSnapshot snapshot) {
@@ -77,14 +99,27 @@ public final class ResetNotificationManager {
             return false;
         }
         return post(context, NOTIFICATION_TEST, "Codex Meter notifications are working",
-                "You’ll be notified for low usage, usage-window resets, and new reset credits.",
+                "You’ll be notified for low usage, usage-window resets, surprise resets, and new reset credits.",
                 NOTIFICATION_TEST);
+    }
+
+    public static boolean sendExternalResetTestNotification(Context context) {
+        return context != null && ResetAlertPreferences.enabled(context)
+                && ResetAlertPreferences.externalResetEnabled(context)
+                && postExternalReset(context,
+                        ExternalResetDetector.FIVE_HOUR | ExternalResetDetector.WEEKLY,
+                        NOTIFICATION_TEST);
     }
 
     public static void ensureChannel(Context context) {
         if (context == null) return;
         NotificationManager manager = manager(context);
-        if (manager != null) createChannel(manager, ResetAlertPreferences.getStyle(context));
+        if (manager != null) {
+            createChannel(manager, ResetAlertPreferences.getStyle(context));
+            if (ResetAlertPreferences.externalResetEnabled(context)) {
+                createExternalChannel(manager, ResetAlertPreferences.getExternalResetStyle(context));
+            }
+        }
     }
 
     public static void clearState(Context context) {
@@ -109,11 +144,73 @@ public final class ResetNotificationManager {
         }
     }
 
+    private static int detectUnexpectedResets(Context context, UsageSnapshot snapshot) {
+        SharedPreferences state = state(context);
+        long observedAt = snapshot.fetchedAtMillis > 0L
+                ? snapshot.fetchedAtMillis : System.currentTimeMillis();
+        boolean manualResetPending = state.getLong(KEY_MANUAL_RESET_PENDING_UNTIL, 0L)
+                >= System.currentTimeMillis();
+        int result = detectUnexpectedReset(state, snapshot.fiveHour, observedAt,
+                manualResetPending, KEY_FIVE_HOUR_LAST_USED, KEY_FIVE_HOUR_LAST_RESET_AT)
+                ? ExternalResetDetector.FIVE_HOUR : ExternalResetDetector.NONE;
+        if (detectUnexpectedReset(state, snapshot.weekly, observedAt, manualResetPending,
+                KEY_WEEKLY_LAST_USED, KEY_WEEKLY_LAST_RESET_AT)) {
+            result |= ExternalResetDetector.WEEKLY;
+        }
+
+        SharedPreferences.Editor editor = state.edit();
+        saveWindowState(editor, snapshot.fiveHour, snapshot.fetchedAtMillis,
+                KEY_FIVE_HOUR_LAST_USED, KEY_FIVE_HOUR_LAST_RESET_AT);
+        saveWindowState(editor, snapshot.weekly, snapshot.fetchedAtMillis,
+                KEY_WEEKLY_LAST_USED, KEY_WEEKLY_LAST_RESET_AT);
+        editor.apply();
+        return result;
+    }
+
+    private static boolean detectUnexpectedReset(SharedPreferences state, UsageWindow current,
+            long observedAt, boolean manualResetPending, String usedKey, String resetAtKey) {
+        return current != null && state.contains(usedKey)
+                && ExternalResetDetector.isUnexpectedReset(state.getInt(usedKey, 0),
+                        state.getLong(resetAtKey, 0L), current, observedAt, manualResetPending);
+    }
+
+    private static void saveWindowState(SharedPreferences.Editor editor, UsageWindow window,
+            long fetchedAt, String usedKey, String resetAtKey) {
+        if (window == null) {
+            editor.remove(usedKey).remove(resetAtKey);
+            return;
+        }
+        editor.putInt(usedKey, window.usedPercent)
+                .putLong(resetAtKey, ExternalResetDetector.expectedResetAt(window, fetchedAt));
+    }
+
+    private static boolean postExternalReset(Context context, int resets, int notificationId) {
+        String label;
+        if (resets == (ExternalResetDetector.FIVE_HOUR | ExternalResetDetector.WEEKLY)) {
+            label = "5-hour and weekly allowances";
+        } else if ((resets & ExternalResetDetector.WEEKLY) != 0) {
+            label = "weekly allowance";
+        } else {
+            label = "5-hour allowance";
+        }
+        return postWithChannel(context, notificationId, "Surprise! Codex limits restored",
+                "Your " + label + " jumped back to 100% before the countdown ended. "
+                        + "Looks like someone reset it for you!",
+                notificationId, true);
+    }
+
     private static boolean post(Context context, int id, String title, String text, int requestCode) {
+        return postWithChannel(context, id, title, text, requestCode, false);
+    }
+
+    private static boolean postWithChannel(Context context, int id, String title, String text,
+            int requestCode, boolean externalReset) {
         if (!canPost(context)) return false;
         NotificationManager manager = manager(context);
         if (manager == null) return false;
-        String channel = createChannel(manager, ResetAlertPreferences.getStyle(context));
+        String channel = externalReset
+                ? createExternalChannel(manager, ResetAlertPreferences.getExternalResetStyle(context))
+                : createChannel(manager, ResetAlertPreferences.getStyle(context));
         PendingIntent contentIntent = PendingIntent.getActivity(context, requestCode,
                 new Intent(context, MainActivity.class).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
                         | Intent.FLAG_ACTIVITY_SINGLE_TOP),
@@ -176,5 +273,23 @@ public final class ResetNotificationManager {
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION).build());
         manager.createNotificationChannel(channel);
         return CHANNEL_NOTIFY;
+    }
+
+    private static String createExternalChannel(NotificationManager manager, String style) {
+        if (ResetAlertPreferences.EXTERNAL_STYLE_SILENT.equals(style)) {
+            return createChannel(manager, ResetAlertPreferences.STYLE_SILENT);
+        }
+        if (ResetAlertPreferences.EXTERNAL_STYLE_NOTIFICATION.equals(style)) {
+            return createChannel(manager, ResetAlertPreferences.STYLE_NOTIFICATION);
+        }
+        NotificationChannel channel = new NotificationChannel(CHANNEL_EXTERNAL_CELEBRATION,
+                "Surprise Codex resets", NotificationManager.IMPORTANCE_HIGH);
+        channel.setDescription("Celebrations when an unexplained reset restores your allowance");
+        channel.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION).build());
+        channel.enableVibration(true);
+        manager.createNotificationChannel(channel);
+        return CHANNEL_EXTERNAL_CELEBRATION;
     }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -16,6 +16,8 @@ import android.os.Build;
 public final class ResetNotificationManager {
     private static final String CHANNEL_ALARM = "codex_reset_alarm";
     private static final String CHANNEL_EXTERNAL_CELEBRATION = "codex_external_reset_celebration_v1";
+    private static final String CHANNEL_EXTERNAL_NOTIFY = "codex_external_reset_notify_v1";
+    private static final String CHANNEL_EXTERNAL_SILENT = "codex_external_reset_silent_v1";
     private static final String CHANNEL_NOTIFY = "codex_reset_notify";
     private static final String CHANNEL_SILENT = "codex_reset_silent";
     private static final String PREFS = "codex_meter_notification_state_v1";
@@ -29,6 +31,7 @@ public final class ResetNotificationManager {
     private static final String KEY_CREDIT_COUNT = "known_reset_credit_count";
     private static final long MANUAL_RESET_SUPPRESSION_MS = 5 * 60_000L;
     private static final int NOTIFICATION_TEST = 74400;
+    private static final int NOTIFICATION_EXTERNAL_RESET_TEST = 74410;
     private static final int NOTIFICATION_EXTERNAL_RESET = 74411;
     private static final int NOTIFICATION_RESET_FIVE_HOUR = 74405;
     private static final int NOTIFICATION_RESET_WEEKLY = 74407;
@@ -60,10 +63,14 @@ public final class ResetNotificationManager {
         }
     }
 
-    public static void markManualReset(Context context, long resetAtMillis) {
+    public static void markManualReset(Context context, long observedAtMillis) {
         if (context == null) return;
-        state(context).edit().putLong(KEY_MANUAL_RESET_PENDING_UNTIL,
-                resetAtMillis + MANUAL_RESET_SUPPRESSION_MS).apply();
+        state(context).edit()
+                .putLong(KEY_MANUAL_RESET_PENDING_UNTIL,
+                        observedAtMillis + MANUAL_RESET_SUPPRESSION_MS)
+                .putInt(KEY_FIVE_HOUR_LAST_USED, 0)
+                .putInt(KEY_WEEKLY_LAST_USED, 0)
+                .apply();
     }
 
     public static void onResetCreditsUpdated(Context context, ResetCreditsSnapshot snapshot) {
@@ -108,7 +115,7 @@ public final class ResetNotificationManager {
                 && ResetAlertPreferences.externalResetEnabled(context)
                 && postExternalReset(context,
                         ExternalResetDetector.FIVE_HOUR | ExternalResetDetector.WEEKLY,
-                        NOTIFICATION_TEST);
+                        NOTIFICATION_EXTERNAL_RESET_TEST);
     }
 
     public static void ensureChannel(Context context) {
@@ -180,8 +187,9 @@ public final class ResetNotificationManager {
             editor.remove(usedKey).remove(resetAtKey);
             return;
         }
+        long observedAt = fetchedAt > 0L ? fetchedAt : System.currentTimeMillis();
         editor.putInt(usedKey, window.usedPercent)
-                .putLong(resetAtKey, ExternalResetDetector.expectedResetAt(window, fetchedAt));
+                .putLong(resetAtKey, ExternalResetDetector.expectedResetAt(window, observedAt));
     }
 
     private static boolean postExternalReset(Context context, int resets, int notificationId) {
@@ -195,7 +203,7 @@ public final class ResetNotificationManager {
         }
         return postWithChannel(context, notificationId, "Surprise! Codex limits restored",
                 "Your " + label + " jumped back to 100% before the countdown ended. "
-                        + "Looks like someone reset it for you!",
+                        + "Looks like someone reset your Codex limits for you!",
                 notificationId, true);
     }
 
@@ -276,20 +284,38 @@ public final class ResetNotificationManager {
     }
 
     private static String createExternalChannel(NotificationManager manager, String style) {
+        String channelId;
+        String channelName;
+        int importance;
         if (ResetAlertPreferences.EXTERNAL_STYLE_SILENT.equals(style)) {
-            return createChannel(manager, ResetAlertPreferences.STYLE_SILENT);
+            channelId = CHANNEL_EXTERNAL_SILENT;
+            channelName = "Silent surprise Codex resets";
+            importance = NotificationManager.IMPORTANCE_LOW;
+        } else if (ResetAlertPreferences.EXTERNAL_STYLE_NOTIFICATION.equals(style)) {
+            channelId = CHANNEL_EXTERNAL_NOTIFY;
+            channelName = "Surprise Codex resets";
+            importance = NotificationManager.IMPORTANCE_DEFAULT;
+        } else {
+            channelId = CHANNEL_EXTERNAL_CELEBRATION;
+            channelName = "Surprise Codex reset celebrations";
+            importance = NotificationManager.IMPORTANCE_HIGH;
         }
-        if (ResetAlertPreferences.EXTERNAL_STYLE_NOTIFICATION.equals(style)) {
-            return createChannel(manager, ResetAlertPreferences.STYLE_NOTIFICATION);
-        }
-        NotificationChannel channel = new NotificationChannel(CHANNEL_EXTERNAL_CELEBRATION,
-                "Surprise Codex resets", NotificationManager.IMPORTANCE_HIGH);
+        NotificationChannel channel = new NotificationChannel(channelId, channelName, importance);
         channel.setDescription("Celebrations when an unexplained reset restores your allowance");
+        if (ResetAlertPreferences.EXTERNAL_STYLE_SILENT.equals(style)) {
+            channel.setSound(null, null);
+            channel.enableVibration(false);
+            manager.createNotificationChannel(channel);
+            return channelId;
+        }
         channel.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
                 new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION).build());
-        channel.enableVibration(true);
+        if (ResetAlertPreferences.EXTERNAL_STYLE_CELEBRATION.equals(style)) {
+            channel.enableVibration(true);
+            channel.setVibrationPattern(new long[]{0L, 180L, 90L, 180L, 90L, 360L});
+        }
         manager.createNotificationChannel(channel);
-        return CHANNEL_EXTERNAL_CELEBRATION;
+        return channelId;
     }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -222,6 +222,7 @@ public final class SettingsActivity extends AppCompatActivity {
             });
 
             SwitchPreferenceCompat externalReset = findPreference("external_reset_enabled_ui");
+            externalReset.setPersistent(false);
             externalReset.setChecked(ResetAlertPreferences.externalResetEnabled(requireContext()));
             externalReset.setOnPreferenceChangeListener((preference, value) -> {
                 ResetAlertPreferences.setExternalResetEnabled(requireContext(), (Boolean) value);
@@ -231,6 +232,7 @@ public final class SettingsActivity extends AppCompatActivity {
             });
 
             ListPreference externalResetStyle = findPreference("external_reset_style_ui");
+            externalResetStyle.setPersistent(false);
             externalResetStyle.setValue(ResetAlertPreferences.getExternalResetStyle(requireContext()));
             externalResetStyle.setOnPreferenceChangeListener((preference, value) -> {
                 ResetAlertPreferences.setExternalResetStyle(requireContext(), String.valueOf(value));

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -221,6 +221,33 @@ public final class SettingsActivity extends AppCompatActivity {
                 return true;
             });
 
+            SwitchPreferenceCompat externalReset = findPreference("external_reset_enabled_ui");
+            externalReset.setChecked(ResetAlertPreferences.externalResetEnabled(requireContext()));
+            externalReset.setOnPreferenceChangeListener((preference, value) -> {
+                ResetAlertPreferences.setExternalResetEnabled(requireContext(), (Boolean) value);
+                if ((Boolean) value) ResetNotificationManager.ensureChannel(requireContext());
+                updateExternalResetControls();
+                return true;
+            });
+
+            ListPreference externalResetStyle = findPreference("external_reset_style_ui");
+            externalResetStyle.setValue(ResetAlertPreferences.getExternalResetStyle(requireContext()));
+            externalResetStyle.setOnPreferenceChangeListener((preference, value) -> {
+                ResetAlertPreferences.setExternalResetStyle(requireContext(), String.valueOf(value));
+                ResetNotificationManager.ensureChannel(requireContext());
+                return true;
+            });
+
+            Preference externalResetTest = findPreference("external_reset_test");
+            externalResetTest.setOnPreferenceClickListener(preference -> {
+                boolean sent = ResetNotificationManager.sendExternalResetTestNotification(requireContext());
+                Toast.makeText(requireContext(), sent
+                        ? "Surprise reset preview sent."
+                        : "Enable surprise resets and allow notifications first.",
+                        sent ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG).show();
+                return true;
+            });
+
             permissionPreference = findPreference("notification_permission");
             permissionPreference.setOnPreferenceClickListener(preference -> {
                 startActivity(new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
@@ -237,6 +264,7 @@ public final class SettingsActivity extends AppCompatActivity {
                 return true;
             });
             updatePermissionSummary();
+            updateExternalResetControls();
         }
 
         private void setNotificationsEnabled(boolean enabled) {
@@ -253,6 +281,7 @@ public final class SettingsActivity extends AppCompatActivity {
             } else {
                 ResetNotificationManager.clearState(requireContext());
             }
+            updateExternalResetControls();
         }
 
         private void saveAlert(String style, String metric, int threshold) {
@@ -276,6 +305,19 @@ public final class SettingsActivity extends AppCompatActivity {
             if (testNotificationPreference != null) {
                 testNotificationPreference.setEnabled(allowed && ResetAlertPreferences.enabled(requireContext()));
             }
+        }
+
+        private void updateExternalResetControls() {
+            if (getContext() == null) return;
+            boolean notificationsEnabled = ResetAlertPreferences.enabled(requireContext());
+            boolean celebrationEnabled = notificationsEnabled
+                    && ResetAlertPreferences.externalResetEnabled(requireContext());
+            Preference toggle = findPreference("external_reset_enabled_ui");
+            Preference style = findPreference("external_reset_style_ui");
+            Preference preview = findPreference("external_reset_test");
+            if (toggle != null) toggle.setEnabled(notificationsEnabled);
+            if (style != null) style.setEnabled(celebrationEnabled);
+            if (preview != null) preview.setEnabled(celebrationEnabled);
         }
     }
 }

--- a/app/src/main/res/values/settings_arrays.xml
+++ b/app/src/main/res/values/settings_arrays.xml
@@ -33,4 +33,10 @@
     <string-array name="settings_threshold_values">
         <item>100</item><item>10</item><item>25</item><item>50</item><item>75</item>
     </string-array>
+    <string-array name="settings_external_reset_style_entries">
+        <item>Celebration</item><item>Standard notification</item><item>Silent</item>
+    </string-array>
+    <string-array name="settings_external_reset_style_values">
+        <item>celebration</item><item>notification</item><item>silent</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -48,6 +48,21 @@
             android:key="notification_threshold_ui"
             android:title="Low when remaining reaches"
             app:useSimpleSummaryProvider="true" />
+        <SwitchPreferenceCompat
+            android:key="external_reset_enabled_ui"
+            android:title="Celebrate surprise resets"
+            android:summary="Notify when an allowance returns to 100% before its countdown ends" />
+        <ListPreference
+            android:entries="@array/settings_external_reset_style_entries"
+            android:entryValues="@array/settings_external_reset_style_values"
+            android:key="external_reset_style_ui"
+            android:title="Surprise reset alert"
+            app:useSimpleSummaryProvider="true" />
+        <Preference
+            android:key="external_reset_test"
+            android:title="Preview surprise reset"
+            android:summary="Send the celebration notification now"
+            app:iconSpaceReserved="false" />
         <Preference
             android:key="notification_permission"
             android:title="Notification permission"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,6 +29,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWindow.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageParser.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ExternalResetDetector.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/Pkce.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/JwtClaims.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java" \
@@ -54,6 +55,9 @@ test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertScheduler.java
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertReceiver.java"
 grep -q 'scheduleFromSnapshot' "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertScheduler.java"
 grep -q 'POST_NOTIFICATIONS' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'external_reset_enabled' "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java"
+grep -q 'markManualReset' "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditApi.java"
+grep -q 'Celebrate surprise resets' "$ROOT/app/src/main/res/xml/preferences_settings.xml"
 
 grep -R -q '<Chronometer' "$ROOT/app/src/main/res/layout/widget_lock_"*.xml
 grep -q 'setChronometerCountDown' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -15,7 +15,8 @@ public final class ParserSelfTest {
         testJwtMerge();
         testPkce();
         testWidgetOptions();
-        System.out.println("All parser, PKCE, and widget-option self-tests passed.");
+        testUnexpectedResetDetection();
+        System.out.println("All parser, PKCE, widget-option, and reset-detection self-tests passed.");
     }
 
     private static void testStandardUsage() throws Exception {
@@ -125,6 +126,27 @@ public final class ParserSelfTest {
         check(WidgetOptions.SURFACE_ONE_UI.equals(transparent.surfaceStyle), "One UI widget style");
         check(WidgetOptions.GRAPHIC_MAX.equals(transparent.graphicScale), "maximum graphic scale");
         check(!WidgetOptions.defaults().showTitle, "widget title defaults off");
+    }
+
+    private static void testUnexpectedResetDetection() {
+        long observedAt = 1_000_000L;
+        UsageWindow full = new UsageWindow(0, 18_000L, 0L, 0L);
+        check(ExternalResetDetector.isUnexpectedReset(1, observedAt + 3_600_000L,
+                full, observedAt, false), "99% to 100% surprise reset");
+        check(ExternalResetDetector.isUnexpectedReset(2, observedAt + 3_600_000L,
+                full, observedAt, false), "98% to 100% surprise reset");
+        check(!ExternalResetDetector.isUnexpectedReset(90, observedAt - 1L,
+                full, observedAt, false), "natural reset excluded");
+        check(!ExternalResetDetector.isUnexpectedReset(90, observedAt + 3_600_000L,
+                full, observedAt, true), "manual reset excluded");
+        check(!ExternalResetDetector.isUnexpectedReset(0, observedAt + 3_600_000L,
+                full, observedAt, false), "already-full allowance excluded");
+        check(!ExternalResetDetector.isUnexpectedReset(90, observedAt + 3_600_000L,
+                new UsageWindow(1, 18_000L, 0L, 0L), observedAt, false),
+                "partial refill excluded");
+        check(ExternalResetDetector.expectedResetAt(
+                new UsageWindow(40, 18_000L, 600L, 0L), observedAt)
+                == observedAt + 600_000L, "relative countdown fallback");
     }
 
     private static String jwt(String payload) {

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -135,8 +135,15 @@ public final class ParserSelfTest {
                 full, observedAt, false), "99% to 100% surprise reset");
         check(ExternalResetDetector.isUnexpectedReset(2, observedAt + 3_600_000L,
                 full, observedAt, false), "98% to 100% surprise reset");
+        check(ExternalResetDetector.isUnexpectedReset(100, observedAt + 3_600_000L,
+                full, observedAt, false), "empty to full surprise reset");
         check(!ExternalResetDetector.isUnexpectedReset(90, observedAt - 1L,
                 full, observedAt, false), "natural reset excluded");
+        check(!ExternalResetDetector.isUnexpectedReset(90,
+                observedAt + ExternalResetDetector.NATURAL_RESET_TOLERANCE_MS,
+                full, observedAt, false), "natural reset tolerance boundary excluded");
+        check(!ExternalResetDetector.isUnexpectedReset(90, 0L,
+                full, observedAt, false), "unknown countdown excluded");
         check(!ExternalResetDetector.isUnexpectedReset(90, observedAt + 3_600_000L,
                 full, observedAt, true), "manual reset excluded");
         check(!ExternalResetDetector.isUnexpectedReset(0, observedAt + 3_600_000L,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- detect allowance jumps to 100% that occur before the prior reset countdown
- suppress celebrations for natural expiry and locally redeemed reset credits, including delayed refresh after redemption
- add configurable celebration delivery settings, dedicated Android channels, and an in-app preview
- cover 98%, 99%, empty-to-full, countdown-boundary, unknown-timing, manual, natural, and partial-refill cases

## Validation
- `bash run-tests.sh`
- `bash build.sh`
- `bash lint.sh`

[surprise_reset_detection_verified.log](https://cursor.com/agents/bc-9efa9248-3389-4dbd-8b40-4dc6b3a8b7aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsurprise_reset_detection_verified.log)

## Manual testing limitation
- Android UI execution is unavailable in this cloud VM because no device is attached and `/dev/kvm` is unavailable; an API 36 AVD was created but cannot boot without hardware acceleration.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9efa9248-3389-4dbd-8b40-4dc6b3a8b7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9efa9248-3389-4dbd-8b40-4dc6b3a8b7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

