### PR TITLE
Add configurable reset-credit expiry reminders

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -139,6 +139,9 @@
             android:name="dev.bennett.codexmeter.ResetAlertReceiver"
             android:exported="false"/>
         <receiver
+            android:name="dev.bennett.codexmeter.ResetCreditExpiryReceiver"
+            android:exported="false"/>
+        <receiver
             android:name="dev.bennett.codexmeter.BootReceiver"
             android:exported="false"
             android:directBootAware="false">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,7 @@
         <activity
             android:name="dev.bennett.codexmeter.ResetCreditActivity"
             android:exported="false"
+            android:launchMode="singleTop"
             android:excludeFromRecents="true"/>
         <activity
             android:theme="@style/AppTheme"

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -19,6 +19,7 @@ public final class AppConstants {
     public static final String EXTRA_AUTH_URL = "auth_url";
     public static final String EXTRA_CREDIT_ID = "credit_id";
     public static final String EXTRA_MESSAGE = "message";
+    public static final String EXTRA_NOTIFICATION_ID = "notification_id";
     public static final String EXTRA_PROMPT_USE_RESET = "prompt_use_reset";
     public static final String EXTRA_SUCCESS = "success";
     public static final String INTERNAL_PERMISSION = "dev.bennett.codexmeter.permission.INTERNAL";

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -8,6 +8,8 @@ public final class AppConstants {
     public static final String ACTION_OAUTH_RESULT = "dev.bennett.codexmeter.action.OAUTH_RESULT";
     public static final String ACTION_REFRESH_WIDGET = "dev.bennett.codexmeter.action.REFRESH_WIDGET";
     public static final String ACTION_RESET_ALERT = "dev.bennett.codexmeter.action.RESET_ALERT";
+    public static final String ACTION_RESET_CREDIT_EXPIRY_ALERT =
+            "dev.bennett.codexmeter.action.RESET_CREDIT_EXPIRY_ALERT";
     public static final String ACTION_RESET_CREDITS_UPDATED = "dev.bennett.codexmeter.action.RESET_CREDITS_UPDATED";
     public static final String ACTION_USAGE_UPDATED = "dev.bennett.codexmeter.action.USAGE_UPDATED";
     public static final String APP_LINK = "codexmeter://auth/complete";
@@ -17,6 +19,7 @@ public final class AppConstants {
     public static final String EXTRA_AUTH_URL = "auth_url";
     public static final String EXTRA_CREDIT_ID = "credit_id";
     public static final String EXTRA_MESSAGE = "message";
+    public static final String EXTRA_PROMPT_USE_RESET = "prompt_use_reset";
     public static final String EXTRA_SUCCESS = "success";
     public static final String INTERNAL_PERMISSION = "dev.bennett.codexmeter.permission.INTERNAL";
     public static final String OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";

--- a/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -59,6 +59,7 @@ public final class AppPreferences {
     public static void clearSnapshot(Context context) {
         prefs(context).edit().remove(KEY_SNAPSHOT).remove(KEY_ERROR).remove(KEY_ERROR_AT).remove(KEY_RESET_CREDITS).remove(KEY_RESET_ERROR).remove(KEY_RESET_ERROR_AT).apply();
         ResetNotificationManager.clearState(context);
+        ResetCreditExpiryScheduler.cancelAll(context);
     }
 
     public static void setLastError(Context context, String str) {

--- a/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
@@ -12,6 +12,8 @@ public final class BootReceiver extends BroadcastReceiver {
         if ("android.intent.action.BOOT_COMPLETED".equals(action) || "android.intent.action.MY_PACKAGE_REPLACED".equals(action)) {
             RefreshScheduler.schedulePeriodic(context);
             ResetAlertScheduler.scheduleFromSnapshot(context, AppPreferences.loadSnapshot(context));
+            ResetCreditExpiryScheduler.scheduleFromSnapshot(context,
+                    AppPreferences.loadResetCredits(context));
             WidgetRenderer.updateAll(context);
         }
     }

--- a/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java
@@ -2,10 +2,18 @@ package dev.bennett.codexmeter;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class ResetAlertPreferences {
     private static final String KEY_METRIC = "metric";
+    private static final String KEY_RESET_CREDIT_EXPIRY = "reset_credit_expiry";
+    private static final String KEY_RESET_CREDIT_EXPIRY_LEAD_TIMES =
+            "reset_credit_expiry_lead_times";
     private static final String KEY_RESET_CREDIT_INCREASES = "reset_credit_increases";
     private static final String KEY_STYLE = "style";
     private static final String KEY_THRESHOLD = "threshold";
@@ -18,6 +26,8 @@ public final class ResetAlertPreferences {
     public static final String STYLE_NOTIFICATION = "notification";
     public static final String STYLE_OFF = "off";
     public static final String STYLE_SILENT = "silent";
+    public static final long DEFAULT_RESET_CREDIT_EXPIRY_LEAD_TIME_MS =
+            24L * 60L * 60L * 1000L;
 
     private ResetAlertPreferences() {
     }
@@ -75,6 +85,52 @@ public final class ResetAlertPreferences {
 
     public static void setResetCreditIncreasesEnabled(Context context, boolean enabled) {
         prefs(context).edit().putBoolean(KEY_RESET_CREDIT_INCREASES, enabled).apply();
+    }
+
+    public static boolean resetCreditExpiryEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_RESET_CREDIT_EXPIRY, true);
+    }
+
+    public static void setResetCreditExpiryEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_RESET_CREDIT_EXPIRY, enabled).apply();
+    }
+
+    public static List<Long> getResetCreditExpiryLeadTimes(Context context) {
+        SharedPreferences preferences = prefs(context);
+        if (!preferences.contains(KEY_RESET_CREDIT_EXPIRY_LEAD_TIMES)) {
+            return Collections.singletonList(DEFAULT_RESET_CREDIT_EXPIRY_LEAD_TIME_MS);
+        }
+        Set<String> stored = preferences.getStringSet(KEY_RESET_CREDIT_EXPIRY_LEAD_TIMES,
+                Collections.emptySet());
+        List<Long> values = new ArrayList<>();
+        if (stored != null) {
+            for (String value : stored) {
+                try {
+                    long parsed = Long.parseLong(value);
+                    if (validExpiryLeadTime(parsed)) values.add(parsed);
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+        Collections.sort(values);
+        return values;
+    }
+
+    public static void setResetCreditExpiryLeadTimes(Context context, List<Long> leadTimes) {
+        Set<String> stored = new HashSet<>();
+        if (leadTimes != null) {
+            for (Long leadTime : leadTimes) {
+                if (leadTime != null && validExpiryLeadTime(leadTime)) {
+                    stored.add(String.valueOf(leadTime));
+                }
+            }
+        }
+        prefs(context).edit().putStringSet(KEY_RESET_CREDIT_EXPIRY_LEAD_TIMES, stored).apply();
+    }
+
+    private static boolean validExpiryLeadTime(long value) {
+        return value >= ResetCreditExpiryReminder.MIN_LEAD_TIME_MS
+                && value <= ResetCreditExpiryReminder.MAX_LEAD_TIME_MS;
     }
 
     private static boolean isValidThreshold(int i) {

--- a/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java
@@ -21,6 +21,7 @@ public final class ResetCreditActivity extends AppCompatActivity {
     private LinearLayout content;
     private boolean dark;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private int expiryNotificationId = -1;
     private Button useButton;
 
     @Override // android.app.Activity
@@ -147,7 +148,10 @@ public final class ResetCreditActivity extends AppCompatActivity {
                 AppConstants.EXTRA_PROMPT_USE_RESET, false)) {
             return;
         }
+        this.expiryNotificationId = intent.getIntExtra(
+                AppConstants.EXTRA_NOTIFICATION_ID, -1);
         intent.removeExtra(AppConstants.EXTRA_PROMPT_USE_RESET);
+        intent.removeExtra(AppConstants.EXTRA_NOTIFICATION_ID);
         ResetCreditsSnapshot snapshot = AppPreferences.loadResetCredits(this);
         if (snapshot != null && snapshot.availableCount > 0
                 && SecureTokenStore.isSignedIn(this)) {
@@ -173,6 +177,9 @@ public final class ResetCreditActivity extends AppCompatActivity {
                             if (!resetConsumeResultConsumeBestAvailable.applied()) {
                                 ResetCreditActivity.this.rebuild();
                             } else {
+                                ResetNotificationManager.dismissResetCreditExpiryNotification(
+                                        ResetCreditActivity.this,
+                                        ResetCreditActivity.this.expiryNotificationId);
                                 ResetCreditActivity.this.finish();
                             }
                         }

--- a/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java
@@ -3,6 +3,7 @@ package dev.bennett.codexmeter;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -30,6 +31,17 @@ public final class ResetCreditActivity extends AppCompatActivity {
         this.content = Ui.installPage(this, "Codex reset", true).content;
         rebuild();
         refreshDetailsIfNeeded();
+        if (bundle == null) {
+            maybePromptUseReset(getIntent());
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        rebuild();
+        maybePromptUseReset(intent);
     }
 
     @Override // android.app.Activity
@@ -128,6 +140,19 @@ public final class ResetCreditActivity extends AppCompatActivity {
             }
         }).create();
         dialog.show();
+    }
+
+    private void maybePromptUseReset(Intent intent) {
+        if (intent == null || !intent.getBooleanExtra(
+                AppConstants.EXTRA_PROMPT_USE_RESET, false)) {
+            return;
+        }
+        intent.removeExtra(AppConstants.EXTRA_PROMPT_USE_RESET);
+        ResetCreditsSnapshot snapshot = AppPreferences.loadResetCredits(this);
+        if (snapshot != null && snapshot.availableCount > 0
+                && SecureTokenStore.isSignedIn(this)) {
+            confirmUse();
+        }
     }
 
     public void consume() {

--- a/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReceiver.java
@@ -1,0 +1,48 @@
+package dev.bennett.codexmeter;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/** Revalidates a scheduled reset-credit reminder before showing it. */
+public final class ResetCreditExpiryReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (context == null || intent == null
+                || !AppConstants.ACTION_RESET_CREDIT_EXPIRY_ALERT.equals(intent.getAction())
+                || !SecureTokenStore.isSignedIn(context)
+                || !ResetAlertPreferences.enabled(context)
+                || !ResetAlertPreferences.resetCreditExpiryEnabled(context)) {
+            return;
+        }
+        String creditId = intent.getStringExtra(ResetCreditExpiryScheduler.EXTRA_CREDIT_ID);
+        long expiresAt = intent.getLongExtra(
+                ResetCreditExpiryScheduler.EXTRA_EXPIRES_AT, 0L);
+        long leadTime = intent.getLongExtra(
+                ResetCreditExpiryScheduler.EXTRA_LEAD_TIME, 0L);
+        if (!ResetAlertPreferences.getResetCreditExpiryLeadTimes(context).contains(leadTime)
+                || !isStillAvailable(context, creditId, expiresAt)) {
+            return;
+        }
+        ResetNotificationManager.showResetCreditExpiryNotification(context,
+                creditId, expiresAt, leadTime);
+        RefreshScheduler.scheduleImmediate(context);
+        WidgetRenderer.updateAll(context);
+    }
+
+    static boolean isStillAvailable(Context context, String creditId, long expiresAt) {
+        if (expiresAt <= System.currentTimeMillis()) return false;
+        ResetCreditsSnapshot snapshot = AppPreferences.loadResetCredits(context);
+        if (snapshot == null) return false;
+        for (RateLimitResetCredit credit : snapshot.credits) {
+            if (credit == null || !credit.isAvailable()
+                    || credit.expiresAtMillis != expiresAt) {
+                continue;
+            }
+            if (creditId == null || creditId.isEmpty() || credit.id.equals(creditId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReminder.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReminder.java
@@ -1,0 +1,63 @@
+package dev.bennett.codexmeter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Pure scheduling model for reset-credit expiry reminders. */
+public final class ResetCreditExpiryReminder {
+    public static final long MIN_LEAD_TIME_MS = 60_000L;
+    public static final long MAX_LEAD_TIME_MS = 365L * 24L * 60L * 60L * 1000L;
+
+    public final String creditId;
+    public final long expiresAtMillis;
+    public final long leadTimeMillis;
+    public final long triggerAtMillis;
+
+    private ResetCreditExpiryReminder(String creditId, long expiresAtMillis,
+            long leadTimeMillis) {
+        this.creditId = creditId == null ? "" : creditId;
+        this.expiresAtMillis = expiresAtMillis;
+        this.leadTimeMillis = leadTimeMillis;
+        this.triggerAtMillis = Math.max(0L, expiresAtMillis - leadTimeMillis);
+    }
+
+    public String token() {
+        return token(creditId, expiresAtMillis, leadTimeMillis);
+    }
+
+    public static String token(String creditId, long expiresAtMillis, long leadTimeMillis) {
+        return (creditId == null ? "" : creditId) + ":" + expiresAtMillis + ":"
+                + leadTimeMillis;
+    }
+
+    public static List<ResetCreditExpiryReminder> plan(List<RateLimitResetCredit> credits,
+            Collection<Long> leadTimes, long nowMillis) {
+        List<ResetCreditExpiryReminder> reminders = new ArrayList<>();
+        if (credits == null || leadTimes == null) return reminders;
+        Set<Long> uniqueLeadTimes = new HashSet<>(leadTimes);
+        for (RateLimitResetCredit credit : credits) {
+            if (credit == null || !credit.isAvailable()
+                    || credit.expiresAtMillis <= nowMillis) {
+                continue;
+            }
+            for (Long leadTime : uniqueLeadTimes) {
+                if (leadTime == null || leadTime < MIN_LEAD_TIME_MS
+                        || leadTime > MAX_LEAD_TIME_MS) {
+                    continue;
+                }
+                reminders.add(new ResetCreditExpiryReminder(credit.id,
+                        credit.expiresAtMillis, leadTime));
+            }
+        }
+        reminders.sort(Comparator
+                .comparingLong((ResetCreditExpiryReminder reminder) -> reminder.triggerAtMillis)
+                .thenComparingLong(reminder -> reminder.expiresAtMillis)
+                .thenComparingLong(reminder -> reminder.leadTimeMillis)
+                .thenComparing(reminder -> reminder.creditId));
+        return reminders;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryScheduler.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryScheduler.java
@@ -1,0 +1,127 @@
+package dev.bennett.codexmeter;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Build;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Schedules one alarm for each configured lead time and available reset credit. */
+public final class ResetCreditExpiryScheduler {
+    static final String EXTRA_CREDIT_ID = "expiry_credit_id";
+    static final String EXTRA_EXPIRES_AT = "expiry_expires_at";
+    static final String EXTRA_LEAD_TIME = "expiry_lead_time";
+    private static final long DELIVERY_GRACE_MS = 1000L;
+    private static final String KEY_ALARM_URIS = "alarm_uris";
+    private static final String PREFS = "codex_meter_reset_expiry_alarms_v1";
+    private static final int REQUEST_CODE = 74209;
+
+    private ResetCreditExpiryScheduler() {
+    }
+
+    public static void scheduleFromSnapshot(Context context, ResetCreditsSnapshot snapshot) {
+        Context app = appContext(context);
+        if (app == null) return;
+        cancelAll(app);
+        if (snapshot == null || !SecureTokenStore.isSignedIn(app)
+                || !ResetAlertPreferences.enabled(app)
+                || !ResetAlertPreferences.resetCreditExpiryEnabled(app)) {
+            return;
+        }
+        List<ResetCreditExpiryReminder> reminders = ResetCreditExpiryReminder.plan(
+                snapshot.credits, ResetAlertPreferences.getResetCreditExpiryLeadTimes(app),
+                System.currentTimeMillis());
+        AlarmManager manager = (AlarmManager) app.getSystemService(Context.ALARM_SERVICE);
+        if (manager == null) return;
+        long now = System.currentTimeMillis();
+        Set<String> scheduledUris = new HashSet<>();
+        for (ResetCreditExpiryReminder reminder : reminders) {
+            if (ResetNotificationManager.isResetCreditExpiryReminderAnnounced(
+                    app, reminder.token())) {
+                continue;
+            }
+            Uri data = data(reminder.creditId, reminder.expiresAtMillis,
+                    reminder.leadTimeMillis);
+            PendingIntent pendingIntent = pending(app, data, reminder);
+            long triggerAt = Math.max(now + DELIVERY_GRACE_MS, reminder.triggerAtMillis);
+            try {
+                if (Build.VERSION.SDK_INT < 31 || manager.canScheduleExactAlarms()) {
+                    manager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP,
+                            triggerAt, pendingIntent);
+                } else {
+                    manager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP,
+                            triggerAt, pendingIntent);
+                }
+                scheduledUris.add(data.toString());
+            } catch (SecurityException exception) {
+                manager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP,
+                        triggerAt, pendingIntent);
+                scheduledUris.add(data.toString());
+            }
+        }
+        prefs(app).edit().putStringSet(KEY_ALARM_URIS, scheduledUris).apply();
+    }
+
+    public static void cancelAll(Context context) {
+        Context app = appContext(context);
+        if (app == null) return;
+        AlarmManager manager = (AlarmManager) app.getSystemService(Context.ALARM_SERVICE);
+        Set<String> uris = prefs(app).getStringSet(KEY_ALARM_URIS, null);
+        if (manager != null && uris != null) {
+            for (String uri : new HashSet<>(uris)) {
+                PendingIntent pendingIntent = existingPending(app, Uri.parse(uri));
+                if (pendingIntent != null) {
+                    manager.cancel(pendingIntent);
+                    pendingIntent.cancel();
+                }
+            }
+        }
+        prefs(app).edit().remove(KEY_ALARM_URIS).apply();
+    }
+
+    private static PendingIntent pending(Context context, Uri data,
+            ResetCreditExpiryReminder reminder) {
+        Intent intent = baseIntent(context, data)
+                .putExtra(EXTRA_CREDIT_ID, reminder.creditId)
+                .putExtra(EXTRA_EXPIRES_AT, reminder.expiresAtMillis)
+                .putExtra(EXTRA_LEAD_TIME, reminder.leadTimeMillis);
+        return PendingIntent.getBroadcast(context, REQUEST_CODE, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    }
+
+    private static PendingIntent existingPending(Context context, Uri data) {
+        return PendingIntent.getBroadcast(context, REQUEST_CODE, baseIntent(context, data),
+                PendingIntent.FLAG_NO_CREATE | PendingIntent.FLAG_IMMUTABLE);
+    }
+
+    private static Intent baseIntent(Context context, Uri data) {
+        return new Intent(context, ResetCreditExpiryReceiver.class)
+                .setAction(AppConstants.ACTION_RESET_CREDIT_EXPIRY_ALERT)
+                .setData(data);
+    }
+
+    private static Uri data(String creditId, long expiresAt, long leadTime) {
+        return new Uri.Builder()
+                .scheme("codexmeter")
+                .authority("reset-credit-expiry")
+                .appendPath(creditId == null || creditId.isEmpty() ? "_" : creditId)
+                .appendQueryParameter("expires", String.valueOf(expiresAt))
+                .appendQueryParameter("lead", String.valueOf(leadTime))
+                .build();
+    }
+
+    private static SharedPreferences prefs(Context context) {
+        return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    private static Context appContext(Context context) {
+        if (context == null) return null;
+        Context applicationContext = context.getApplicationContext();
+        return applicationContext == null ? context : applicationContext;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -11,7 +11,9 @@ import android.content.pm.PackageManager;
 import android.media.AudioAttributes;
 import android.media.RingtoneManager;
 import android.os.Build;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 /** Posts and deduplicates Codex usage, reset-time, and reset-credit notifications. */
 public final class ResetNotificationManager {
@@ -22,6 +24,8 @@ public final class ResetNotificationManager {
     private static final String KEY_FIVE_HOUR_WINDOW = "low_five_hour_window";
     private static final String KEY_WEEKLY_WINDOW = "low_weekly_window";
     private static final String KEY_CREDIT_COUNT = "known_reset_credit_count";
+    private static final String KEY_CREDIT_EXPIRY_ANNOUNCED =
+            "reset_credit_expiry_announced";
     private static final String KEY_USER_RESET_FIVE_HOUR_UNTIL = "user_reset_five_hour_until";
     private static final String KEY_USER_RESET_WEEKLY_UNTIL = "user_reset_weekly_until";
     private static final long UNKNOWN_USER_RESET_SUPPRESSION_MS = 15 * 60 * 1000L;
@@ -31,6 +35,7 @@ public final class ResetNotificationManager {
     private static final int NOTIFICATION_LOW_FIVE_HOUR = 74505;
     private static final int NOTIFICATION_LOW_WEEKLY = 74507;
     private static final int NOTIFICATION_NEW_CREDIT = 74509;
+    private static final int NOTIFICATION_CREDIT_EXPIRY_BASE = 74600;
     private static final int NOTIFICATION_REFILL_FIVE_HOUR = 74511;
     private static final int NOTIFICATION_REFILL_WEEKLY = 74512;
     private static final int NOTIFICATION_REFILL_BOTH = 74513;
@@ -66,6 +71,11 @@ public final class ResetNotificationManager {
     public static void onResetCreditsUpdated(Context context, ResetCreditsSnapshot snapshot) {
         if (context == null || snapshot == null) return;
         onResetCreditCountUpdated(context, snapshot.availableCount);
+        pruneResetCreditExpiryHistory(context, snapshot);
+        try {
+            ResetCreditExpiryScheduler.scheduleFromSnapshot(context, snapshot);
+        } catch (RuntimeException ignored) {
+        }
     }
 
     static void onResetCreditSummaryUpdated(Context context, int availableCount) {
@@ -121,6 +131,39 @@ public final class ResetNotificationManager {
                 weekly ? NOTIFICATION_RESET_WEEKLY : NOTIFICATION_RESET_FIVE_HOUR);
     }
 
+    public static boolean showResetCreditExpiryNotification(Context context, String creditId,
+            long expiresAtMillis, long leadTimeMillis) {
+        if (context == null || expiresAtMillis <= System.currentTimeMillis()
+                || !ResetAlertPreferences.enabled(context)
+                || !ResetAlertPreferences.resetCreditExpiryEnabled(context)) {
+            return false;
+        }
+        String token = ResetCreditExpiryReminder.token(creditId, expiresAtMillis,
+                leadTimeMillis);
+        if (isResetCreditExpiryReminderAnnounced(context, token)) return false;
+        int notificationId = NOTIFICATION_CREDIT_EXPIRY_BASE
+                + Math.floorMod((creditId == null ? token : creditId).hashCode(), 1000);
+        long now = System.currentTimeMillis();
+        String text = "One reset credit expires "
+                + UsageFormat.absolute(context, expiresAtMillis, now) + " ("
+                + UsageFormat.relative(expiresAtMillis, now)
+                + "). Use it before it expires.";
+        if (!postResetCreditExpiry(context, notificationId,
+                "Codex reset credit expires soon", text)) {
+            return false;
+        }
+        Set<String> announced = new HashSet<>(state(context).getStringSet(
+                KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()));
+        announced.add(token);
+        state(context).edit().putStringSet(KEY_CREDIT_EXPIRY_ANNOUNCED, announced).apply();
+        return true;
+    }
+
+    static boolean isResetCreditExpiryReminderAnnounced(Context context, String token) {
+        return context != null && token != null && state(context).getStringSet(
+                KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()).contains(token);
+    }
+
     public static boolean sendTestNotification(Context context) {
         if (context == null || !ResetAlertPreferences.enabled(context)) {
             return false;
@@ -146,7 +189,23 @@ public final class ResetNotificationManager {
                 .remove(KEY_FIVE_HOUR_WINDOW)
                 .remove(KEY_WEEKLY_WINDOW)
                 .remove(KEY_CREDIT_COUNT)
+                .remove(KEY_CREDIT_EXPIRY_ANNOUNCED)
                 .apply();
+    }
+
+    private static void pruneResetCreditExpiryHistory(Context context,
+            ResetCreditsSnapshot snapshot) {
+        Set<String> active = new HashSet<>();
+        for (ResetCreditExpiryReminder reminder : ResetCreditExpiryReminder.plan(
+                snapshot.credits, ResetAlertPreferences.getResetCreditExpiryLeadTimes(context),
+                System.currentTimeMillis())) {
+            active.add(reminder.token());
+        }
+        Set<String> announced = new HashSet<>(state(context).getStringSet(
+                KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()));
+        if (announced.retainAll(active)) {
+            state(context).edit().putStringSet(KEY_CREDIT_EXPIRY_ANNOUNCED, announced).apply();
+        }
     }
 
     private static void notifyLowWindow(Context context, UsageWindow window, long fetchedAt,
@@ -241,6 +300,39 @@ public final class ResetNotificationManager {
                 .setContentText(text)
                 .setStyle(new Notification.BigTextStyle().bigText(text))
                 .setContentIntent(contentIntent)
+                .setAutoCancel(true)
+                .setCategory(Notification.CATEGORY_REMINDER)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
+                .setShowWhen(true)
+                .build();
+        manager.notify(id, notification);
+        return true;
+    }
+
+    private static boolean postResetCreditExpiry(Context context, int id, String title,
+            String text) {
+        NotificationManager manager = manager(context);
+        if (manager == null) return false;
+        String channel = createChannel(manager, ResetAlertPreferences.getStyle(context));
+        if (!canPost(context, manager, channel)) return false;
+        Intent detailsIntent = new Intent(context, ResetCreditActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent details = PendingIntent.getActivity(context, id, detailsIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        Intent useIntent = new Intent(context, ResetCreditActivity.class)
+                .setAction("dev.bennett.codexmeter.action.USE_RESET_FROM_NOTIFICATION")
+                .putExtra(AppConstants.EXTRA_PROMPT_USE_RESET, true)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent useReset = PendingIntent.getActivity(context, id + 10_000, useIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        Notification notification = new Notification.Builder(context, channel)
+                .setSmallIcon(R.drawable.ic_reset_notification)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setStyle(new Notification.BigTextStyle().bigText(text))
+                .setContentIntent(details)
+                .addAction(new Notification.Action.Builder(R.drawable.ic_reset_notification,
+                        "Use reset", useReset).build())
                 .setAutoCancel(true)
                 .setCategory(Notification.CATEGORY_REMINDER)
                 .setVisibility(Notification.VISIBILITY_PUBLIC)

--- a/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -39,6 +39,7 @@ public final class ResetNotificationManager {
     private static final int NOTIFICATION_REFILL_FIVE_HOUR = 74511;
     private static final int NOTIFICATION_REFILL_WEEKLY = 74512;
     private static final int NOTIFICATION_REFILL_BOTH = 74513;
+    private static final Object EXPIRY_STATE_LOCK = new Object();
 
     private ResetNotificationManager() {
     }
@@ -140,28 +141,51 @@ public final class ResetNotificationManager {
         }
         String token = ResetCreditExpiryReminder.token(creditId, expiresAtMillis,
                 leadTimeMillis);
-        if (isResetCreditExpiryReminderAnnounced(context, token)) return false;
-        int notificationId = NOTIFICATION_CREDIT_EXPIRY_BASE
-                + Math.floorMod((creditId == null ? token : creditId).hashCode(), 1000);
-        long now = System.currentTimeMillis();
-        String text = "One reset credit expires "
-                + UsageFormat.absolute(context, expiresAtMillis, now) + " ("
-                + UsageFormat.relative(expiresAtMillis, now)
-                + "). Use it before it expires.";
-        if (!postResetCreditExpiry(context, notificationId,
-                "Codex reset credit expires soon", text)) {
-            return false;
+        synchronized (EXPIRY_STATE_LOCK) {
+            if (isResetCreditExpiryReminderAnnouncedLocked(context, token)) return false;
+            int notificationId = notificationIdForCredit(creditId, token);
+            long now = System.currentTimeMillis();
+            String text = "One reset credit expires "
+                    + UsageFormat.absolute(context, expiresAtMillis, now) + " ("
+                    + UsageFormat.relative(expiresAtMillis, now)
+                    + "). Use it before it expires.";
+            if (!postResetCreditExpiry(context, notificationId,
+                    "Codex reset credit expires soon", text)) {
+                return false;
+            }
+            Set<String> announced = new HashSet<>(state(context).getStringSet(
+                    KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()));
+            announced.add(token);
+            state(context).edit().putStringSet(
+                    KEY_CREDIT_EXPIRY_ANNOUNCED, announced).apply();
+            return true;
         }
-        Set<String> announced = new HashSet<>(state(context).getStringSet(
-                KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()));
-        announced.add(token);
-        state(context).edit().putStringSet(KEY_CREDIT_EXPIRY_ANNOUNCED, announced).apply();
-        return true;
     }
 
     static boolean isResetCreditExpiryReminderAnnounced(Context context, String token) {
-        return context != null && token != null && state(context).getStringSet(
-                KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()).contains(token);
+        if (context == null || token == null) return false;
+        synchronized (EXPIRY_STATE_LOCK) {
+            return isResetCreditExpiryReminderAnnouncedLocked(context, token);
+        }
+    }
+
+    public static void onResetCreditExpirySettingsChanged(Context context,
+            ResetCreditsSnapshot snapshot) {
+        if (context == null) return;
+        if (!ResetAlertPreferences.resetCreditExpiryEnabled(context)) {
+            clearResetCreditExpiryReminderHistory(context);
+        } else if (snapshot != null) {
+            pruneResetCreditExpiryHistory(context, snapshot);
+        }
+        ResetCreditExpiryScheduler.scheduleFromSnapshot(context, snapshot);
+    }
+
+    public static void dismissResetCreditExpiryNotification(Context context,
+            int notificationId) {
+        NotificationManager notificationManager = context == null ? null : manager(context);
+        if (notificationManager != null && notificationId >= NOTIFICATION_CREDIT_EXPIRY_BASE) {
+            notificationManager.cancel(notificationId);
+        }
     }
 
     public static boolean sendTestNotification(Context context) {
@@ -180,7 +204,10 @@ public final class ResetNotificationManager {
     }
 
     public static void clearState(Context context) {
-        if (context != null) state(context).edit().clear().apply();
+        if (context == null) return;
+        synchronized (EXPIRY_STATE_LOCK) {
+            state(context).edit().clear().apply();
+        }
     }
 
     public static void clearNotificationHistory(Context context) {
@@ -189,8 +216,8 @@ public final class ResetNotificationManager {
                 .remove(KEY_FIVE_HOUR_WINDOW)
                 .remove(KEY_WEEKLY_WINDOW)
                 .remove(KEY_CREDIT_COUNT)
-                .remove(KEY_CREDIT_EXPIRY_ANNOUNCED)
                 .apply();
+        clearResetCreditExpiryReminderHistory(context);
     }
 
     private static void pruneResetCreditExpiryHistory(Context context,
@@ -201,11 +228,32 @@ public final class ResetNotificationManager {
                 System.currentTimeMillis())) {
             active.add(reminder.token());
         }
-        Set<String> announced = new HashSet<>(state(context).getStringSet(
-                KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()));
-        if (announced.retainAll(active)) {
-            state(context).edit().putStringSet(KEY_CREDIT_EXPIRY_ANNOUNCED, announced).apply();
+        synchronized (EXPIRY_STATE_LOCK) {
+            Set<String> announced = new HashSet<>(state(context).getStringSet(
+                    KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()));
+            if (announced.retainAll(active)) {
+                state(context).edit().putStringSet(
+                        KEY_CREDIT_EXPIRY_ANNOUNCED, announced).apply();
+            }
         }
+    }
+
+    private static void clearResetCreditExpiryReminderHistory(Context context) {
+        synchronized (EXPIRY_STATE_LOCK) {
+            state(context).edit().remove(KEY_CREDIT_EXPIRY_ANNOUNCED).apply();
+        }
+    }
+
+    private static boolean isResetCreditExpiryReminderAnnouncedLocked(
+            Context context, String token) {
+        return state(context).getStringSet(
+                KEY_CREDIT_EXPIRY_ANNOUNCED, new HashSet<>()).contains(token);
+    }
+
+    private static int notificationIdForCredit(String creditId, String fallbackToken) {
+        return NOTIFICATION_CREDIT_EXPIRY_BASE
+                + Math.floorMod((creditId == null || creditId.isEmpty()
+                ? fallbackToken : creditId).hashCode(), 1000);
     }
 
     private static void notifyLowWindow(Context context, UsageWindow window, long fetchedAt,
@@ -322,6 +370,7 @@ public final class ResetNotificationManager {
         Intent useIntent = new Intent(context, ResetCreditActivity.class)
                 .setAction("dev.bennett.codexmeter.action.USE_RESET_FROM_NOTIFICATION")
                 .putExtra(AppConstants.EXTRA_PROMPT_USE_RESET, true)
+                .putExtra(AppConstants.EXTRA_NOTIFICATION_ID, id)
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent useReset = PendingIntent.getActivity(context, id + 10_000, useIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -7,10 +7,15 @@ import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.text.InputType;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
@@ -21,6 +26,10 @@ import dev.oneuiproject.oneui.preference.HorizontalRadioPreference;
 import dev.oneuiproject.oneui.preference.LayoutPreference;
 import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 import dev.oneuiproject.oneui.widget.CardItemView;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /** Settings built from the One UI Design Library preference components used by its sample app. */
 public final class SettingsActivity extends AppCompatActivity {
@@ -40,6 +49,7 @@ public final class SettingsActivity extends AppCompatActivity {
     }
 
     public static final class SettingsFragment extends PreferenceFragmentCompat {
+        private Preference expiryTimesPreference;
         private Preference permissionPreference;
         private Preference testNotificationPreference;
 
@@ -233,6 +243,28 @@ public final class SettingsActivity extends AppCompatActivity {
                 return true;
             });
 
+            SwitchPreferenceCompat resetCreditExpiry =
+                    findPreference("reset_credit_expiry_ui");
+            resetCreditExpiry.setPersistent(false);
+            resetCreditExpiry.setChecked(
+                    ResetAlertPreferences.resetCreditExpiryEnabled(requireContext()));
+            resetCreditExpiry.setOnPreferenceChangeListener((preference, value) -> {
+                boolean enabled = (Boolean) value;
+                ResetAlertPreferences.setResetCreditExpiryEnabled(requireContext(), enabled);
+                expiryTimesPreference.setEnabled(enabled);
+                scheduleResetCreditExpiryReminders();
+                return true;
+            });
+
+            expiryTimesPreference = findPreference("reset_credit_expiry_times_ui");
+            expiryTimesPreference.setEnabled(
+                    ResetAlertPreferences.resetCreditExpiryEnabled(requireContext()));
+            expiryTimesPreference.setOnPreferenceClickListener(preference -> {
+                showExpiryReminderTimesDialog();
+                return true;
+            });
+            updateExpiryTimesSummary();
+
             permissionPreference = findPreference("notification_permission");
             permissionPreference.setOnPreferenceClickListener(preference -> {
                 startActivity(new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
@@ -249,6 +281,157 @@ public final class SettingsActivity extends AppCompatActivity {
                 return true;
             });
             updatePermissionSummary();
+        }
+
+        private void showExpiryReminderTimesDialog() {
+            List<Long> leadTimes = ResetAlertPreferences.getResetCreditExpiryLeadTimes(
+                    requireContext());
+            AlertDialog.Builder builder = new AlertDialog.Builder(requireContext())
+                    .setTitle("Reminder times")
+                    .setNeutralButton("Add", (dialog, which) ->
+                            showAddExpiryReminderDialog())
+                    .setNegativeButton("Done", null);
+            if (leadTimes.isEmpty()) {
+                builder.setMessage("No reminder times are configured. Add one to choose how "
+                        + "long before expiry Codex Meter should notify you.");
+            } else {
+                String[] labels = new String[leadTimes.size()];
+                for (int i = 0; i < leadTimes.size(); i++) {
+                    labels[i] = formatLeadTime(leadTimes.get(i))
+                            + " before expiry — tap to remove";
+                }
+                builder.setItems(labels, (dialog, which) -> {
+                    List<Long> updated = new ArrayList<>(leadTimes);
+                    long removed = updated.remove(which);
+                    saveExpiryLeadTimes(updated);
+                    Toast.makeText(requireContext(),
+                            formatLeadTime(removed) + " reminder removed.",
+                            Toast.LENGTH_SHORT).show();
+                });
+            }
+            builder.show();
+        }
+
+        private void showAddExpiryReminderDialog() {
+            boolean dark = Ui.isDark(requireContext());
+            LinearLayout container = new LinearLayout(requireContext());
+            container.setOrientation(LinearLayout.VERTICAL);
+            container.setPadding(Ui.dp(requireContext(), 24), Ui.dp(requireContext(), 8),
+                    Ui.dp(requireContext(), 24), 0);
+            TextView explanation = Ui.text(requireContext(),
+                    "Notify me this long before each available reset credit expires.",
+                    14.0f, Ui.secondaryText(dark));
+            container.addView(explanation, new LinearLayout.LayoutParams(-1, -2));
+
+            LinearLayout inputRow = Ui.horizontal(requireContext(), 12);
+            LinearLayout.LayoutParams rowParams = new LinearLayout.LayoutParams(-1, -2);
+            rowParams.setMargins(0, Ui.dp(requireContext(), 16), 0, 0);
+            EditText amount = new EditText(requireContext());
+            amount.setHint("Amount");
+            amount.setSingleLine(true);
+            amount.setTextColor(Ui.mainText(dark));
+            amount.setHintTextColor(Ui.secondaryText(dark));
+            amount.setInputType(InputType.TYPE_CLASS_NUMBER
+                    | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+            inputRow.addView(amount, new LinearLayout.LayoutParams(0,
+                    Ui.dp(requireContext(), 54), 1.0f));
+            String[] units = {"Minutes", "Hours", "Days", "Weeks"};
+            Spinner unit = Ui.spinner(requireContext(), units, dark);
+            unit.setSelection(1);
+            LinearLayout.LayoutParams unitParams = new LinearLayout.LayoutParams(
+                    Ui.dp(requireContext(), 142), Ui.dp(requireContext(), 54));
+            unitParams.setMargins(Ui.dp(requireContext(), 8), 0, 0, 0);
+            inputRow.addView(unit, unitParams);
+            container.addView(inputRow, rowParams);
+
+            AlertDialog dialog = new AlertDialog.Builder(requireContext())
+                    .setTitle("Add reminder time")
+                    .setView(container)
+                    .setNegativeButton("Cancel", null)
+                    .setPositiveButton("Add", null)
+                    .create();
+            dialog.setOnShowListener(ignored -> dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    .setOnClickListener(view -> {
+                        Long leadTime = parseLeadTime(amount.getText().toString(),
+                                unit.getSelectedItemPosition());
+                        if (leadTime == null) {
+                            amount.setError("Enter a time from 1 minute to 1 year, "
+                                    + "in whole minutes.");
+                            return;
+                        }
+                        List<Long> updated = new ArrayList<>(
+                                ResetAlertPreferences.getResetCreditExpiryLeadTimes(
+                                        requireContext()));
+                        if (!updated.contains(leadTime)) updated.add(leadTime);
+                        saveExpiryLeadTimes(updated);
+                        dialog.dismiss();
+                    }));
+            dialog.show();
+        }
+
+        private Long parseLeadTime(String amount, int unitPosition) {
+            long[] unitMillis = {
+                    TimeUnit.MINUTES.toMillis(1),
+                    TimeUnit.HOURS.toMillis(1),
+                    TimeUnit.DAYS.toMillis(1),
+                    TimeUnit.DAYS.toMillis(7)
+            };
+            if (amount == null || amount.trim().isEmpty()
+                    || unitPosition < 0 || unitPosition >= unitMillis.length) {
+                return null;
+            }
+            try {
+                long value = new BigDecimal(amount.trim())
+                        .multiply(BigDecimal.valueOf(unitMillis[unitPosition]))
+                        .longValueExact();
+                return value >= ResetCreditExpiryReminder.MIN_LEAD_TIME_MS
+                        && value <= ResetCreditExpiryReminder.MAX_LEAD_TIME_MS
+                        && value % ResetCreditExpiryReminder.MIN_LEAD_TIME_MS == 0L
+                        ? value : null;
+            } catch (ArithmeticException | NumberFormatException exception) {
+                return null;
+            }
+        }
+
+        private void saveExpiryLeadTimes(List<Long> leadTimes) {
+            ResetAlertPreferences.setResetCreditExpiryLeadTimes(requireContext(), leadTimes);
+            updateExpiryTimesSummary();
+            scheduleResetCreditExpiryReminders();
+        }
+
+        private void updateExpiryTimesSummary() {
+            if (expiryTimesPreference == null) return;
+            List<Long> leadTimes = ResetAlertPreferences.getResetCreditExpiryLeadTimes(
+                    requireContext());
+            if (leadTimes.isEmpty()) {
+                expiryTimesPreference.setSummary("No reminder times configured");
+                return;
+            }
+            List<String> labels = new ArrayList<>();
+            for (Long leadTime : leadTimes) labels.add(formatLeadTime(leadTime));
+            expiryTimesPreference.setSummary(String.join(", ", labels) + " before expiry");
+        }
+
+        private String formatLeadTime(long millis) {
+            if (millis % TimeUnit.DAYS.toMillis(7) == 0L) {
+                long weeks = millis / TimeUnit.DAYS.toMillis(7);
+                return weeks + " week" + (weeks == 1 ? "" : "s");
+            }
+            if (millis % TimeUnit.DAYS.toMillis(1) == 0L) {
+                long days = millis / TimeUnit.DAYS.toMillis(1);
+                return days + " day" + (days == 1 ? "" : "s");
+            }
+            if (millis % TimeUnit.HOURS.toMillis(1) == 0L) {
+                long hours = millis / TimeUnit.HOURS.toMillis(1);
+                return hours + " hour" + (hours == 1 ? "" : "s");
+            }
+            long minutes = millis / TimeUnit.MINUTES.toMillis(1);
+            return minutes + " minute" + (minutes == 1 ? "" : "s");
+        }
+
+        private void scheduleResetCreditExpiryReminders() {
+            ResetCreditExpiryScheduler.scheduleFromSnapshot(requireContext(),
+                    AppPreferences.loadResetCredits(requireContext()));
         }
 
         private void setNotificationsEnabled(boolean enabled) {
@@ -275,6 +458,7 @@ public final class SettingsActivity extends AppCompatActivity {
                 ResetNotificationManager.onResetCreditsUpdated(requireContext(), AppPreferences.loadResetCredits(requireContext()));
             }
             ResetAlertScheduler.scheduleFromSnapshot(requireContext(), AppPreferences.loadSnapshot(requireContext()));
+            scheduleResetCreditExpiryReminders();
         }
 
         private void updatePermissionSummary() {

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -27,6 +27,7 @@ import dev.oneuiproject.oneui.preference.LayoutPreference;
 import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 import dev.oneuiproject.oneui.widget.CardItemView;
 import java.math.BigDecimal;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -381,7 +382,11 @@ public final class SettingsActivity extends AppCompatActivity {
                 return null;
             }
             try {
-                long value = new BigDecimal(amount.trim())
+                char decimalSeparator = DecimalFormatSymbols.getInstance()
+                        .getDecimalSeparator();
+                String normalized = decimalSeparator == '.'
+                        ? amount.trim() : amount.trim().replace(decimalSeparator, '.');
+                long value = new BigDecimal(normalized)
                         .multiply(BigDecimal.valueOf(unitMillis[unitPosition]))
                         .longValueExact();
                 return value >= ResetCreditExpiryReminder.MIN_LEAD_TIME_MS
@@ -430,7 +435,7 @@ public final class SettingsActivity extends AppCompatActivity {
         }
 
         private void scheduleResetCreditExpiryReminders() {
-            ResetCreditExpiryScheduler.scheduleFromSnapshot(requireContext(),
+            ResetNotificationManager.onResetCreditExpirySettingsChanged(requireContext(),
                     AppPreferences.loadResetCredits(requireContext()));
         }
 

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -56,6 +56,14 @@
             android:key="reset_credit_increases_ui"
             android:title="New reset credits"
             android:summary="Notify when your available reset-credit count increases" />
+        <SwitchPreferenceCompat
+            android:key="reset_credit_expiry_ui"
+            android:title="Expiring reset credits"
+            android:summary="Remind me before an available reset credit expires" />
+        <Preference
+            android:key="reset_credit_expiry_times_ui"
+            android:title="Reminder times"
+            app:iconSpaceReserved="false" />
         <Preference
             android:key="notification_permission"
             android:title="Notification permission"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -30,6 +30,8 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageParser.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/RateLimitResetCredit.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReminder.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/Pkce.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/JwtClaims.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java" \
@@ -68,6 +70,11 @@ test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertScheduler.java
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertReceiver.java"
 grep -q 'scheduleFromSnapshot' "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertScheduler.java"
 grep -q 'POST_NOTIFICATIONS' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryScheduler.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReceiver.java"
+grep -q 'ResetCreditExpiryReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'reset_credit_expiry_times_ui' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 
 grep -R -q '<Chronometer' "$ROOT/app/src/main/res/layout/widget_lock_"*.xml
 grep -q 'setChronometerCountDown' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -75,6 +75,10 @@ test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReceive
 grep -q 'ResetCreditExpiryReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'reset_credit_expiry_times_ui' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q '"Use reset", useReset' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java"
+grep -q 'EXTRA_PROMPT_USE_RESET' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java"
 
 grep -R -q '<Chronometer' "$ROOT/app/src/main/res/layout/widget_lock_"*.xml
 grep -q 'setChronometerCountDown' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -2,7 +2,10 @@ package dev.bennett.codexmeter;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 
 public final class ParserSelfTest {
     public static void main(String[] args) throws Exception {
@@ -13,6 +16,7 @@ public final class ParserSelfTest {
         testMalformedWindowIgnored();
         testZeroDurationWindowIgnored();
         testCelebrationDetection();
+        testResetCreditExpiryReminders();
         testJwtMerge();
         testPkce();
         testWidgetOptions();
@@ -135,6 +139,43 @@ public final class ParserSelfTest {
         System.out.println("Celebration demo: countdown elapsed -> natural reset, no surprise notification.");
         System.out.println("Celebration demo: user reset marker -> no surprise notification.");
         System.out.println("Celebration demo: reset credits 2 -> 5 -> notification reports 3 added credits.");
+    }
+
+    private static void testResetCreditExpiryReminders() {
+        long now = 1_000_000L;
+        RateLimitResetCredit soon = new RateLimitResetCredit("soon", "both", "available",
+                now - 1, now + TimeUnit.HOURS.toMillis(48), "", "");
+        RateLimitResetCredit later = new RateLimitResetCredit("later", "both", "available",
+                now - 1, now + TimeUnit.DAYS.toMillis(7), "", "");
+        RateLimitResetCredit redeemed = new RateLimitResetCredit("used", "both", "redeemed",
+                now - 1, now + TimeUnit.HOURS.toMillis(2), "", "");
+        RateLimitResetCredit expired = new RateLimitResetCredit("expired", "both", "available",
+                now - 1, now - 1, "", "");
+        long ninetyMinutes = TimeUnit.MINUTES.toMillis(90);
+        List<ResetCreditExpiryReminder> reminders = ResetCreditExpiryReminder.plan(
+                Arrays.asList(soon, later, redeemed, expired),
+                Arrays.asList(TimeUnit.HOURS.toMillis(1), TimeUnit.HOURS.toMillis(24),
+                        ninetyMinutes, ninetyMinutes, 1L,
+                        ResetCreditExpiryReminder.MAX_LEAD_TIME_MS + 1L),
+                now);
+        check(reminders.size() == 6,
+                "every available credit gets each valid unique expiry reminder");
+        check(reminders.get(0).creditId.equals("soon")
+                        && reminders.get(0).leadTimeMillis == TimeUnit.HOURS.toMillis(24),
+                "expiry reminders are sorted by trigger time");
+        check(reminders.stream().anyMatch(reminder ->
+                        reminder.creditId.equals("later")
+                                && reminder.leadTimeMillis == ninetyMinutes),
+                "arbitrary whole-minute reminder time is accepted");
+        check(reminders.stream().noneMatch(reminder ->
+                        reminder.creditId.equals("used")
+                                || reminder.creditId.equals("expired")),
+                "redeemed and expired credits are excluded");
+        check(reminders.stream().map(ResetCreditExpiryReminder::token).distinct().count()
+                        == reminders.size(),
+                "reminder identities are unique across credits and lead times");
+        System.out.println("Reset-credit expiry demo: multiple custom lead times planned for "
+                + "every available credit.");
     }
 
     private static UsageSnapshot snapshot(int fiveHourUsed, int weeklyUsed,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

[reset_expiry_notification_walkthrough_demo.mp4](https://cursor.com/agents/bc-661ac1c8-d292-43e8-8250-96bb23d317d3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freset_expiry_notification_walkthrough_demo.mp4)

Configures a custom six-hour reminder and shows Android delivering the expiry notification.

[reset_expiry_action_confirmation_demo.mp4](https://cursor.com/agents/bc-661ac1c8-d292-43e8-8250-96bb23d317d3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freset_expiry_action_confirmation_demo.mp4)

Uses the notification action to open the in-app irreversible redemption confirmation.

[Reset redemption confirmation](https://cursor.com/agents/bc-661ac1c8-d292-43e8-8250-96bb23d317d3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freset_expiry_final_confirmation.png)

## Summary
- add multiple custom lead times for reset-credit expiry reminders in Settings
- schedule and revalidate per-credit alarms across refreshes, reboot, and sign-out
- add a notification action that opens the existing in-app redemption confirmation and dismisses after success
- synchronize reminder deduplication and support locale-aware custom time entry
- cover reminder planning and source integration in the core self-tests

## Testing
- installed Android 11 x86_64 in a CPU-only headless emulator and installed the debug APK
- seeded an available credit expiring in six hours, configured a six-hour reminder, observed alarm delivery, and opened confirmation through USE RESET
- removed the temporary debug-only seed before final validation
- `./run-tests.sh` passed
- `./build.sh` produced and verified the signed release APK
- `./lint.sh` completed successfully

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-661ac1c8-d292-43e8-8250-96bb23d317d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-661ac1c8-d292-43e8-8250-96bb23d317d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

