### PR TITLE
Move privacy details into Settings

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
-import dev.oneuiproject.oneui.widget.CardItemView;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class MainActivity extends AppCompatActivity {
@@ -208,8 +207,6 @@ public final class MainActivity extends AppCompatActivity {
                 Ui.addSpacer(this.content, 20);
             }
             this.content.addView(buildResetCreditsCard());
-            Ui.addSpacer(this.content, 20);
-            this.content.addView(buildPrivacyCard());
         }
     }
 
@@ -370,20 +367,6 @@ public final class MainActivity extends AppCompatActivity {
         });
         linearLayoutCard.addView(button, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60.0f)));
         return linearLayoutCard;
-    }
-
-    private LinearLayout buildPrivacyCard() {
-        LinearLayout card = Ui.card(this, this.dark);
-        card.setPadding(0, 0, 0, 0);
-        CardItemView row = Ui.actionRow(
-                this,
-                "Local data and privacy",
-                "OAuth tokens are encrypted with Android Keystore. Requests go only to OpenAI for authentication and ChatGPT & Codex endpoints.",
-                R.drawable.ic_oui_privacy,
-                null);
-        row.getSummaryView().setMaxLines(6);
-        card.addView(row);
-        return card;
     }
 
     private LinearLayout buildWidgetCard() {

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -59,6 +59,15 @@
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="Privacy">
+        <Preference
+            android:icon="@drawable/ic_oui_privacy"
+            android:summary="OAuth tokens are encrypted with Android Keystore. Requests go only to OpenAI for authentication and ChatGPT &amp; Codex endpoints."
+            android:title="Local data and privacy"
+            app:iconSpaceReserved="false"
+            app:selectable="false" />
+    </PreferenceCategory>
+
     <dev.oneuiproject.oneui.preference.InsetPreferenceCategory app:height="20dp" />
 
     <Preference


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the privacy card from the main dashboard.
- Add the same local data and privacy explanation to a dedicated Settings section.

## Testing
- `./run-tests.sh`
- `./build.sh`
- `./lint.sh`
- Parsed the Settings XML and asserted the privacy content appears once in Settings and no longer exists in `MainActivity`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3f56a70-6735-4ec5-973a-ce35d3283c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3f56a70-6735-4ec5-973a-ce35d3283c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

