### PR TITLE
Add One UI first-run onboarding and modern OAuth return

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,10 @@
             </intent-filter>
         </activity>
         <activity
+            android:name="dev.bennett.codexmeter.OnboardingActivity"
+            android:exported="false"
+            android:launchMode="singleTop"/>
+        <activity
             android:name="dev.bennett.codexmeter.SettingsActivity"
             android:exported="false"/>
         <activity

--- a/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -13,6 +13,8 @@ public final class AppPreferences {
     private static final String KEY_OAUTH_PENDING = "oauth_pending";
     private static final String KEY_OAUTH_STARTED_AT = "oauth_started_at";
     private static final String KEY_OAUTH_URL = "oauth_url";
+    private static final String KEY_ONBOARDING_COMPLETE = "onboarding_complete";
+    private static final String KEY_ONBOARDING_STEP = "onboarding_step";
     private static final String KEY_REFRESH_MINUTES = "refresh_minutes";
     private static final String KEY_REFRESH_ON_LAUNCH = "refresh_on_launch";
     private static final String KEY_RESET_CREDITS = "reset_credits_snapshot";
@@ -329,6 +331,28 @@ public final class AppPreferences {
 
     public static String getOAuthUrl(Context context) {
         return isOAuthPending(context) ? prefs(context).getString(KEY_OAUTH_URL, "") : "";
+    }
+
+    public static boolean isOnboardingComplete(Context context) {
+        return prefs(context).getBoolean(KEY_ONBOARDING_COMPLETE, false);
+    }
+
+    public static int getOnboardingStep(Context context) {
+        return OnboardingFlow.normalizeStep(
+                prefs(context).getInt(KEY_ONBOARDING_STEP, OnboardingFlow.STEP_WELCOME));
+    }
+
+    public static void setOnboardingStep(Context context, int step) {
+        prefs(context).edit()
+                .putInt(KEY_ONBOARDING_STEP, OnboardingFlow.normalizeStep(step))
+                .apply();
+    }
+
+    public static void completeOnboarding(Context context) {
+        prefs(context).edit()
+                .putBoolean(KEY_ONBOARDING_COMPLETE, true)
+                .remove(KEY_ONBOARDING_STEP)
+                .apply();
     }
 
     private static String trim(String str, String str2) {

--- a/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -74,6 +74,9 @@ public final class MainActivity extends AppCompatActivity {
         this.appliedTheme = AppPreferences.getAppTheme(this);
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
+        if (routeToOnboarding(getIntent())) {
+            return;
+        }
         this.dark = Ui.isDark(this);
         Ui.Page page = Ui.installPage(this, "Codex Meter", false);
         this.content = page.content;
@@ -109,6 +112,9 @@ public final class MainActivity extends AppCompatActivity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
+        if (routeToOnboarding(intent)) {
+            return;
+        }
         handleLaunchIntent(intent);
         rebuild();
     }
@@ -192,6 +198,40 @@ public final class MainActivity extends AppCompatActivity {
             }
             intent.setData(null);
         }
+    }
+
+    private boolean routeToOnboarding(Intent intent) {
+        boolean oauthReturn = isOAuthReturnIntent(intent);
+        int action = OnboardingFlow.launchAction(
+                AppPreferences.isOnboardingComplete(this),
+                SecureTokenStore.isSignedIn(this),
+                oauthReturn);
+        if (action == OnboardingFlow.LAUNCH_MAIN_AND_COMPLETE) {
+            // Existing signed-in installs predate onboarding and should not be interrupted.
+            AppPreferences.completeOnboarding(this);
+            return false;
+        }
+        if (action != OnboardingFlow.LAUNCH_ONBOARDING) {
+            return false;
+        }
+        if (oauthReturn) {
+            AppPreferences.setOAuthPending(this, false, "");
+            intent.setData(null);
+        }
+        startActivity(new Intent(this, OnboardingActivity.class)
+                .putExtra(OnboardingActivity.EXTRA_AUTH_RETURN, oauthReturn)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP));
+        finish();
+        return true;
+    }
+
+    private static boolean isOAuthReturnIntent(Intent intent) {
+        Uri data = intent == null ? null : intent.getData();
+        return data != null
+                && "codexmeter".equals(data.getScheme())
+                && "auth".equals(data.getHost())
+                && data.getPath() != null
+                && data.getPath().startsWith("/complete");
     }
 
     public void rebuild() {

--- a/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -192,8 +192,8 @@ public final class MainActivity extends AppCompatActivity {
         }
         Uri data = intent == null ? null : intent.getData();
         if (data != null && "codexmeter".equals(data.getScheme()) && "auth".equals(data.getHost())) {
-            AppPreferences.setOAuthPending(this, false, "");
             if (SecureTokenStore.isSignedIn(this)) {
+                AppPreferences.setOAuthPending(this, false, "");
                 RefreshScheduler.scheduleImmediate(this);
             }
             intent.setData(null);
@@ -215,7 +215,9 @@ public final class MainActivity extends AppCompatActivity {
             return false;
         }
         if (oauthReturn) {
-            AppPreferences.setOAuthPending(this, false, "");
+            if (SecureTokenStore.isSignedIn(this)) {
+                AppPreferences.setOAuthPending(this, false, "");
+            }
             intent.setData(null);
         }
         startActivity(new Intent(this, OnboardingActivity.class)

--- a/app/src/main/java/dev/bennett/codexmeter/OAuthBrowserPage.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OAuthBrowserPage.java
@@ -1,0 +1,64 @@
+package dev.bennett.codexmeter;
+
+/** Generates the small localhost page shown after the browser OAuth callback. */
+public final class OAuthBrowserPage {
+    private OAuthBrowserPage() {
+    }
+
+    public static String render(String message, boolean success, String appLink) {
+        String safeMessage = htmlEscape(message);
+        String safeLink = htmlEscape(appLink);
+        String scriptLink = javascriptString(appLink);
+        String title = success ? "You’re connected" : "Let’s try that again";
+        String eyebrow = success ? "SIGN-IN COMPLETE" : "SIGN-IN NEEDS ATTENTION";
+        String action = success ? "Open Codex Meter" : "Back to Codex Meter";
+        String symbol = success ? "&#10003;" : "!";
+        String autoReturn = success
+                ? "<script>setTimeout(function(){window.location.href='" + scriptLink
+                    + "';},700);</script>"
+                : "";
+        return "<!doctype html><html lang=\"en\"><head>"
+                + "<meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+                + "<meta name=\"color-scheme\" content=\"light dark\"><title>Codex Meter</title>"
+                + "<style>"
+                + ":root{color-scheme:light dark;--bg:#f1f1f3;--card:#fcfcff;--text:#000;--sub:#747477;"
+                + "--accent:#387aff;--on:#fff;--soft:#e8efff;--ring:#d9d9de}"
+                + "*{box-sizing:border-box}body{margin:0;min-height:100vh;background:var(--bg);color:var(--text);"
+                + "font-family:SamsungOne,'Samsung Sans',system-ui,-apple-system,sans-serif;display:grid;"
+                + "place-items:center;padding:24px}.card{width:min(440px,100%);background:var(--card);"
+                + "border-radius:28px;padding:30px 26px 26px;box-shadow:0 8px 30px rgba(0,0,0,.06)}"
+                + ".mark{display:grid;place-items:center;width:58px;height:58px;border-radius:50%;"
+                + "background:var(--soft);color:var(--accent);font-size:29px;font-weight:700;margin-bottom:28px}"
+                + ".eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.08em;margin:0 0 9px}"
+                + "h1{font-size:30px;line-height:1.16;letter-spacing:-.025em;margin:0 0 12px}"
+                + "p{font-size:16px;line-height:1.5;color:var(--sub);margin:0 0 28px}"
+                + ".button{display:block;width:100%;padding:16px 20px;border-radius:20px;background:var(--accent);"
+                + "color:var(--on);text-align:center;text-decoration:none;font-size:16px;font-weight:700}"
+                + ".hint{font-size:12px;line-height:1.4;color:var(--sub);text-align:center;margin:16px 0 0}"
+                + "@media(prefers-color-scheme:dark){:root{--bg:#050608;--card:#16181c;--text:#f8f8fa;"
+                + "--sub:#b7bac2;--accent:#5ca9ff;--on:#07182a;--soft:#1c3552;--ring:#373a40}"
+                + ".card{box-shadow:none}}"
+                + "@media(prefers-reduced-motion:no-preference){.card{animation:in .28s ease-out both}"
+                + "@keyframes in{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}}"
+                + "</style></head><body><main class=\"card\">"
+                + "<div class=\"mark\" aria-hidden=\"true\">" + symbol + "</div>"
+                + "<div class=\"eyebrow\">" + eyebrow + "</div><h1>" + title + "</h1>"
+                + "<p>" + safeMessage + "</p><a class=\"button\" href=\"" + safeLink + "\">"
+                + action + "</a><div class=\"hint\">"
+                + (success ? "Returning to the app automatically…" : "Return to the app to restart secure sign-in.")
+                + "</div></main>" + autoReturn + "</body></html>";
+    }
+
+    static String htmlEscape(String value) {
+        if (value == null) return "";
+        return value.replace("&", "&amp;").replace("<", "&lt;")
+                .replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&#39;");
+    }
+
+    static String javascriptString(String value) {
+        if (value == null) return "";
+        return value.replace("\\", "\\\\").replace("'", "\\'")
+                .replace("\r", "\\r").replace("\n", "\\n")
+                .replace("\u2028", "\\u2028").replace("\u2029", "\\u2029");
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/OAuthService.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OAuthService.java
@@ -276,27 +276,7 @@ public final class OAuthService extends Service {
     }
 
     private static void writeBrowser(Socket socket, int status, String message, boolean success) throws Exception {
-        String safe = htmlEscape(message);
-        String accent = success ? "#42d6a4" : "#f4b95f";
-        String title = success ? "Signed in" : "Sign-in issue";
-        String openButton = success
-                ? "<a class=\"button\" href=\"" + AppConstants.APP_LINK + "\">Open Codex Meter</a>"
-                : "";
-        String script = success
-                ? "<script>setTimeout(function(){try{location.href='" + AppConstants.APP_LINK
-                    + "';}catch(e){}},450);</script>"
-                : "";
-        String html = "<!doctype html><html><head><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
-                + "<title>Codex Meter</title><style>body{margin:0;background:#0e1012;color:#f6f7f8;font-family:system-ui,sans-serif;display:grid;place-items:center;min-height:100vh}"
-                + ".c{box-sizing:border-box;width:min(440px,calc(100% - 40px));padding:28px;border:1px solid #33383d;border-radius:24px;background:#15181b}"
-                + "i{display:block;width:14px;height:14px;border-radius:50%;background:" + accent + ";margin-bottom:18px}"
-                + "h1{font-size:26px;margin:0 0 10px}p{line-height:1.5;color:#c5cbd0;margin:0 0 20px}"
-                + ".button{display:inline-block;padding:12px 17px;border-radius:13px;background:#42d6a4;color:#09271e;text-decoration:none;font-weight:700}"
-                + ".hint{font-size:12px;color:#89939a;margin-top:16px}</style></head>"
-                + "<body><main class=\"c\"><i></i><h1>" + title + "</h1><p>" + safe + "</p>"
-                + openButton
-                + (success ? "<div class=\"hint\">If the app does not open automatically, use the button above.</div>" : "")
-                + "</main>" + script + "</body></html>";
+        String html = OAuthBrowserPage.render(message, success, AppConstants.APP_LINK);
         byte[] body = html.getBytes(StandardCharsets.UTF_8);
         String reason = status >= 200 && status < 300 ? "OK" : "Error";
         ByteArrayOutputStream response = new ByteArrayOutputStream(body.length + 256);
@@ -432,12 +412,6 @@ public final class OAuthService extends Service {
         String message = exception.getMessage();
         if (message == null || message.trim().isEmpty()) return exception.getClass().getSimpleName();
         return message.length() > 200 ? message.substring(0, 200) : message;
-    }
-
-    private static String htmlEscape(String value) {
-        if (value == null) return "";
-        return value.replace("&", "&amp;").replace("<", "&lt;")
-                .replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&#39;");
     }
 
     private static final class Callback {

--- a/app/src/main/java/dev/bennett/codexmeter/OAuthService.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OAuthService.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public final class OAuthService extends Service {
     public static final String ACTION_START = "dev.bennett.codexmeter.oauth.START";
     public static final String ACTION_CANCEL = "dev.bennett.codexmeter.oauth.CANCEL";
+    public static final String ACTION_CANCEL_SILENT = "dev.bennett.codexmeter.oauth.CANCEL_SILENT";
     private static final String CHANNEL_ID = "oauth_sign_in";
     private static final int NOTIFICATION_ID = 7301;
 
@@ -51,8 +52,8 @@ public final class OAuthService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         String action = intent == null ? ACTION_START : intent.getAction();
-        if (ACTION_CANCEL.equals(action)) {
-            cancelFlow("Sign-in cancelled.");
+        if (ACTION_CANCEL.equals(action) || ACTION_CANCEL_SILENT.equals(action)) {
+            cancelFlow("Sign-in cancelled.", ACTION_CANCEL.equals(action));
             return START_NOT_STICKY;
         }
         if (SecureTokenStore.isSignedIn(this)) {
@@ -290,11 +291,13 @@ public final class OAuthService extends Service {
         socket.getOutputStream().flush();
     }
 
-    private void cancelFlow(String message) {
+    private void cancelFlow(String message, boolean broadcast) {
         cancelled = true;
         AppPreferences.setOAuthPending(this, false, "");
         closeServer();
-        broadcastResult(false, message);
+        if (broadcast) {
+            broadcastResult(false, message);
+        }
         finishService();
     }
 

--- a/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -10,14 +10,11 @@ import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.view.Gravity;
-import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
@@ -35,6 +32,7 @@ public final class OnboardingActivity extends AppCompatActivity {
     private boolean dark;
     private int step;
     private boolean receiverRegistered;
+    private boolean oauthRequested;
     private String authMessage = "";
     private String lastLaunchedAuthUrl = "";
 
@@ -52,6 +50,7 @@ public final class OnboardingActivity extends AppCompatActivity {
                 return;
             }
             if (AppConstants.ACTION_OAUTH_RESULT.equals(action)) {
+                oauthRequested = false;
                 boolean success = intent.getBooleanExtra(AppConstants.EXTRA_SUCCESS, false);
                 String message = intent.getStringExtra(AppConstants.EXTRA_MESSAGE);
                 if (success || SecureTokenStore.isSignedIn(OnboardingActivity.this)) {
@@ -79,6 +78,7 @@ public final class OnboardingActivity extends AppCompatActivity {
         this.content = this.page.content;
         findViewById(R.id.dashboard_refresh).setEnabled(false);
         boolean oauthReturn = getIntent().getBooleanExtra(EXTRA_AUTH_RETURN, false);
+        this.oauthRequested = AppPreferences.isOAuthPending(this);
         this.step = OnboardingFlow.initialStep(
                 AppPreferences.getOnboardingStep(this),
                 SecureTokenStore.isSignedIn(this),
@@ -104,6 +104,7 @@ public final class OnboardingActivity extends AppCompatActivity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
+        this.oauthRequested = AppPreferences.isOAuthPending(this);
         if (SecureTokenStore.isSignedIn(this)) {
             showStep(OnboardingFlow.STEP_COMPLETE);
         } else if (intent.getBooleanExtra(EXTRA_AUTH_RETURN, false)) {
@@ -357,6 +358,7 @@ public final class OnboardingActivity extends AppCompatActivity {
             return;
         }
         boolean resuming = AppPreferences.isOAuthPending(this);
+        this.oauthRequested = true;
         this.authMessage = resuming
                 ? "Resuming secure ChatGPT sign-in…"
                 : "Preparing secure ChatGPT sign-in…";
@@ -365,6 +367,7 @@ public final class OnboardingActivity extends AppCompatActivity {
             startForegroundService(new Intent(this, OAuthService.class)
                     .setAction(OAuthService.ACTION_START));
         } catch (RuntimeException exception) {
+            this.oauthRequested = false;
             AppPreferences.setOAuthPending(this, false, "");
             this.authMessage = "Could not start sign-in: " + safeMessage(exception);
             render();
@@ -384,8 +387,23 @@ public final class OnboardingActivity extends AppCompatActivity {
     }
 
     private void completeAndOpenMain() {
+        cancelPendingSignIn();
         AppPreferences.completeOnboarding(this);
         openMain();
+    }
+
+    private void cancelPendingSignIn() {
+        if (!this.oauthRequested && !AppPreferences.isOAuthPending(this)) {
+            return;
+        }
+        this.oauthRequested = false;
+        try {
+            startService(new Intent(this, OAuthService.class)
+                    .setAction(OAuthService.ACTION_CANCEL));
+        } catch (RuntimeException ignored) {
+            // The service may already have stopped after the browser returned.
+        }
+        AppPreferences.setOAuthPending(this, false, "");
     }
 
     private void openMain() {

--- a/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -1,0 +1,401 @@
+package dev.bennett.codexmeter;
+
+import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.widget.NestedScrollView;
+
+import dev.oneuiproject.oneui.widget.CardItemView;
+import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
+
+/** First-run setup built from the same One UI Design Library primitives as the app. */
+public final class OnboardingActivity extends AppCompatActivity {
+    public static final String EXTRA_AUTH_RETURN = "oauth_return";
+
+    private LinearLayout content;
+    private Ui.Page page;
+    private boolean dark;
+    private int step;
+    private boolean receiverRegistered;
+    private String authMessage = "";
+    private String lastLaunchedAuthUrl = "";
+
+    private final BroadcastReceiver authReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent == null ? null : intent.getAction();
+            if (AppConstants.ACTION_OAUTH_READY.equals(action)) {
+                String url = intent.getStringExtra(AppConstants.EXTRA_AUTH_URL);
+                if (url != null && !url.isEmpty()) {
+                    authMessage = "Your secure ChatGPT sign-in is open in the browser.";
+                    render();
+                    openAuthUrl(url);
+                }
+                return;
+            }
+            if (AppConstants.ACTION_OAUTH_RESULT.equals(action)) {
+                boolean success = intent.getBooleanExtra(AppConstants.EXTRA_SUCCESS, false);
+                String message = intent.getStringExtra(AppConstants.EXTRA_MESSAGE);
+                if (success || SecureTokenStore.isSignedIn(OnboardingActivity.this)) {
+                    showStep(OnboardingFlow.STEP_COMPLETE);
+                } else {
+                    authMessage = message == null || message.trim().isEmpty()
+                            ? "Sign-in did not complete. Please try again."
+                            : message;
+                    showStep(OnboardingFlow.STEP_ACCOUNT);
+                }
+            }
+        }
+    };
+
+    @Override
+    protected void onCreate(Bundle bundle) {
+        Ui.applySelectedTheme(this);
+        super.onCreate(bundle);
+        if (AppPreferences.isOnboardingComplete(this)) {
+            openMain();
+            return;
+        }
+        this.dark = Ui.isDark(this);
+        this.page = Ui.installPage(this, "Set up Codex Meter", false);
+        this.content = this.page.content;
+        findViewById(R.id.dashboard_refresh).setEnabled(false);
+        boolean oauthReturn = getIntent().getBooleanExtra(EXTRA_AUTH_RETURN, false);
+        this.step = OnboardingFlow.initialStep(
+                AppPreferences.getOnboardingStep(this),
+                SecureTokenStore.isSignedIn(this),
+                oauthReturn);
+        if (oauthReturn && !SecureTokenStore.isSignedIn(this)) {
+            this.authMessage = "Sign-in did not complete. You can safely try again.";
+        }
+        render();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        if (SecureTokenStore.isSignedIn(this)) {
+            showStep(OnboardingFlow.STEP_COMPLETE);
+        } else if (intent.getBooleanExtra(EXTRA_AUTH_RETURN, false)) {
+            this.authMessage = "Sign-in did not complete. You can safely try again.";
+            showStep(OnboardingFlow.STEP_ACCOUNT);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (this.content != null && SecureTokenStore.isSignedIn(this)
+                && this.step != OnboardingFlow.STEP_COMPLETE) {
+            showStep(OnboardingFlow.STEP_COMPLETE);
+        }
+    }
+
+    @Override
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    protected void onStart() {
+        super.onStart();
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(AppConstants.ACTION_OAUTH_READY);
+        filter.addAction(AppConstants.ACTION_OAUTH_RESULT);
+        try {
+            if (Build.VERSION.SDK_INT >= 33) {
+                registerReceiver(this.authReceiver, filter, AppConstants.INTERNAL_PERMISSION, null,
+                        Context.RECEIVER_NOT_EXPORTED);
+            } else {
+                registerReceiver(this.authReceiver, filter, AppConstants.INTERNAL_PERMISSION, null);
+            }
+            this.receiverRegistered = true;
+        } catch (RuntimeException exception) {
+            this.receiverRegistered = false;
+            this.authMessage = "Sign-in updates are unavailable: " + safeMessage(exception);
+            render();
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        if (this.receiverRegistered) {
+            try {
+                unregisterReceiver(this.authReceiver);
+            } catch (RuntimeException ignored) {
+            }
+            this.receiverRegistered = false;
+        }
+        super.onStop();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        goBack();
+        return true;
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (this.step > OnboardingFlow.STEP_WELCOME) {
+            goBack();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+    private void render() {
+        if (this.content == null) return;
+        this.content.removeAllViews();
+        this.page.toolbar.setTitle("Set up Codex Meter");
+        this.page.toolbar.setShowNavigationButtonAsBack(this.step > OnboardingFlow.STEP_WELCOME);
+
+        addProgress();
+        if (this.step == OnboardingFlow.STEP_WELCOME) {
+            buildWelcome();
+        } else if (this.step == OnboardingFlow.STEP_USAGE) {
+            buildUsage();
+        } else if (this.step == OnboardingFlow.STEP_ACCOUNT) {
+            buildAccount();
+        } else {
+            buildComplete();
+        }
+        NestedScrollView scroll = findViewById(R.id.dashboard_scroll);
+        scroll.post(() -> scroll.scrollTo(0, 0));
+    }
+
+    private void addProgress() {
+        TextView label = Ui.text(this, "STEP " + (this.step + 1) + " OF "
+                + OnboardingFlow.STEP_COUNT, 12.0f, Ui.accent(this, this.dark));
+        label.setTypeface(Ui.mediumTypeface(this));
+        label.setLetterSpacing(0.08f);
+        LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(-1, -2);
+        labelParams.setMargins(Ui.dp(this, 14), Ui.dp(this, 6), Ui.dp(this, 14), Ui.dp(this, 10));
+        this.content.addView(label, labelParams);
+
+        ProgressBar progress = Ui.progress(this, this.dark);
+        progress.setProgress((this.step + 1) * 100 / OnboardingFlow.STEP_COUNT);
+        LinearLayout.LayoutParams progressParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 5));
+        progressParams.setMargins(Ui.dp(this, 14), 0, Ui.dp(this, 14), Ui.dp(this, 26));
+        this.content.addView(progress, progressParams);
+    }
+
+    private void buildWelcome() {
+        addIntro("Meet Codex Meter",
+                "Your ChatGPT Codex allowance, reset timing, and available reset credits in one "
+                        + "quick One UI view.",
+                R.drawable.ic_oui_battery);
+
+        RoundedLinearLayout card = Ui.seslCard(this, this.dark);
+        TextView title = Ui.text(this, "Built to feel at home on Galaxy", 18.0f,
+                Ui.mainText(this.dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        TextView body = Ui.text(this,
+                "Reachable layouts, responsive cards, system theming, and Samsung lock-screen "
+                        + "widgets all use the app’s native One UI components.",
+                15.0f, Ui.secondaryText(this.dark));
+        LinearLayout.LayoutParams bodyParams = new LinearLayout.LayoutParams(-1, -2);
+        bodyParams.setMargins(0, Ui.dp(this, 10), 0, 0);
+        card.addView(body, bodyParams);
+        this.content.addView(card);
+        addPrimaryAction("Continue", () -> showStep(OnboardingFlow.STEP_USAGE));
+    }
+
+    private void buildUsage() {
+        addIntro("Everything important at a glance",
+                "See what remains without digging through ChatGPT, then keep it visible with "
+                        + "home-screen and supported Galaxy lock-screen widgets.",
+                R.drawable.ic_oui_time);
+
+        this.content.addView(Ui.separator(this, "What you get"));
+        RoundedLinearLayout features = Ui.seslRowCard(this, this.dark);
+        CardItemView limits = Ui.actionRow(this, "Live Codex limits",
+                "Five-hour and weekly allowance with reset timing",
+                R.drawable.ic_oui_calendar_week, null);
+        limits.setShowBottomDivider(true);
+        features.addView(limits);
+        CardItemView widgets = Ui.actionRow(this, "Native One UI widgets",
+                "At-a-glance usage on your home and lock screens",
+                R.drawable.ic_oui_add_home, null);
+        widgets.setShowBottomDivider(true);
+        features.addView(widgets);
+        features.addView(Ui.actionRow(this, "Useful alerts",
+                "Optional updates when limits reset or credits arrive",
+                R.drawable.ic_oui_notification, null));
+        this.content.addView(features);
+        addPrimaryAction("Continue", () -> showStep(OnboardingFlow.STEP_ACCOUNT));
+    }
+
+    private void buildAccount() {
+        addIntro("Connect your ChatGPT account",
+                "Use OpenAI’s secure browser flow to sign up or sign in. Codex Meter never sees "
+                        + "your password.",
+                R.drawable.ic_oui_samsung_account);
+
+        this.content.addView(Ui.separator(this, "Private by design"));
+        RoundedLinearLayout privacy = Ui.seslRowCard(this, this.dark);
+        CardItemView encrypted = Ui.actionRow(this, "Encrypted on this device",
+                "Session tokens are protected by Android Keystore",
+                R.drawable.ic_oui_privacy, null);
+        encrypted.setShowBottomDivider(true);
+        privacy.addView(encrypted);
+        privacy.addView(Ui.actionRow(this, "No analytics SDK",
+                "Your account and usage are not sent through a Codex Meter server",
+                R.drawable.ic_oui_contact_outline, null));
+        this.content.addView(privacy);
+
+        if (!this.authMessage.isEmpty()) {
+            RoundedLinearLayout status = Ui.seslCard(this, this.dark);
+            TextView message = Ui.text(this, this.authMessage, 14.0f,
+                    Ui.secondaryText(this.dark));
+            status.addView(message);
+            LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(-1, -2);
+            statusParams.setMargins(0, Ui.dp(this, 16), 0, 0);
+            this.content.addView(status, statusParams);
+        }
+
+        String signInLabel = AppPreferences.isOAuthPending(this)
+                ? "Continue sign-in with ChatGPT"
+                : "Sign up or sign in with ChatGPT";
+        addPrimaryAction(signInLabel, this::startSignIn);
+        Button later = Ui.button(this, "Not now", false, this.dark);
+        later.setOnClickListener(view -> completeAndOpenMain());
+        LinearLayout.LayoutParams laterParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 54));
+        laterParams.setMargins(0, Ui.dp(this, 10), 0, Ui.dp(this, 8));
+        this.content.addView(later, laterParams);
+    }
+
+    private void buildComplete() {
+        boolean signedIn = SecureTokenStore.isSignedIn(this);
+        addIntro(signedIn ? "You’re all set" : "Setup complete",
+                signedIn
+                        ? "Your ChatGPT account is connected. Codex Meter will load your latest "
+                            + "allowance as the app opens."
+                        : "You can connect ChatGPT later from the Codex Meter dashboard.",
+                signedIn ? R.drawable.ic_oui_samsung_account : R.drawable.ic_oui_info_outline);
+
+        RoundedLinearLayout account = Ui.seslRowCard(this, this.dark);
+        AuthTokens tokens = SecureTokenStore.load(this);
+        account.addView(Ui.actionRow(this,
+                signedIn ? "ChatGPT connected" : "Continue without an account",
+                signedIn && tokens != null && !tokens.email.isEmpty()
+                        ? tokens.email
+                        : (signedIn ? "Secure sign-in complete" : "Sign in whenever you’re ready"),
+                signedIn ? R.drawable.ic_oui_contact_outline : R.drawable.ic_oui_privacy,
+                null));
+        this.content.addView(account);
+        addPrimaryAction("Open Codex Meter", this::completeAndOpenMain);
+    }
+
+    private void addIntro(String titleText, String bodyText, int iconResource) {
+        RoundedLinearLayout hero = Ui.seslCard(this, this.dark);
+        ImageView icon = new ImageView(this);
+        icon.setImageResource(iconResource);
+        icon.setColorFilter(Ui.accent(this, this.dark));
+        icon.setPadding(Ui.dp(this, 14), Ui.dp(this, 14), Ui.dp(this, 14), Ui.dp(this, 14));
+        GradientDrawable iconBackground = new GradientDrawable();
+        iconBackground.setShape(GradientDrawable.OVAL);
+        int accent = Ui.accent(this, this.dark);
+        iconBackground.setColor(Color.argb(this.dark ? 45 : 24,
+                Color.red(accent), Color.green(accent), Color.blue(accent)));
+        icon.setBackground(iconBackground);
+        hero.addView(icon, new LinearLayout.LayoutParams(Ui.dp(this, 62), Ui.dp(this, 62)));
+
+        TextView title = Ui.title(this, titleText, this.dark);
+        title.setTextSize(34.0f);
+        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(-1, -2);
+        titleParams.setMargins(0, Ui.dp(this, 24), 0, 0);
+        hero.addView(title, titleParams);
+
+        TextView body = Ui.text(this, bodyText, 16.0f, Ui.secondaryText(this.dark));
+        body.setLineSpacing(0.0f, 1.18f);
+        LinearLayout.LayoutParams bodyParams = new LinearLayout.LayoutParams(-1, -2);
+        bodyParams.setMargins(0, Ui.dp(this, 12), 0, Ui.dp(this, 4));
+        hero.addView(body, bodyParams);
+        this.content.addView(hero);
+    }
+
+    private void addPrimaryAction(String label, Runnable action) {
+        Button button = Ui.nativePrimaryButton(this, label);
+        button.setOnClickListener(view -> action.run());
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(-1, Ui.dp(this, 60));
+        params.setMargins(0, Ui.dp(this, 22), 0, Ui.dp(this, 8));
+        this.content.addView(button, params);
+    }
+
+    private void showStep(int requestedStep) {
+        this.step = OnboardingFlow.normalizeStep(requestedStep);
+        AppPreferences.setOnboardingStep(this, this.step);
+        render();
+    }
+
+    private void goBack() {
+        showStep(OnboardingFlow.previousStep(this.step));
+    }
+
+    private void startSignIn() {
+        if (SecureTokenStore.isSignedIn(this)) {
+            showStep(OnboardingFlow.STEP_COMPLETE);
+            return;
+        }
+        boolean resuming = AppPreferences.isOAuthPending(this);
+        this.authMessage = resuming
+                ? "Resuming secure ChatGPT sign-in…"
+                : "Preparing secure ChatGPT sign-in…";
+        render();
+        try {
+            startForegroundService(new Intent(this, OAuthService.class)
+                    .setAction(OAuthService.ACTION_START));
+        } catch (RuntimeException exception) {
+            AppPreferences.setOAuthPending(this, false, "");
+            this.authMessage = "Could not start sign-in: " + safeMessage(exception);
+            render();
+        }
+    }
+
+    private void openAuthUrl(String url) {
+        if (!url.equals(this.lastLaunchedAuthUrl) || hasWindowFocus()) {
+            this.lastLaunchedAuthUrl = url;
+            try {
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+            } catch (RuntimeException exception) {
+                this.authMessage = "No browser is available to complete sign-in.";
+                render();
+            }
+        }
+    }
+
+    private void completeAndOpenMain() {
+        AppPreferences.completeOnboarding(this);
+        openMain();
+    }
+
+    private void openMain() {
+        startActivity(new Intent(this, MainActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP));
+        finish();
+    }
+
+    private static String safeMessage(RuntimeException exception) {
+        String message = exception.getMessage();
+        if (message == null || message.trim().isEmpty()) {
+            return exception.getClass().getSimpleName();
+        }
+        return message.length() > 180 ? message.substring(0, 180) : message;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -399,7 +399,7 @@ public final class OnboardingActivity extends AppCompatActivity {
         this.oauthRequested = false;
         try {
             startService(new Intent(this, OAuthService.class)
-                    .setAction(OAuthService.ACTION_CANCEL));
+                    .setAction(OAuthService.ACTION_CANCEL_SILENT));
         } catch (RuntimeException ignored) {
             // The service may already have stopped after the browser returned.
         }

--- a/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -75,7 +75,7 @@ public final class OnboardingActivity extends AppCompatActivity {
             return;
         }
         this.dark = Ui.isDark(this);
-        this.page = Ui.installPage(this, "Set up Codex Meter", false);
+        this.page = Ui.installPage(this, "Codex Meter", false);
         this.content = this.page.content;
         findViewById(R.id.dashboard_refresh).setEnabled(false);
         boolean oauthReturn = getIntent().getBooleanExtra(EXTRA_AUTH_RETURN, false);
@@ -164,7 +164,7 @@ public final class OnboardingActivity extends AppCompatActivity {
     private void render() {
         if (this.content == null) return;
         this.content.removeAllViews();
-        this.page.toolbar.setTitle("Set up Codex Meter");
+        this.page.toolbar.setTitle("Codex Meter");
         this.page.toolbar.setShowNavigationButtonAsBack(this.step > OnboardingFlow.STEP_WELCOME);
 
         addProgress();

--- a/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -19,6 +19,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.widget.NestedScrollView;
 
@@ -85,6 +86,17 @@ public final class OnboardingActivity extends AppCompatActivity {
         if (oauthReturn && !SecureTokenStore.isSignedIn(this)) {
             this.authMessage = "Sign-in did not complete. You can safely try again.";
         }
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (step > OnboardingFlow.STEP_WELCOME) {
+                    goBack();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        });
         render();
     }
 
@@ -147,15 +159,6 @@ public final class OnboardingActivity extends AppCompatActivity {
     public boolean onSupportNavigateUp() {
         goBack();
         return true;
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (this.step > OnboardingFlow.STEP_WELCOME) {
-            goBack();
-        } else {
-            super.onBackPressed();
-        }
     }
 
     private void render() {

--- a/app/src/main/java/dev/bennett/codexmeter/OnboardingFlow.java
+++ b/app/src/main/java/dev/bennett/codexmeter/OnboardingFlow.java
@@ -1,0 +1,41 @@
+package dev.bennett.codexmeter;
+
+/** Pure onboarding navigation rules shared by the activity and JVM self-tests. */
+public final class OnboardingFlow {
+    public static final int STEP_WELCOME = 0;
+    public static final int STEP_USAGE = 1;
+    public static final int STEP_ACCOUNT = 2;
+    public static final int STEP_COMPLETE = 3;
+    public static final int STEP_COUNT = 4;
+
+    public static final int LAUNCH_MAIN = 0;
+    public static final int LAUNCH_ONBOARDING = 1;
+    public static final int LAUNCH_MAIN_AND_COMPLETE = 2;
+
+    private OnboardingFlow() {
+    }
+
+    public static int launchAction(boolean completed, boolean signedIn, boolean oauthReturn) {
+        if (completed) return LAUNCH_MAIN;
+        if (oauthReturn || !signedIn) return LAUNCH_ONBOARDING;
+        return LAUNCH_MAIN_AND_COMPLETE;
+    }
+
+    public static int initialStep(int savedStep, boolean signedIn, boolean oauthReturn) {
+        if (signedIn) return STEP_COMPLETE;
+        if (oauthReturn) return STEP_ACCOUNT;
+        return normalizeStep(savedStep);
+    }
+
+    public static int normalizeStep(int step) {
+        return step >= STEP_WELCOME && step < STEP_COUNT ? step : STEP_WELCOME;
+    }
+
+    public static int nextStep(int step) {
+        return Math.min(normalizeStep(step) + 1, STEP_COMPLETE);
+    }
+
+    public static int previousStep(int step) {
+        return Math.max(normalizeStep(step) - 1, STEP_WELCOME);
+    }
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -33,6 +33,8 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/Pkce.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/JwtClaims.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingFlow.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthBrowserPage.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
@@ -47,6 +49,7 @@ grep -q 'android.permission.ACCESS_NETWORK_STATE' "$ROOT/app/src/main/AndroidMan
 grep -q 'android.permission.POST_NOTIFICATIONS' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'android.permission.SCHEDULE_EXACT_ALARM' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'android:scheme="codexmeter"' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'OnboardingActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ResetAlertReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'MY_PACKAGE_REPLACED' "$ROOT/app/src/main/AndroidManifest.xml"
 
@@ -84,5 +87,11 @@ grep -R -q 'app:widgetStyle="monotone"' "$ROOT/app/src/main/res/xml/samsung_lock
 grep -q 'RESET_CREDITS_CONSUME_URL' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
 grep -q 'ResetCreditActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'showResetAction' "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java"
+grep -q 'dev.oneuiproject.oneui.widget.CardItemView' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java"
+grep -q 'Ui.nativePrimaryButton' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java"
+grep -q 'OAuthBrowserPage.render' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthService.java"
 
-echo "Parser, OAuth metadata, reset-credit, countdown, alert, and Samsung widget source checks passed."
+echo "Parser, OAuth, onboarding, reset-credit, countdown, alert, and Samsung widget source checks passed."

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -16,7 +16,9 @@ public final class ParserSelfTest {
         testJwtMerge();
         testPkce();
         testWidgetOptions();
-        System.out.println("All parser, celebration, PKCE, and widget-option self-tests passed.");
+        testOnboardingFlow();
+        testOAuthBrowserPage();
+        System.out.println("All parser, OAuth, onboarding, and widget-option self-tests passed.");
     }
 
     private static void testStandardUsage() throws Exception {
@@ -185,6 +187,59 @@ public final class ParserSelfTest {
         check(WidgetOptions.SURFACE_ONE_UI.equals(transparent.surfaceStyle), "One UI widget style");
         check(WidgetOptions.GRAPHIC_MAX.equals(transparent.graphicScale), "maximum graphic scale");
         check(!WidgetOptions.defaults().showTitle, "widget title defaults off");
+    }
+
+    private static void testOnboardingFlow() {
+        check(OnboardingFlow.launchAction(false, false, false)
+                        == OnboardingFlow.LAUNCH_ONBOARDING,
+                "fresh install opens onboarding");
+        check(OnboardingFlow.launchAction(false, true, false)
+                        == OnboardingFlow.LAUNCH_MAIN_AND_COMPLETE,
+                "signed-in upgrade is not interrupted");
+        check(OnboardingFlow.launchAction(false, true, true)
+                        == OnboardingFlow.LAUNCH_ONBOARDING,
+                "OAuth return reaches onboarding completion");
+        check(OnboardingFlow.launchAction(true, false, false)
+                        == OnboardingFlow.LAUNCH_MAIN,
+                "completed onboarding stays completed after sign-out");
+        check(OnboardingFlow.initialStep(OnboardingFlow.STEP_USAGE, false, false)
+                        == OnboardingFlow.STEP_USAGE,
+                "incomplete onboarding resumes saved page");
+        check(OnboardingFlow.initialStep(OnboardingFlow.STEP_WELCOME, true, true)
+                        == OnboardingFlow.STEP_COMPLETE,
+                "successful OAuth opens completion page");
+        check(OnboardingFlow.initialStep(OnboardingFlow.STEP_WELCOME, false, true)
+                        == OnboardingFlow.STEP_ACCOUNT,
+                "failed OAuth returns to account page");
+        check(OnboardingFlow.nextStep(OnboardingFlow.STEP_COMPLETE)
+                        == OnboardingFlow.STEP_COMPLETE,
+                "next step clamps at completion");
+        check(OnboardingFlow.previousStep(OnboardingFlow.STEP_WELCOME)
+                        == OnboardingFlow.STEP_WELCOME,
+                "previous step clamps at welcome");
+        check(OnboardingFlow.normalizeStep(99) == OnboardingFlow.STEP_WELCOME,
+                "invalid persisted page resets safely");
+    }
+
+    private static void testOAuthBrowserPage() {
+        String success = OAuthBrowserPage.render(
+                "Connected <securely> & ready.", true, "codexmeter://auth/complete");
+        check(success.contains("You’re connected"), "browser success title");
+        check(success.contains("Codex Meter</a>"), "browser app return action");
+        check(success.contains("prefers-color-scheme:dark"), "browser One UI light and dark themes");
+        check(success.contains("border-radius:28px"), "browser One UI rounded card");
+        check(success.contains("Connected &lt;securely&gt; &amp; ready."),
+                "browser message HTML escaping");
+        check(success.contains("setTimeout"), "successful browser page automatically returns");
+
+        String failure = OAuthBrowserPage.render(
+                "Denied", false, "codexmeter://auth/complete");
+        check(failure.contains("Let’s try that again"), "browser failure title");
+        check(failure.contains("Back to Codex Meter"), "browser failure return action");
+        check(!failure.contains("setTimeout"), "failure page waits for user");
+
+        String escapedScript = OAuthBrowserPage.javascriptString("x'\\\n\u2028");
+        check("x\\'\\\\\\n\\u2028".equals(escapedScript), "browser script escaping");
     }
 
     private static String jwt(String payload) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a resumable four-step first-run onboarding flow using the app's One UI Design Library primitives
- route OAuth browser returns back through onboarding and preserve existing signed-in upgrades
- silently cancel abandoned OAuth services when onboarding is skipped while preserving resumable failure returns
- replace the legacy localhost callback page with a responsive One UI-inspired light/dark result page
- support Android 16 predictive-back navigation through `OnBackPressedDispatcher`
- add pure-Java coverage for onboarding decisions, navigation bounds, browser rendering, escaping, and redirect behavior

## Walkthrough
[oneui_onboarding_pages_final.mp4](https://cursor.com/agents/bc-ea647d24-c934-44ef-892f-5bdb569ebca5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foneui_onboarding_pages_final.mp4)

[OAuth callback page](https://cursor.com/agents/bc-ea647d24-c934-44ef-892f-5bdb569ebca5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foauth_redirect_oneui.webp)

[oauth_redirect_return_final.mp4](https://cursor.com/agents/bc-ea647d24-c934-44ef-892f-5bdb569ebca5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foauth_redirect_return_final.mp4)

[oauth_skip_cleanup_one_tap_clean.mp4](https://cursor.com/agents/bc-ea647d24-c934-44ef-892f-5bdb569ebca5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foauth_skip_cleanup_one_tap_clean.mp4)

## Testing
- `./run-tests.sh`
- `./build.sh`
- `./lint.sh`
- API 30 emulator: fresh install, onboarding navigation, OAuth authorization launch, placeholder completion, one-tap skip, callback deep-link return, and pending OAuth service cancellation

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea647d24-c934-44ef-892f-5bdb569ebca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea647d24-c934-44ef-892f-5bdb569ebca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

