### PR TITLE
Prepare Codex Meter 2.1.0 release

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -130,6 +130,9 @@ jobs:
       actions: read
       contents: write
     steps:
+      - name: Check out release sources
+        uses: actions/checkout@v7
+
       - name: Download verified APK
         uses: actions/download-artifact@v8
         with:
@@ -143,6 +146,26 @@ jobs:
           cd release-dist
           sha256sum -c SHA256SUMS.txt
 
+      - name: Prepare release notes
+        shell: bash
+        env:
+          VERSION_NAME: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          awk -v version="$VERSION_NAME" '
+            $0 == "## " version || index($0, "## " version " —") == 1 {
+              found = 1
+              next
+            }
+            found && /^## / { exit }
+            found { print }
+            END { if (!found) exit 2 }
+          ' CHANGELOG.md > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "::error::CHANGELOG.md has no release notes for $VERSION_NAME"
+            exit 1
+          fi
+
       - name: Publish GitHub release
         shell: bash
         env:
@@ -155,7 +178,11 @@ jobs:
             gh release create "$GITHUB_REF_NAME" \
               --draft \
               --verify-tag \
-              --generate-notes \
+              --notes-file release-notes.md \
+              --title "Codex Meter $VERSION_NAME"
+          else
+            gh release edit "$GITHUB_REF_NAME" \
+              --notes-file release-notes.md \
               --title "Codex Meter $VERSION_NAME"
           fi
           gh release upload "$GITHUB_REF_NAME" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2.1.0 — 2026-07-13
+
+### Added
+
+- A resumable four-step One UI onboarding flow for first launch, including sign-in, skip, upgrade, and predictive-back handling (#13).
+- A responsive light/dark OAuth completion page that returns users to the app after browser sign-in (#13).
+- Optional notifications when five-hour or weekly allowances unexpectedly refill before their scheduled reset (#12).
+- An independent notification preference for increases in available reset credits (#12).
+
+### Changed
+
+- Settings now uses an expanded, collapsible One UI toolbar that keeps primary controls within one-hand reach (#9).
+- Local-data and privacy details now live in a dedicated Settings section instead of the dashboard (#10).
+- Reset-credit observations are coalesced across usage and detail responses to prevent duplicate increase notifications (#12).
+
+### Fixed
+
+- Suppressed false refill celebrations after reset-credit redemption, including delayed backend propagation (#12).
+- Retried credit notifications when Android previously blocked application- or channel-level delivery (#12).
+- Cleaned up abandoned OAuth services when onboarding is skipped and hardened callback handling across Android versions (#13).
+
+### Development
+
+- Removed obsolete release binaries, recovery documents, generated caches, and superseded direct-build tools (#11).
+- Documented the Android toolchain, package-authentication requirements, and release validation path for cloud builds (#8).
+
 ## 2.0.0 — 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Codex Meter is an unofficial native Android application and widget for viewing the Codex allowance attached to a signed-in ChatGPT account. It displays the rolling five-hour and weekly limits, reset times, reset credits, home-screen widgets, Samsung One UI lock-screen widgets, and optional reset notifications.
 
-## Version 2.0.1
+## Version 2.1.0
 
-Version 2.0 introduces a Samsung One UI-native dashboard and settings experience, responsive home-screen widget layouts, dedicated five-hour and weekly lock-screen widgets, and a reproducible Gradle build. It retains the local reset countdowns and threshold-based alerts introduced in 1.7.
+Version 2.1 adds a resumable One UI first-run experience, a modern browser return page for OAuth sign-in, and optional notifications for unexpected allowance refills and reset-credit increases. It also brings the Settings screen into one-hand reach and consolidates local-data and privacy details there.
 
 ### Live countdowns
 
@@ -64,7 +64,7 @@ Requirements:
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.0.1`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
+Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.1.0`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
 
 ## Platform stability
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 10
-        versionName = "2.0.1"
+        versionCode = 11
+        versionName = "2.1.0"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -28,13 +28,13 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 10;
-    public static final String VERSION_NAME = "2.0.1";
+    public static final int VERSION_CODE = 11;
+    public static final String VERSION_NAME = "2.1.0";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.0.1 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.1.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.0.1"
+VERSION_NAME="2.1.0"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,10 +40,12 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.0.1"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 10' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.0.1"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 10' "$ROOT/app/build.gradle.kts"
+grep -q 'VERSION_NAME = "2.1.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 11' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.1.0"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 11' "$ROOT/app/build.gradle.kts"
+grep -q 'codex-meter-android/2.1.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.1.0"' "$ROOT/build.sh"
 
 grep -q 'android.permission.ACCESS_NETWORK_STATE' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'android.permission.POST_NOTIFICATIONS' "$ROOT/app/src/main/AndroidManifest.xml"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump Android, runtime, user-agent, packaging, and regression metadata to 2.1.0 / version code 11
- document the user-facing changes from PRs #9–#13 and repository maintenance from #8/#11
- publish curated changelog sections as GitHub release notes instead of unreliable auto-generated history

## Release contents
- resumable One UI onboarding and modern OAuth browser return
- surprise allowance-refill and reset-credit increase notifications
- one-hand-reach Settings behavior and consolidated privacy details
- notification and OAuth lifecycle hardening

## Release plan
After this PR is merged to `main`, push tag `v2.1.0`. The tag workflow will test, lint, decrypt the persistent signing key, build and verify the release APK, verify `SHA256SUMS.txt`, and publish both assets with the curated 2.1.0 notes.

## Testing
- `./run-tests.sh`
- `./lint.sh`
- `./build.sh`
- APK badging verified package `dev.bennett.codexmeter`, version code 11, version name 2.1.0, minimum API 26, target API 36, and launcher `MainActivity`
- APK Signature Scheme v2 and one signer verified
- `sha256sum -c dist/SHA256SUMS.txt`
- release-note extraction, workflow YAML parsing, CLI notes-file support, and whitespace validation
- GitHub Actions build job passed, including regression tests, Android lint, APK assembly/verification, and artifact upload
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11b7de2f-20c5-48f6-84a1-e83056450c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11b7de2f-20c5-48f6-84a1-e83056450c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

