### PR TITLE
Add external reset celebration notifications

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java
+++ b/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java
@@ -1,0 +1,55 @@
+package dev.bennett.codexmeter;
+
+/** Pure decision logic for unexpected allowance refills and reset-credit increases. */
+public final class CelebrationDetector {
+    public static final int FIVE_HOUR = 1;
+    public static final int WEEKLY = 1 << 1;
+
+    private CelebrationDetector() {
+    }
+
+    /**
+     * Returns a bit mask for windows that became completely available before their previously
+     * advertised reset deadline. A missing deadline is deliberately ignored because a natural
+     * reset cannot be distinguished from an external refill in that case.
+     */
+    public static int detectUnexpectedRefills(UsageSnapshot previous, UsageSnapshot current) {
+        if (previous == null || current == null || current.fetchedAtMillis <= 0L) return 0;
+        int refills = 0;
+        if (isUnexpectedRefill(previous, previous.fiveHour, current.fiveHour,
+                current.fetchedAtMillis)) {
+            refills |= FIVE_HOUR;
+        }
+        if (isUnexpectedRefill(previous, previous.weekly, current.weekly,
+                current.fetchedAtMillis)) {
+            refills |= WEEKLY;
+        }
+        return refills;
+    }
+
+    public static int resetCreditsAdded(int previous, int current) {
+        if (previous < 0 || current <= previous) return 0;
+        return current - previous;
+    }
+
+    static long expectedResetMillis(UsageSnapshot snapshot, UsageWindow window) {
+        if (snapshot == null || window == null) return 0L;
+        long resetAt = window.resetAtMillis();
+        if (resetAt > 0L) return resetAt;
+        if (snapshot.fetchedAtMillis <= 0L || window.resetAfterSeconds <= 0L) return 0L;
+        if (window.resetAfterSeconds > (Long.MAX_VALUE - snapshot.fetchedAtMillis) / 1000L) {
+            return Long.MAX_VALUE;
+        }
+        return snapshot.fetchedAtMillis + window.resetAfterSeconds * 1000L;
+    }
+
+    private static boolean isUnexpectedRefill(UsageSnapshot previous, UsageWindow oldWindow,
+            UsageWindow newWindow, long observedAtMillis) {
+        if (oldWindow == null || newWindow == null
+                || oldWindow.usedPercent <= 0 || newWindow.usedPercent != 0) {
+            return false;
+        }
+        long expectedReset = expectedResetMillis(previous, oldWindow);
+        return expectedReset > observedAtMillis;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java
+++ b/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java
@@ -32,6 +32,17 @@ public final class CelebrationDetector {
         return current - previous;
     }
 
+    public static int withoutUserResetRefills(int refills, long observedAtMillis,
+            long fiveHourSuppressUntil, long weeklySuppressUntil) {
+        if (fiveHourSuppressUntil > observedAtMillis) {
+            refills &= ~FIVE_HOUR;
+        }
+        if (weeklySuppressUntil > observedAtMillis) {
+            refills &= ~WEEKLY;
+        }
+        return refills;
+    }
+
     static long expectedResetMillis(UsageSnapshot snapshot, UsageWindow window) {
         if (snapshot == null || window == null) return 0L;
         long resetAt = window.resetAtMillis();

--- a/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java
@@ -6,8 +6,10 @@ import android.content.SharedPreferences;
 /* JADX INFO: loaded from: classes.dex */
 public final class ResetAlertPreferences {
     private static final String KEY_METRIC = "metric";
+    private static final String KEY_RESET_CREDIT_INCREASES = "reset_credit_increases";
     private static final String KEY_STYLE = "style";
     private static final String KEY_THRESHOLD = "threshold";
+    private static final String KEY_UNEXPECTED_REFILLS = "unexpected_refills";
     public static final String METRIC_BOTH = "both";
     public static final String METRIC_FIVE_HOUR = "five_hour";
     public static final String METRIC_WEEKLY = "weekly";
@@ -57,6 +59,22 @@ public final class ResetAlertPreferences {
 
     public static boolean enabled(Context context) {
         return !STYLE_OFF.equals(getStyle(context));
+    }
+
+    public static boolean unexpectedRefillsEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_UNEXPECTED_REFILLS, true);
+    }
+
+    public static void setUnexpectedRefillsEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_UNEXPECTED_REFILLS, enabled).apply();
+    }
+
+    public static boolean resetCreditIncreasesEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_RESET_CREDIT_INCREASES, true);
+    }
+
+    public static void setResetCreditIncreasesEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_RESET_CREDIT_INCREASES, enabled).apply();
     }
 
     private static boolean isValidThreshold(int i) {

--- a/app/src/main/java/dev/bennett/codexmeter/ResetCreditApi.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetCreditApi.java
@@ -89,6 +89,7 @@ public final class ResetCreditApi {
             String message = "";
 
             if (ResetConsumeResult.RESET.equals(code)) {
+                ResetNotificationManager.markUserReset(app, AppPreferences.loadSnapshot(app));
                 try {
                     UsageSnapshot snapshot = UsageApi.refreshAndCache(app);
                     RefreshScheduler.scheduleAtNextReset(app, snapshot);

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -48,9 +48,6 @@ public final class ResetNotificationManager {
         int unexpectedRefills = suppressUserResetRefills(context,
                 CelebrationDetector.detectUnexpectedRefills(previous, snapshot),
                 snapshot.fetchedAtMillis);
-        if (snapshot.resetCreditsAvailable >= 0) {
-            onResetCreditCountUpdated(context, snapshot.resetCreditsAvailable);
-        }
         if (!ResetAlertPreferences.enabled(context)) return;
         String metric = ResetAlertPreferences.getMetric(context);
         if (!ResetAlertPreferences.METRIC_WEEKLY.equals(metric)) {
@@ -69,6 +66,11 @@ public final class ResetNotificationManager {
     public static void onResetCreditsUpdated(Context context, ResetCreditsSnapshot snapshot) {
         if (context == null || snapshot == null) return;
         onResetCreditCountUpdated(context, snapshot.availableCount);
+    }
+
+    static void onResetCreditSummaryUpdated(Context context, int availableCount) {
+        if (context == null || availableCount < 0) return;
+        onResetCreditCountUpdated(context, availableCount);
     }
 
     private static void onResetCreditCountUpdated(Context context, int current) {
@@ -242,9 +244,11 @@ public final class ResetNotificationManager {
     }
 
     private static boolean canPost(Context context) {
-        return Build.VERSION.SDK_INT < 33
+        NotificationManager manager = manager(context);
+        return manager != null && manager.areNotificationsEnabled()
+                && (Build.VERSION.SDK_INT < 33
                 || context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
-                == PackageManager.PERMISSION_GRANTED;
+                == PackageManager.PERMISSION_GRANTED);
     }
 
     private static NotificationManager manager(Context context) {

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -184,30 +184,24 @@ public final class ResetNotificationManager {
     private static int suppressUserResetRefills(Context context, int refills, long observedAt) {
         SharedPreferences preferences = state(context);
         SharedPreferences.Editor editor = preferences.edit();
-        int filtered = suppressUserResetWindow(preferences, editor,
-                KEY_USER_RESET_FIVE_HOUR_UNTIL, CelebrationDetector.FIVE_HOUR,
-                refills, observedAt);
-        filtered = suppressUserResetWindow(preferences, editor,
-                KEY_USER_RESET_WEEKLY_UNTIL, CelebrationDetector.WEEKLY,
-                filtered, observedAt);
+        long fiveHourUntil = preferences.getLong(KEY_USER_RESET_FIVE_HOUR_UNTIL, 0L);
+        long weeklyUntil = preferences.getLong(KEY_USER_RESET_WEEKLY_UNTIL, 0L);
+        int filtered = CelebrationDetector.withoutUserResetRefills(refills, observedAt,
+                fiveHourUntil, weeklyUntil);
+        clearUsedSuppression(editor, KEY_USER_RESET_FIVE_HOUR_UNTIL,
+                CelebrationDetector.FIVE_HOUR, refills, filtered, observedAt, fiveHourUntil);
+        clearUsedSuppression(editor, KEY_USER_RESET_WEEKLY_UNTIL,
+                CelebrationDetector.WEEKLY, refills, filtered, observedAt, weeklyUntil);
         editor.apply();
         return filtered;
     }
 
-    private static int suppressUserResetWindow(SharedPreferences preferences,
-            SharedPreferences.Editor editor, String key, int window, int refills,
-            long observedAt) {
-        long suppressUntil = preferences.getLong(key, 0L);
-        if (suppressUntil <= 0L) return refills;
-        if (observedAt >= suppressUntil) {
+    private static void clearUsedSuppression(SharedPreferences.Editor editor, String key,
+            int window, int before, int after, long observedAt, long suppressUntil) {
+        if (suppressUntil > 0L && (observedAt >= suppressUntil
+                || ((before & window) != 0 && (after & window) == 0))) {
             editor.remove(key);
-            return refills;
         }
-        if ((refills & window) != 0) {
-            editor.remove(key);
-            return refills & ~window;
-        }
-        return refills;
     }
 
     private static void markUserResetWindow(SharedPreferences.Editor editor, String key,

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -21,18 +21,36 @@ public final class ResetNotificationManager {
     private static final String KEY_FIVE_HOUR_WINDOW = "low_five_hour_window";
     private static final String KEY_WEEKLY_WINDOW = "low_weekly_window";
     private static final String KEY_CREDIT_COUNT = "known_reset_credit_count";
+    private static final String KEY_USER_RESET_FIVE_HOUR_UNTIL = "user_reset_five_hour_until";
+    private static final String KEY_USER_RESET_WEEKLY_UNTIL = "user_reset_weekly_until";
+    private static final long UNKNOWN_USER_RESET_SUPPRESSION_MS = 15 * 60 * 1000L;
     private static final int NOTIFICATION_TEST = 74400;
     private static final int NOTIFICATION_RESET_FIVE_HOUR = 74405;
     private static final int NOTIFICATION_RESET_WEEKLY = 74407;
     private static final int NOTIFICATION_LOW_FIVE_HOUR = 74505;
     private static final int NOTIFICATION_LOW_WEEKLY = 74507;
     private static final int NOTIFICATION_NEW_CREDIT = 74509;
+    private static final int NOTIFICATION_REFILL_FIVE_HOUR = 74511;
+    private static final int NOTIFICATION_REFILL_WEEKLY = 74512;
+    private static final int NOTIFICATION_REFILL_BOTH = 74513;
 
     private ResetNotificationManager() {
     }
 
     public static void onUsageUpdated(Context context, UsageSnapshot snapshot) {
-        if (context == null || snapshot == null || !ResetAlertPreferences.enabled(context)) return;
+        onUsageUpdated(context, null, snapshot);
+    }
+
+    public static void onUsageUpdated(Context context, UsageSnapshot previous,
+            UsageSnapshot snapshot) {
+        if (context == null || snapshot == null) return;
+        int unexpectedRefills = suppressUserResetRefills(context,
+                CelebrationDetector.detectUnexpectedRefills(previous, snapshot),
+                snapshot.fetchedAtMillis);
+        if (snapshot.resetCreditsAvailable >= 0) {
+            onResetCreditCountUpdated(context, snapshot.resetCreditsAvailable);
+        }
+        if (!ResetAlertPreferences.enabled(context)) return;
         String metric = ResetAlertPreferences.getMetric(context);
         if (!ResetAlertPreferences.METRIC_WEEKLY.equals(metric)) {
             notifyLowWindow(context, snapshot.fiveHour, snapshot.fetchedAtMillis,
@@ -42,25 +60,49 @@ public final class ResetNotificationManager {
             notifyLowWindow(context, snapshot.weekly, snapshot.fetchedAtMillis,
                     "Weekly", KEY_WEEKLY_WINDOW, NOTIFICATION_LOW_WEEKLY);
         }
+        if (ResetAlertPreferences.unexpectedRefillsEnabled(context)) {
+            notifyUnexpectedRefill(context, unexpectedRefills);
+        }
     }
 
     public static void onResetCreditsUpdated(Context context, ResetCreditsSnapshot snapshot) {
         if (context == null || snapshot == null) return;
+        onResetCreditCountUpdated(context, snapshot.availableCount);
+    }
+
+    private static void onResetCreditCountUpdated(Context context, int current) {
         SharedPreferences state = state(context);
-        int current = snapshot.availableCount;
         if (!state.contains(KEY_CREDIT_COUNT)) {
             state.edit().putInt(KEY_CREDIT_COUNT, current).apply();
             return;
         }
         int previous = state.getInt(KEY_CREDIT_COUNT, current);
         state.edit().putInt(KEY_CREDIT_COUNT, current).apply();
-        if (!ResetAlertPreferences.enabled(context) || current <= previous) return;
-        int added = current - previous;
+        int added = CelebrationDetector.resetCreditsAdded(previous, current);
+        if (!ResetAlertPreferences.enabled(context)
+                || !ResetAlertPreferences.resetCreditIncreasesEnabled(context)
+                || added <= 0) return;
         String text = added == 1
-                ? "A new Codex reset is available. You now have " + current + "."
-                : added + " new Codex resets are available. You now have " + current + ".";
-        post(context, NOTIFICATION_NEW_CREDIT, "New Codex reset available", text,
+                ? "One Codex reset credit was added. You now have " + current + "."
+                : added + " Codex reset credits were added. You now have " + current + ".";
+        post(context, NOTIFICATION_NEW_CREDIT,
+                added == 1 ? "Codex reset credit added" : "Codex reset credits added", text,
                 NOTIFICATION_NEW_CREDIT);
+    }
+
+    /**
+     * Marks cached non-full windows as user-reset so delayed propagation cannot be mistaken for
+     * an external refill on a later refresh.
+     */
+    public static void markUserReset(Context context, UsageSnapshot snapshot) {
+        if (context == null || snapshot == null) return;
+        long now = System.currentTimeMillis();
+        SharedPreferences.Editor editor = state(context).edit();
+        markUserResetWindow(editor, KEY_USER_RESET_FIVE_HOUR_UNTIL,
+                snapshot, snapshot.fiveHour, now);
+        markUserResetWindow(editor, KEY_USER_RESET_WEEKLY_UNTIL,
+                snapshot, snapshot.weekly, now);
+        editor.apply();
     }
 
     public static void showResetNotification(Context context, String metric) {
@@ -77,7 +119,7 @@ public final class ResetNotificationManager {
             return false;
         }
         return post(context, NOTIFICATION_TEST, "Codex Meter notifications are working",
-                "You’ll be notified for low usage, usage-window resets, and new reset credits.",
+                "Low usage, scheduled resets, surprise refills, and reset-credit alerts are ready.",
                 NOTIFICATION_TEST);
     }
 
@@ -89,6 +131,15 @@ public final class ResetNotificationManager {
 
     public static void clearState(Context context) {
         if (context != null) state(context).edit().clear().apply();
+    }
+
+    public static void clearNotificationHistory(Context context) {
+        if (context == null) return;
+        state(context).edit()
+                .remove(KEY_FIVE_HOUR_WINDOW)
+                .remove(KEY_WEEKLY_WINDOW)
+                .remove(KEY_CREDIT_COUNT)
+                .apply();
     }
 
     private static void notifyLowWindow(Context context, UsageWindow window, long fetchedAt,
@@ -107,6 +158,67 @@ public final class ResetNotificationManager {
                 notificationId)) {
             state.edit().putLong(stateKey, windowId).apply();
         }
+    }
+
+    private static void notifyUnexpectedRefill(Context context, int refills) {
+        if (refills == 0) return;
+        boolean fiveHour = (refills & CelebrationDetector.FIVE_HOUR) != 0;
+        boolean weekly = (refills & CelebrationDetector.WEEKLY) != 0;
+        if (fiveHour && weekly) {
+            post(context, NOTIFICATION_REFILL_BOTH, "Surprise Codex refill",
+                    "Your 5-hour and weekly allowances jumped to 100% before their scheduled resets. Enjoy the bonus capacity.",
+                    NOTIFICATION_REFILL_BOTH);
+        } else if (weekly) {
+            post(context, NOTIFICATION_REFILL_WEEKLY, "Surprise weekly Codex refill",
+                    "Your weekly allowance jumped to 100% before its scheduled reset. Enjoy the bonus capacity.",
+                    NOTIFICATION_REFILL_WEEKLY);
+        } else {
+            post(context, NOTIFICATION_REFILL_FIVE_HOUR, "Surprise 5-hour Codex refill",
+                    "Your 5-hour allowance jumped to 100% before its scheduled reset. Enjoy the bonus capacity.",
+                    NOTIFICATION_REFILL_FIVE_HOUR);
+        }
+    }
+
+    private static int suppressUserResetRefills(Context context, int refills, long observedAt) {
+        SharedPreferences preferences = state(context);
+        SharedPreferences.Editor editor = preferences.edit();
+        int filtered = suppressUserResetWindow(preferences, editor,
+                KEY_USER_RESET_FIVE_HOUR_UNTIL, CelebrationDetector.FIVE_HOUR,
+                refills, observedAt);
+        filtered = suppressUserResetWindow(preferences, editor,
+                KEY_USER_RESET_WEEKLY_UNTIL, CelebrationDetector.WEEKLY,
+                filtered, observedAt);
+        editor.apply();
+        return filtered;
+    }
+
+    private static int suppressUserResetWindow(SharedPreferences preferences,
+            SharedPreferences.Editor editor, String key, int window, int refills,
+            long observedAt) {
+        long suppressUntil = preferences.getLong(key, 0L);
+        if (suppressUntil <= 0L) return refills;
+        if (observedAt >= suppressUntil) {
+            editor.remove(key);
+            return refills;
+        }
+        if ((refills & window) != 0) {
+            editor.remove(key);
+            return refills & ~window;
+        }
+        return refills;
+    }
+
+    private static void markUserResetWindow(SharedPreferences.Editor editor, String key,
+            UsageSnapshot snapshot, UsageWindow window, long now) {
+        if (window == null || window.usedPercent <= 0) {
+            editor.remove(key);
+            return;
+        }
+        long suppressUntil = CelebrationDetector.expectedResetMillis(snapshot, window);
+        if (suppressUntil <= now) {
+            suppressUntil = now + UNKNOWN_USER_RESET_SUPPRESSION_MS;
+        }
+        editor.putLong(key, suppressUntil);
     }
 
     private static boolean post(Context context, int id, String title, String text, int requestCode) {
@@ -151,7 +263,7 @@ public final class ResetNotificationManager {
         if (ResetAlertPreferences.STYLE_SILENT.equals(style)) {
             NotificationChannel channel = new NotificationChannel(CHANNEL_SILENT,
                     "Codex usage alerts", NotificationManager.IMPORTANCE_LOW);
-            channel.setDescription("Low usage, reset times, and new reset credits");
+            channel.setDescription("Low usage, scheduled resets, surprise refills, and reset credits");
             channel.setSound(null, null);
             channel.enableVibration(false);
             manager.createNotificationChannel(channel);
@@ -160,7 +272,7 @@ public final class ResetNotificationManager {
         if (ResetAlertPreferences.STYLE_ALARM.equals(style)) {
             NotificationChannel channel = new NotificationChannel(CHANNEL_ALARM,
                     "Codex usage alarms", NotificationManager.IMPORTANCE_HIGH);
-            channel.setDescription("Low usage, reset times, and new reset credits");
+            channel.setDescription("Low usage, scheduled resets, surprise refills, and reset credits");
             channel.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM),
                     new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_ALARM)
                             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION).build());
@@ -170,7 +282,7 @@ public final class ResetNotificationManager {
         }
         NotificationChannel channel = new NotificationChannel(CHANNEL_NOTIFY,
                 "Codex usage alerts", NotificationManager.IMPORTANCE_DEFAULT);
-        channel.setDescription("Low usage, reset times, and new reset credits");
+        channel.setDescription("Low usage, scheduled resets, surprise refills, and reset credits");
         channel.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
                 new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_NOTIFICATION)
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION).build());

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager;
 import android.media.AudioAttributes;
 import android.media.RingtoneManager;
 import android.os.Build;
+import java.util.Locale;
 
 /** Posts and deduplicates Codex usage, reset-time, and reset-credit notifications. */
 public final class ResetNotificationManager {
@@ -154,7 +155,8 @@ public final class ResetNotificationManager {
         if (state.getLong(stateKey, 0L) == windowId) return;
         int remaining = window.remainingPercent();
         if (post(context, notificationId, label + " Codex usage is low",
-                remaining + "% remaining in the current " + label.toLowerCase() + " window.",
+                remaining + "% remaining in the current "
+                        + label.toLowerCase(Locale.ROOT) + " window.",
                 notificationId)) {
             state.edit().putLong(stateKey, windowId).apply();
         }

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -122,7 +122,7 @@ public final class ResetNotificationManager {
     }
 
     public static boolean sendTestNotification(Context context) {
-        if (context == null || !ResetAlertPreferences.enabled(context) || !canPost(context)) {
+        if (context == null || !ResetAlertPreferences.enabled(context)) {
             return false;
         }
         return post(context, NOTIFICATION_TEST, "Codex Meter notifications are working",
@@ -189,25 +189,28 @@ public final class ResetNotificationManager {
 
     private static int suppressUserResetRefills(Context context, int refills, long observedAt) {
         SharedPreferences preferences = state(context);
-        SharedPreferences.Editor editor = preferences.edit();
         long fiveHourUntil = preferences.getLong(KEY_USER_RESET_FIVE_HOUR_UNTIL, 0L);
         long weeklyUntil = preferences.getLong(KEY_USER_RESET_WEEKLY_UNTIL, 0L);
+        if (fiveHourUntil <= 0L && weeklyUntil <= 0L) return refills;
         int filtered = CelebrationDetector.withoutUserResetRefills(refills, observedAt,
                 fiveHourUntil, weeklyUntil);
-        clearUsedSuppression(editor, KEY_USER_RESET_FIVE_HOUR_UNTIL,
-                CelebrationDetector.FIVE_HOUR, refills, filtered, observedAt, fiveHourUntil);
-        clearUsedSuppression(editor, KEY_USER_RESET_WEEKLY_UNTIL,
-                CelebrationDetector.WEEKLY, refills, filtered, observedAt, weeklyUntil);
-        editor.apply();
+        boolean clearFiveHour = shouldClearSuppression(CelebrationDetector.FIVE_HOUR,
+                refills, filtered, observedAt, fiveHourUntil);
+        boolean clearWeekly = shouldClearSuppression(CelebrationDetector.WEEKLY,
+                refills, filtered, observedAt, weeklyUntil);
+        if (clearFiveHour || clearWeekly) {
+            SharedPreferences.Editor editor = preferences.edit();
+            if (clearFiveHour) editor.remove(KEY_USER_RESET_FIVE_HOUR_UNTIL);
+            if (clearWeekly) editor.remove(KEY_USER_RESET_WEEKLY_UNTIL);
+            editor.apply();
+        }
         return filtered;
     }
 
-    private static void clearUsedSuppression(SharedPreferences.Editor editor, String key,
-            int window, int before, int after, long observedAt, long suppressUntil) {
-        if (suppressUntil > 0L && (observedAt >= suppressUntil
-                || ((before & window) != 0 && (after & window) == 0))) {
-            editor.remove(key);
-        }
+    private static boolean shouldClearSuppression(int window, int before, int after,
+            long observedAt, long suppressUntil) {
+        return suppressUntil > 0L && (observedAt >= suppressUntil
+                || ((before & window) != 0 && (after & window) == 0));
     }
 
     private static void markUserResetWindow(SharedPreferences.Editor editor, String key,
@@ -224,10 +227,10 @@ public final class ResetNotificationManager {
     }
 
     private static boolean post(Context context, int id, String title, String text, int requestCode) {
-        if (!canPost(context)) return false;
         NotificationManager manager = manager(context);
         if (manager == null) return false;
         String channel = createChannel(manager, ResetAlertPreferences.getStyle(context));
+        if (!canPost(context, manager, channel)) return false;
         PendingIntent contentIntent = PendingIntent.getActivity(context, requestCode,
                 new Intent(context, MainActivity.class).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
                         | Intent.FLAG_ACTIVITY_SINGLE_TOP),
@@ -247,12 +250,16 @@ public final class ResetNotificationManager {
         return true;
     }
 
-    private static boolean canPost(Context context) {
-        NotificationManager manager = manager(context);
-        return manager != null && manager.areNotificationsEnabled()
-                && (Build.VERSION.SDK_INT < 33
-                || context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
-                == PackageManager.PERMISSION_GRANTED);
+    private static boolean canPost(Context context, NotificationManager manager,
+            String channelId) {
+        if (!manager.areNotificationsEnabled()
+                || (Build.VERSION.SDK_INT >= 33
+                && context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+                != PackageManager.PERMISSION_GRANTED)) {
+            return false;
+        }
+        NotificationChannel channel = manager.getNotificationChannel(channelId);
+        return channel != null && channel.getImportance() != NotificationManager.IMPORTANCE_NONE;
     }
 
     private static NotificationManager manager(Context context) {

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -80,17 +80,21 @@ public final class ResetNotificationManager {
             return;
         }
         int previous = state.getInt(KEY_CREDIT_COUNT, current);
-        state.edit().putInt(KEY_CREDIT_COUNT, current).apply();
         int added = CelebrationDetector.resetCreditsAdded(previous, current);
         if (!ResetAlertPreferences.enabled(context)
                 || !ResetAlertPreferences.resetCreditIncreasesEnabled(context)
-                || added <= 0) return;
+                || added <= 0) {
+            state.edit().putInt(KEY_CREDIT_COUNT, current).apply();
+            return;
+        }
         String text = added == 1
                 ? "One Codex reset credit was added. You now have " + current + "."
                 : added + " Codex reset credits were added. You now have " + current + ".";
-        post(context, NOTIFICATION_NEW_CREDIT,
+        if (post(context, NOTIFICATION_NEW_CREDIT,
                 added == 1 ? "Codex reset credit added" : "Codex reset credits added", text,
-                NOTIFICATION_NEW_CREDIT);
+                NOTIFICATION_NEW_CREDIT)) {
+            state.edit().putInt(KEY_CREDIT_COUNT, current).apply();
+        }
     }
 
     /**

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -217,6 +217,22 @@ public final class SettingsActivity extends AppCompatActivity {
                 return true;
             });
 
+            SwitchPreferenceCompat unexpectedRefills = findPreference("unexpected_refills_ui");
+            unexpectedRefills.setPersistent(false);
+            unexpectedRefills.setChecked(ResetAlertPreferences.unexpectedRefillsEnabled(requireContext()));
+            unexpectedRefills.setOnPreferenceChangeListener((preference, value) -> {
+                ResetAlertPreferences.setUnexpectedRefillsEnabled(requireContext(), (Boolean) value);
+                return true;
+            });
+
+            SwitchPreferenceCompat resetCreditIncreases = findPreference("reset_credit_increases_ui");
+            resetCreditIncreases.setPersistent(false);
+            resetCreditIncreases.setChecked(ResetAlertPreferences.resetCreditIncreasesEnabled(requireContext()));
+            resetCreditIncreases.setOnPreferenceChangeListener((preference, value) -> {
+                ResetAlertPreferences.setResetCreditIncreasesEnabled(requireContext(), (Boolean) value);
+                return true;
+            });
+
             permissionPreference = findPreference("notification_permission");
             permissionPreference.setOnPreferenceClickListener(preference -> {
                 startActivity(new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
@@ -247,7 +263,7 @@ public final class SettingsActivity extends AppCompatActivity {
             if (enabled) {
                 ResetNotificationManager.ensureChannel(requireContext());
             } else {
-                ResetNotificationManager.clearState(requireContext());
+                ResetNotificationManager.clearNotificationHistory(requireContext());
             }
         }
 

--- a/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
@@ -57,6 +57,8 @@ public final class UsageApi {
             try {
                 ResetCreditApi.refreshAndCacheLocked(context, authTokens);
             } catch (Exception e2) {
+                ResetNotificationManager.onResetCreditSummaryUpdated(context,
+                        usageSnapshot.resetCreditsAvailable);
                 AppPreferences.setResetCreditsError(context, safeMessage(e2));
             }
         }

--- a/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
@@ -45,10 +45,11 @@ public final class UsageApi {
             if (usageSnapshot.fiveHour == null && usageSnapshot.weekly == null) {
                 throw new Exception("OpenAI returned no recognizable Codex usage windows.");
             }
+            UsageSnapshot previousSnapshot = AppPreferences.loadSnapshot(context);
             if (!AppPreferences.saveSnapshot(context, usageSnapshot)) {
                 throw new Exception("Usage was received, but it could not be saved on this device.");
             }
-            ResetNotificationManager.onUsageUpdated(context, usageSnapshot);
+            ResetNotificationManager.onUsageUpdated(context, previousSnapshot, usageSnapshot);
             try {
                 ResetAlertScheduler.scheduleFromSnapshot(context, usageSnapshot);
             } catch (RuntimeException e) {

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -48,6 +48,14 @@
             android:key="notification_threshold_ui"
             android:title="Low when remaining reaches"
             app:useSimpleSummaryProvider="true" />
+        <SwitchPreferenceCompat
+            android:key="unexpected_refills_ui"
+            android:title="Surprise limit refills"
+            android:summary="Celebrate when an allowance reaches 100% before its scheduled reset" />
+        <SwitchPreferenceCompat
+            android:key="reset_credit_increases_ui"
+            android:title="New reset credits"
+            android:summary="Notify when your available reset-credit count increases" />
         <Preference
             android:key="notification_permission"
             android:title="Notification permission"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,6 +29,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWindow.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageParser.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/Pkce.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/JwtClaims.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java" \

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -12,10 +12,11 @@ public final class ParserSelfTest {
         testPrimaryLimitWinsOverAdditional();
         testMalformedWindowIgnored();
         testZeroDurationWindowIgnored();
+        testCelebrationDetection();
         testJwtMerge();
         testPkce();
         testWidgetOptions();
-        System.out.println("All parser, PKCE, and widget-option self-tests passed.");
+        System.out.println("All parser, celebration, PKCE, and widget-option self-tests passed.");
     }
 
     private static void testStandardUsage() throws Exception {
@@ -81,6 +82,56 @@ public final class ParserSelfTest {
         UsageSnapshot snapshot = UsageParser.parse(json, 1L);
         check(snapshot.fiveHour == null && snapshot.weekly == null,
                 "zero-duration usage window ignored");
+    }
+
+    private static void testCelebrationDetection() {
+        long firstFetch = 1_000_000L;
+        UsageSnapshot previous = snapshot(2, 1, 3600L, firstFetch);
+        UsageSnapshot earlyFull = snapshot(0, 0, 7200L, firstFetch + 1000L);
+        int both = CelebrationDetector.detectUnexpectedRefills(previous, earlyFull);
+        check(both == (CelebrationDetector.FIVE_HOUR | CelebrationDetector.WEEKLY),
+                "98% and 99% remaining refills both celebrate");
+
+        UsageSnapshot fullyUsed = snapshot(100, 50, 3600L, firstFetch);
+        UsageSnapshot weeklyOnlyFull = snapshot(0, 0, 7200L, firstFetch + 2000L);
+        int refill = CelebrationDetector.detectUnexpectedRefills(fullyUsed, weeklyOnlyFull);
+        check(refill == (CelebrationDetector.FIVE_HOUR | CelebrationDetector.WEEKLY),
+                "any non-full percentage reaching 100% celebrates");
+
+        UsageSnapshot notFull = snapshot(1, 1, 7200L, firstFetch + 2000L);
+        check(CelebrationDetector.detectUnexpectedRefills(previous, notFull) == 0,
+                "99% is not a complete refill");
+
+        UsageSnapshot atNaturalReset = snapshot(0, 0, 7200L, firstFetch + 3_600_000L);
+        check(CelebrationDetector.detectUnexpectedRefills(previous, atNaturalReset) == 0,
+                "countdown expiry is a natural reset");
+
+        UsageSnapshot withoutCountdown = snapshot(50, 50, 0L, firstFetch);
+        check(CelebrationDetector.detectUnexpectedRefills(withoutCountdown, earlyFull) == 0,
+                "unknown reset time does not guess");
+        check(CelebrationDetector.detectUnexpectedRefills(null, earlyFull) == 0,
+                "first snapshot establishes a baseline");
+
+        check(CelebrationDetector.resetCreditsAdded(-1, 2) == 0,
+                "first reset-credit count establishes a baseline");
+        check(CelebrationDetector.resetCreditsAdded(2, 3) == 1,
+                "single reset-credit increase");
+        check(CelebrationDetector.resetCreditsAdded(2, 5) == 3,
+                "multiple reset-credit increase");
+        check(CelebrationDetector.resetCreditsAdded(3, 2) == 0,
+                "reset-credit decrease is not celebrated");
+
+        System.out.println("Celebration demo: 98% and 99% remaining -> surprise refill for both windows.");
+        System.out.println("Celebration demo: countdown elapsed -> natural reset, no surprise notification.");
+        System.out.println("Celebration demo: reset credits 2 -> 5 -> notification reports 3 added credits.");
+    }
+
+    private static UsageSnapshot snapshot(int fiveHourUsed, int weeklyUsed,
+            long resetAfterSeconds, long fetchedAtMillis) {
+        return new UsageSnapshot("pro", true, false,
+                new UsageWindow(fiveHourUsed, 18_000L, resetAfterSeconds, 0L),
+                new UsageWindow(weeklyUsed, 604_800L, resetAfterSeconds, 0L),
+                fetchedAtMillis);
     }
 
     private static void testJwtMerge() {

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -112,6 +112,14 @@ public final class ParserSelfTest {
         check(CelebrationDetector.detectUnexpectedRefills(null, earlyFull) == 0,
                 "first snapshot establishes a baseline");
 
+        int allRefills = CelebrationDetector.FIVE_HOUR | CelebrationDetector.WEEKLY;
+        check(CelebrationDetector.withoutUserResetRefills(allRefills, firstFetch + 1000L,
+                firstFetch + 5000L, firstFetch + 5000L) == 0,
+                "manual reset suppresses both refill celebrations");
+        check(CelebrationDetector.withoutUserResetRefills(allRefills, firstFetch + 6000L,
+                firstFetch + 5000L, firstFetch + 5000L) == allRefills,
+                "expired manual reset suppression does not hide external refills");
+
         check(CelebrationDetector.resetCreditsAdded(-1, 2) == 0,
                 "first reset-credit count establishes a baseline");
         check(CelebrationDetector.resetCreditsAdded(2, 3) == 1,
@@ -123,6 +131,7 @@ public final class ParserSelfTest {
 
         System.out.println("Celebration demo: 98% and 99% remaining -> surprise refill for both windows.");
         System.out.println("Celebration demo: countdown elapsed -> natural reset, no surprise notification.");
+        System.out.println("Celebration demo: user reset marker -> no surprise notification.");
         System.out.println("Celebration demo: reset credits 2 -> 5 -> notification reports 3 added credits.");
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- detect five-hour and weekly allowances that jump to 100% before their cached reset deadlines
- suppress celebration alerts after user-initiated reset-credit redemption, including delayed propagation
- add independent settings for surprise refills and reset-credit increases
- coalesce reset-credit observations by using the usage-summary count only when the detailed endpoint fails
- retry deliverable reset-credit alerts when Android blocks app or selected-channel delivery
- avoid no-op preference writes during normal usage refreshes
- add pure-Java coverage for refill, manual-reset suppression, and credit-increase decisions

## Review follow-up
- honor `IMPORTANCE_NONE` on the selected Android notification channel before treating delivery as successful
- apply manual-reset suppression preference edits only when a key is consumed or expires

## Testing
- `./run-tests.sh` passes all core and celebration scenarios
- `./build.sh` produces and verifies the signed release APK
- `./lint.sh` passes with no warnings in changed files

[copilot_review_fixes_tests.log](https://cursor.com/agents/bc-193e1add-ec23-4caf-97a4-443939ca96e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcopilot_review_fixes_tests.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-193e1add-ec23-4caf-97a4-443939ca96e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-193e1add-ec23-4caf-97a4-443939ca96e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

