### PR TITLE
Add One UI one-hand reach behavior to Settings

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -31,11 +31,7 @@ public final class SettingsActivity extends AppCompatActivity {
         AppPreferences.setAppStyle(this, WidgetOptions.SURFACE_ONE_UI);
         setContentView(R.layout.activity_settings);
         ToolbarLayout toolbar = findViewById(R.id.settings_toolbar_layout);
-        toolbar.setTitle("Settings");
-        toolbar.setExpandable(false);
-        toolbar.setExpanded(false, false);
-        toolbar.setShowNavigationButtonAsBack(true);
-        Ui.configureSystemBars(this, toolbar, Ui.isDark(this));
+        Ui.configureReachToolbar(toolbar, "Settings", true);
         if (bundle == null) {
             getSupportFragmentManager().beginTransaction()
                     .replace(R.id.settings_fragment, new SettingsFragment())

--- a/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -98,6 +98,8 @@ public final class Ui {
     public static void configureReachToolbar(ToolbarLayout toolbar, String title, boolean back) {
         toolbar.setTitle(title);
         toolbar.setShowNavigationButtonAsBack(back);
+        // Force SESL to recalculate its responsive app-bar height after XML inflation.
+        toolbar.setExpandable(false);
         toolbar.setExpandable(true);
         toolbar.setExpanded(true, false);
     }

--- a/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -90,11 +90,16 @@ public final class Ui {
         View root = LayoutInflater.from(activity).inflate(R.layout.activity_oneui_dashboard, parent, false);
         ToolbarLayout toolbar = root.findViewById(R.id.toolbar_layout);
         LinearLayout content = root.findViewById(R.id.dashboard_content);
-        toolbar.setTitle(title);
-        toolbar.setShowNavigationButtonAsBack(back);
-        toolbar.setExpanded(true, false);
+        configureReachToolbar(toolbar, title, back);
         activity.setContentView(root);
         return new Page(toolbar, content);
+    }
+
+    public static void configureReachToolbar(ToolbarLayout toolbar, String title, boolean back) {
+        toolbar.setTitle(title);
+        toolbar.setShowNavigationButtonAsBack(back);
+        toolbar.setExpandable(true);
+        toolbar.setExpanded(true, false);
     }
 
     public static void startSecondaryActivity(Activity activity, Class<? extends Activity> activityClass) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -4,8 +4,8 @@
     android:id="@+id/settings_toolbar_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:expanded="false"
-    app:expandable="false"
+    app:expanded="true"
+    app:expandable="true"
     app:showNavButtonAsBack="true"
     app:title="Settings">
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -49,6 +49,13 @@ grep -q 'android:scheme="codexmeter"' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ResetAlertReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'MY_PACKAGE_REPLACED' "$ROOT/app/src/main/AndroidManifest.xml"
 
+grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"
+grep -q 'app:expandable="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"
+grep -q 'Ui.configureReachToolbar(toolbar, "Settings", true);' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'toolbar.setExpandable(true);' "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
+grep -q 'toolbar.setExpanded(true, false);' "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
+
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertScheduler.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertReceiver.java"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -53,6 +53,7 @@ grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.x
 grep -q 'app:expandable="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"
 grep -q 'Ui.configureReachToolbar(toolbar, "Settings", true);' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'toolbar.setExpandable(false);' "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
 grep -q 'toolbar.setExpandable(true);' "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
 grep -q 'toolbar.setExpanded(true, false);' "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- share the dashboard's expanded `ToolbarLayout` configuration with Settings
- enable expanded and collapsible Settings title behavior in XML
- force SESL to recalculate responsive app-bar height after inflation
- add lightweight regression guards for the reach-layout contract

## Walkthrough
[settings_one_hand_reach_direct_apk_demo.mp4](https://cursor.com/agents/bc-019f5856-057b-7b60-ac76-ce154671bd09/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_one_hand_reach_direct_apk_demo.mp4)

[Expanded Settings one-hand layout](https://cursor.com/agents/bc-019f5856-057b-7b60-ac76-ce154671bd09/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_one_hand_reach_expanded_final.webp)

Signed APK: `/opt/cursor/artifacts/CodexMeter-2.0.1-settings-one-hand-reach.apk`

## Testing
- `./run-tests.sh`
- `./lint.sh`
- `./build.sh`
- `sha256sum -c dist/SHA256SUMS.txt`
- APK badging verified package `dev.bennett.codexmeter` and launcher `MainActivity`
- final signed release installed on API 26 emulator with tall phone profile
- manually verified dashboard-to-Settings navigation, expanded title/content displacement, scroll collapse, re-expansion, theme controls, and back navigation

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5856-057b-7b60-ac76-ce154671bd09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5856-057b-7b60-ac76-ce154671bd09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

