### PR TITLE
Add secure GitHub app updates and upgrade recovery

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,20 @@ android {
         targetSdk = 36
         versionCode = 11
         versionName = "2.1.0"
+        providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
+            versionCode = it
+        }
+        providers.gradleProperty("demoVersionName").orNull?.let {
+            versionName = it
+        }
+        val updateApiUrl = providers.gradleProperty("demoUpdateUrl").orNull
+            ?: "https://api.github.com/repos/thatjoshguy67/Codex-Meter/releases?per_page=30"
+        buildConfigField("String", "UPDATE_API_URL",
+            "\"${updateApiUrl.replace("\\", "\\\\").replace("\"", "\\\"")}\"")
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     signingConfigs {

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application
+        android:usesCleartextTraffic="true"
+        tools:replace="android:usesCleartextTraffic" />
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <application
         android:theme="@style/AppTheme"
         android:label="@string/app_name"
@@ -45,6 +46,12 @@
             android:launchMode="singleTop"/>
         <activity
             android:name="dev.bennett.codexmeter.SettingsActivity"
+            android:exported="false"/>
+        <activity
+            android:name="dev.bennett.codexmeter.UpdateActivity"
+            android:exported="false"/>
+        <activity
+            android:name="dev.bennett.codexmeter.ReleaseHistoryActivity"
             android:exported="false"/>
         <activity
             android:name="dev.bennett.codexmeter.AboutActivity"
@@ -84,6 +91,76 @@
                 android:resource="@xml/widget_supported_cell_size_info"/>
         </receiver>
         <receiver
+            android:label="@string/lock_widget_square_name"
+            android:name="dev.bennett.codexmeter.SamsungLockSquareWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/samsung_lock_square_info"/>
+            <meta-data
+                android:name="samsung.appwidget.monotone.info"
+                android:resource="@xml/samsung_lock_square_oneui_info"/>
+        </receiver>
+        <receiver
+            android:label="@string/lock_widget_wide_name"
+            android:name="dev.bennett.codexmeter.SamsungLockWideWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/samsung_lock_wide_info"/>
+            <meta-data
+                android:name="samsung.appwidget.monotone.info"
+                android:resource="@xml/samsung_lock_wide_oneui_info"/>
+        </receiver>
+        <receiver
+            android:label="@string/lock_widget_rings_square_name"
+            android:name="dev.bennett.codexmeter.SamsungLockRingsSquareWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/samsung_lock_rings_square_info"/>
+            <meta-data
+                android:name="samsung.appwidget.monotone.info"
+                android:resource="@xml/samsung_lock_rings_square_oneui_info"/>
+        </receiver>
+        <receiver
+            android:label="@string/lock_widget_rings_wide_name"
+            android:name="dev.bennett.codexmeter.SamsungLockRingsWideWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/samsung_lock_rings_wide_info"/>
+            <meta-data
+                android:name="samsung.appwidget.monotone.info"
+                android:resource="@xml/samsung_lock_rings_wide_oneui_info"/>
+        </receiver>
+        <receiver
+            android:label="@string/lock_widget_dials_square_name"
+            android:name="dev.bennett.codexmeter.SamsungLockDialsSquareWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/samsung_lock_dials_square_info"/>
+            <meta-data
+                android:name="samsung.appwidget.monotone.info"
+                android:resource="@xml/samsung_lock_dials_square_oneui_info"/>
+        </receiver>
+        <receiver
             android:label="@string/lock_widget_dials_wide_name"
             android:name="dev.bennett.codexmeter.SamsungLockDialsWideWidget"
             android:exported="true">
@@ -96,6 +173,34 @@
             <meta-data
                 android:name="samsung.appwidget.monotone.info"
                 android:resource="@xml/samsung_lock_dials_wide_oneui_info"/>
+        </receiver>
+        <receiver
+            android:label="@string/lock_widget_bars_square_name"
+            android:name="dev.bennett.codexmeter.SamsungLockBarsSquareWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/samsung_lock_bars_square_info"/>
+            <meta-data
+                android:name="samsung.appwidget.monotone.info"
+                android:resource="@xml/samsung_lock_bars_square_oneui_info"/>
+        </receiver>
+        <receiver
+            android:label="@string/lock_widget_bars_wide_name"
+            android:name="dev.bennett.codexmeter.SamsungLockBarsWideWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/samsung_lock_bars_wide_info"/>
+            <meta-data
+                android:name="samsung.appwidget.monotone.info"
+                android:resource="@xml/samsung_lock_bars_wide_oneui_info"/>
         </receiver>
         <receiver
             android:label="@string/lock_widget_five_hour_name"
@@ -139,6 +244,9 @@
             android:name="dev.bennett.codexmeter.ResetAlertReceiver"
             android:exported="false"/>
         <receiver
+            android:name="dev.bennett.codexmeter.UpdateInstallReceiver"
+            android:exported="false"/>
+        <receiver
             android:name="dev.bennett.codexmeter.BootReceiver"
             android:exported="false"
             android:directBootAware="false">
@@ -152,6 +260,10 @@
             android:value="SEP10"/>
         <service
             android:name="dev.bennett.codexmeter.UsageRefreshJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"/>
+        <service
+            android:name="dev.bennett.codexmeter.ReleaseUpdateJobService"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false"/>
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
             android:exported="false"/>
         <activity
             android:name="dev.bennett.codexmeter.UpdateActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="false"/>
         <activity
             android:name="dev.bennett.codexmeter.ReleaseHistoryActivity"
@@ -264,6 +265,10 @@
             android:exported="false"/>
         <service
             android:name="dev.bennett.codexmeter.ReleaseUpdateJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"/>
+        <service
+            android:name="dev.bennett.codexmeter.WidgetRepairJobService"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false"/>
         <service

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -6,6 +6,8 @@ import android.os.Build;
 public final class AppConstants {
     public static final String ACTION_OAUTH_READY = "dev.bennett.codexmeter.action.OAUTH_READY";
     public static final String ACTION_OAUTH_RESULT = "dev.bennett.codexmeter.action.OAUTH_RESULT";
+    public static final String ACTION_INSTALL_STATUS = "dev.bennett.codexmeter.action.INSTALL_STATUS";
+    public static final String ACTION_RELEASES_UPDATED = "dev.bennett.codexmeter.action.RELEASES_UPDATED";
     public static final String ACTION_REFRESH_WIDGET = "dev.bennett.codexmeter.action.REFRESH_WIDGET";
     public static final String ACTION_RESET_ALERT = "dev.bennett.codexmeter.action.RESET_ALERT";
     public static final String ACTION_RESET_CREDITS_UPDATED = "dev.bennett.codexmeter.action.RESET_CREDITS_UPDATED";

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -39,4 +39,8 @@ public final class AppConstants {
     public static String userAgent() {
         return "codex-meter-android/2.1.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
+
+    public static String updaterUserAgent() {
+        return "codex-meter-android/" + VERSION_NAME + " updater";
+    }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
@@ -11,8 +11,13 @@ public final class BootReceiver extends BroadcastReceiver {
         String action = intent == null ? null : intent.getAction();
         if ("android.intent.action.BOOT_COMPLETED".equals(action) || "android.intent.action.MY_PACKAGE_REPLACED".equals(action)) {
             RefreshScheduler.schedulePeriodic(context);
+            ReleaseUpdateScheduler.ensureScheduled(context);
             ResetAlertScheduler.scheduleFromSnapshot(context, AppPreferences.loadSnapshot(context));
-            WidgetRenderer.updateAll(context);
+            if ("android.intent.action.MY_PACKAGE_REPLACED".equals(action)) {
+                WidgetUpgradeRepair.afterPackageReplaced(context);
+            } else {
+                WidgetUpgradeRepair.runIfNeeded(context);
+            }
         }
     }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/CodexUsageWidget.java
+++ b/app/src/main/java/dev/bennett/codexmeter/CodexUsageWidget.java
@@ -42,4 +42,26 @@ public final class CodexUsageWidget extends AppWidgetProvider {
             }
         }
     }
+
+    @Override
+    public void onRestored(Context context, int[] oldWidgetIds, int[] newWidgetIds) {
+        if (oldWidgetIds != null && newWidgetIds != null) {
+            int count = Math.min(oldWidgetIds.length, newWidgetIds.length);
+            for (int index = 0; index < count; index++) {
+                int oldId = oldWidgetIds[index];
+                int newId = newWidgetIds[index];
+                AppPreferences.saveWidgetOptions(context, newId,
+                        AppPreferences.loadWidgetOptions(context, oldId));
+                AppPreferences.saveWidgetTapAction(context, newId,
+                        AppPreferences.getWidgetTapAction(context, oldId));
+                AppPreferences.deleteWidgetOptions(context, oldId);
+            }
+        }
+        if (newWidgetIds != null) {
+            AppWidgetManager manager = AppWidgetManager.getInstance(context);
+            for (int appWidgetId : newWidgetIds) {
+                WidgetRenderer.update(context, manager, appWidgetId);
+            }
+        }
+    }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/GitHubRelease.java
+++ b/app/src/main/java/dev/bennett/codexmeter/GitHubRelease.java
@@ -1,0 +1,38 @@
+package dev.bennett.codexmeter;
+
+/** Validated metadata for one installable GitHub release. */
+public final class GitHubRelease {
+    public final String version;
+    public final String tag;
+    public final String name;
+    public final String notes;
+    public final String publishedAt;
+    public final String pageUrl;
+    public final String apkName;
+    public final String apkUrl;
+    public final long apkSize;
+    public final String checksumUrl;
+    public final boolean prerelease;
+
+    GitHubRelease(String version, String tag, String name, String notes, String publishedAt,
+            String pageUrl, String apkName, String apkUrl, long apkSize, String checksumUrl,
+            boolean prerelease) {
+        this.version = version;
+        this.tag = tag;
+        this.name = name;
+        this.notes = notes;
+        this.publishedAt = publishedAt;
+        this.pageUrl = pageUrl;
+        this.apkName = apkName;
+        this.apkUrl = apkUrl;
+        this.apkSize = apkSize;
+        this.checksumUrl = checksumUrl;
+        this.prerelease = prerelease;
+    }
+
+    public boolean isNewerThan(String currentVersion) {
+        ReleaseVersion release = ReleaseVersion.parse(version);
+        ReleaseVersion current = ReleaseVersion.parse(currentVersion);
+        return release != null && current != null && release.compareTo(current) > 0;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java
+++ b/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java
@@ -18,6 +18,11 @@ public final class GitHubReleaseParser {
     }
 
     public static List<GitHubRelease> parse(String json) throws Exception {
+        return parse(json, false);
+    }
+
+    static List<GitHubRelease> parse(String json, boolean allowLocalDebugServer)
+            throws Exception {
         JSONArray releases = new JSONArray(json == null ? "[]" : json);
         ArrayList<GitHubRelease> parsed = new ArrayList<>();
         Set<String> versions = new HashSet<>();
@@ -55,8 +60,9 @@ public final class GitHubReleaseParser {
             String apkUrl = apk.optString("browser_download_url", "");
             String checksumUrl = checksum.optString("browser_download_url", "");
             String pageUrl = release.optString("html_url", "");
-            if (!isGitHubHttps(apkUrl) || !isGitHubHttps(checksumUrl)
-                    || !isGitHubHttps(pageUrl)) {
+            if (!isTrustedReleaseUrl(apkUrl, allowLocalDebugServer)
+                    || !isTrustedReleaseUrl(checksumUrl, allowLocalDebugServer)
+                    || !isTrustedReleaseUrl(pageUrl, allowLocalDebugServer)) {
                 continue;
             }
             long apkSize = apk.optLong("size", -1L);
@@ -111,13 +117,21 @@ public final class GitHubReleaseParser {
     }
 
     static boolean isGitHubHttps(String value) {
+        return isTrustedReleaseUrl(value, false);
+    }
+
+    private static boolean isTrustedReleaseUrl(String value, boolean allowLocalDebugServer) {
         try {
             URI uri = URI.create(value);
             String host = uri.getHost();
-            return "https".equalsIgnoreCase(uri.getScheme())
+            boolean github = "https".equalsIgnoreCase(uri.getScheme())
                     && host != null
                     && ("github.com".equalsIgnoreCase(host)
                     || host.toLowerCase(java.util.Locale.US).endsWith(".github.com"));
+            return github || (allowLocalDebugServer
+                    && "http".equalsIgnoreCase(uri.getScheme())
+                    && "10.0.2.2".equals(host)
+                    && uri.getPort() == 8765);
         } catch (RuntimeException exception) {
             return false;
         }

--- a/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java
+++ b/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java
@@ -1,0 +1,130 @@
+package dev.bennett.codexmeter;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/** Parses only release entries that match the repository's signed APK release contract. */
+public final class GitHubReleaseParser {
+    private static final int MAX_NOTES = 6000;
+
+    private GitHubReleaseParser() {
+    }
+
+    public static List<GitHubRelease> parse(String json) throws Exception {
+        JSONArray releases = new JSONArray(json == null ? "[]" : json);
+        ArrayList<GitHubRelease> parsed = new ArrayList<>();
+        Set<String> versions = new HashSet<>();
+        for (int index = 0; index < releases.length(); index++) {
+            JSONObject release = releases.optJSONObject(index);
+            if (release == null || release.optBoolean("draft", false)) {
+                continue;
+            }
+            String tag = clean(release.optString("tag_name", ""), 100);
+            ReleaseVersion version = ReleaseVersion.parse(tag);
+            if (version == null || versions.contains(version.normalized())) {
+                continue;
+            }
+            String expectedApk = "CodexMeter-" + version.normalized() + ".apk";
+            JSONObject apk = null;
+            JSONObject checksum = null;
+            JSONArray assets = release.optJSONArray("assets");
+            if (assets != null) {
+                for (int assetIndex = 0; assetIndex < assets.length(); assetIndex++) {
+                    JSONObject asset = assets.optJSONObject(assetIndex);
+                    if (asset == null) {
+                        continue;
+                    }
+                    String assetName = asset.optString("name", "");
+                    if (expectedApk.equals(assetName)) {
+                        apk = asset;
+                    } else if ("SHA256SUMS.txt".equals(assetName)) {
+                        checksum = asset;
+                    }
+                }
+            }
+            if (apk == null || checksum == null) {
+                continue;
+            }
+            String apkUrl = apk.optString("browser_download_url", "");
+            String checksumUrl = checksum.optString("browser_download_url", "");
+            String pageUrl = release.optString("html_url", "");
+            if (!isGitHubHttps(apkUrl) || !isGitHubHttps(checksumUrl)
+                    || !isGitHubHttps(pageUrl)) {
+                continue;
+            }
+            long apkSize = apk.optLong("size", -1L);
+            if (apkSize <= 0L) {
+                continue;
+            }
+            String releaseName = clean(release.optString("name", ""), 160);
+            if (releaseName.isEmpty()) {
+                releaseName = "Codex Meter " + version.normalized();
+            }
+            String notes = clean(release.optString("body", ""), MAX_NOTES);
+            boolean prerelease = release.optBoolean("prerelease", false)
+                    || version.isPrerelease();
+            versions.add(version.normalized());
+            parsed.add(new GitHubRelease(version.normalized(), tag, releaseName, notes,
+                    clean(release.optString("published_at", ""), 80), pageUrl, expectedApk,
+                    apkUrl, apkSize, checksumUrl, prerelease));
+        }
+        parsed.sort(new Comparator<GitHubRelease>() {
+            @Override
+            public int compare(GitHubRelease left, GitHubRelease right) {
+                return -ReleaseVersion.compare(left.version, right.version);
+            }
+        });
+        return Collections.unmodifiableList(parsed);
+    }
+
+    public static GitHubRelease latestStable(List<GitHubRelease> releases) {
+        if (releases == null) {
+            return null;
+        }
+        for (GitHubRelease release : releases) {
+            if (release != null && !release.prerelease) {
+                return release;
+            }
+        }
+        return null;
+    }
+
+    public static GitHubRelease findVersion(List<GitHubRelease> releases, String version) {
+        ReleaseVersion wanted = ReleaseVersion.parse(version);
+        if (wanted == null || releases == null) {
+            return null;
+        }
+        for (GitHubRelease release : releases) {
+            ReleaseVersion candidate = ReleaseVersion.parse(release.version);
+            if (candidate != null && candidate.compareTo(wanted) == 0) {
+                return release;
+            }
+        }
+        return null;
+    }
+
+    static boolean isGitHubHttps(String value) {
+        try {
+            URI uri = URI.create(value);
+            String host = uri.getHost();
+            return "https".equalsIgnoreCase(uri.getScheme())
+                    && host != null
+                    && ("github.com".equalsIgnoreCase(host)
+                    || host.toLowerCase(java.util.Locale.US).endsWith(".github.com"));
+        } catch (RuntimeException exception) {
+            return false;
+        }
+    }
+
+    private static String clean(String value, int maxLength) {
+        String cleaned = value == null ? "" : value.trim();
+        return cleaned.length() <= maxLength ? cleaned : cleaned.substring(0, maxLength);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
@@ -1,6 +1,7 @@
 package dev.bennett.codexmeter;
 
 import android.content.Intent;
+import android.appwidget.AppWidgetManager;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
@@ -30,7 +31,7 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
         setResult(0);
-        this.appWidgetId = getIntent().getIntExtra("appWidgetId", 0);
+        this.appWidgetId = getIntent().getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, 0);
         if (this.appWidgetId == 0) {
             Toast.makeText(this, "No lock-screen widget was selected.", 1).show();
             finish();
@@ -125,7 +126,8 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
     public void save() {
         AppPreferences.saveLockWidgetOptions(this, this.appWidgetId, currentOptions());
         SamsungLockWidgetSupport.updateById(this, this.appWidgetId);
-        setResult(-1, new Intent().putExtra("appWidgetId", this.appWidgetId));
+        setResult(-1, new Intent().putExtra(
+                AppWidgetManager.EXTRA_APPWIDGET_ID, this.appWidgetId));
         Toast.makeText(this, "Lock-screen widget updated.", 0).show();
         finish();
     }

--- a/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -65,6 +65,10 @@ public final class MainActivity extends AppCompatActivity {
             }
             if (AppConstants.ACTION_USAGE_UPDATED.equals(action) || AppConstants.ACTION_RESET_CREDITS_UPDATED.equals(action)) {
                 MainActivity.this.rebuild();
+                return;
+            }
+            if (AppConstants.ACTION_RELEASES_UPDATED.equals(action)) {
+                MainActivity.this.rebuild();
             }
         }
     };
@@ -87,8 +91,10 @@ public final class MainActivity extends AppCompatActivity {
         this.swipeRefresh.setProgressBackgroundColorSchemeColor(Ui.cardColor(this, this.dark));
         this.swipeRefresh.setOnRefreshListener(this::refreshFromPull);
         handleLaunchIntent(getIntent());
+        WidgetUpgradeRepair.runIfNeeded(this);
         rebuild();
         RefreshScheduler.schedulePeriodic(this);
+        ReleaseUpdateScheduler.ensureScheduled(this);
     }
 
     @Override
@@ -141,6 +147,7 @@ public final class MainActivity extends AppCompatActivity {
         intentFilter.addAction(AppConstants.ACTION_OAUTH_RESULT);
         intentFilter.addAction(AppConstants.ACTION_USAGE_UPDATED);
         intentFilter.addAction(AppConstants.ACTION_RESET_CREDITS_UPDATED);
+        intentFilter.addAction(AppConstants.ACTION_RELEASES_UPDATED);
         try {
             if (Build.VERSION.SDK_INT >= 33) {
                 registerReceiver(this.authReceiver, intentFilter, "dev.bennett.codexmeter.permission.INTERNAL", null, 4);
@@ -239,6 +246,11 @@ public final class MainActivity extends AppCompatActivity {
     public void rebuild() {
         if (this.content != null) {
             this.content.removeAllViews();
+            GitHubRelease update = UpdatePreferences.availableUpdate(this);
+            if (update != null) {
+                this.content.addView(buildUpdateCard(update));
+                Ui.addSpacer(this.content, 20);
+            }
             this.content.addView(buildUsageDashboard());
             Ui.addSpacer(this.content, 20);
             if (!SecureTokenStore.isSignedIn(this)) {
@@ -250,6 +262,26 @@ public final class MainActivity extends AppCompatActivity {
             }
             this.content.addView(buildResetCreditsCard());
         }
+    }
+
+    private LinearLayout buildUpdateCard(GitHubRelease release) {
+        LinearLayout card = Ui.card(this, this.dark);
+        TextView title = Ui.text(this, "Codex Meter " + release.version + " is ready", 18,
+                Ui.mainText(this.dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        TextView summary = Ui.text(this,
+                "A signed GitHub release is available. The APK will be checksum-verified before "
+                        + "Android asks you to approve installation.",
+                13, Ui.secondaryText(this.dark));
+        LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
+        summaryParams.setMargins(0, Ui.dp(this, 7), 0, Ui.dp(this, 14));
+        card.addView(summary, summaryParams);
+        Button update = Ui.nativePrimaryButton(this, "Review update");
+        update.setOnClickListener(view -> startActivity(new Intent(this, UpdateActivity.class)
+                .putExtra(UpdateActivity.EXTRA_VERSION, release.version)));
+        card.addView(update, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
+        return card;
     }
 
     private void addHeader() {

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
@@ -69,7 +69,8 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
     private void render(List<GitHubRelease> releases, boolean failed) {
         content.removeAllViews();
         LinearLayout notice = Ui.card(this, dark);
-        TextView current = Ui.text(this, "Installed version " + AppConstants.VERSION_NAME, 18,
+        TextView current = Ui.text(this, "Installed version "
+                + UpdatePreferences.installedVersion(this), 18,
                 Ui.mainText(dark));
         current.setTypeface(Ui.mediumTypeface(this));
         notice.addView(current);
@@ -118,7 +119,8 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
     }
 
     private void addRelease(GitHubRelease release) {
-        int comparison = ReleaseVersion.compare(release.version, AppConstants.VERSION_NAME);
+        int comparison = ReleaseVersion.compare(release.version,
+                UpdatePreferences.installedVersion(this));
         LinearLayout card = Ui.card(this, dark);
         String suffix = release.prerelease ? " · Prerelease"
                 : comparison > 0 ? " · Update"

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
@@ -6,6 +6,7 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -22,6 +23,12 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
         dark = Ui.isDark(this);
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                finish();
+            }
+        });
         content = Ui.installPage(this, "Release history", true).content;
         List<GitHubRelease> cached = UpdatePreferences.releases(this);
         if (cached.isEmpty()) {

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
@@ -1,0 +1,146 @@
+package dev.bennett.codexmeter;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import androidx.appcompat.app.AppCompatActivity;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/** Advanced release picker with explicit downgrade constraints. */
+public final class ReleaseHistoryActivity extends AppCompatActivity {
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private LinearLayout content;
+    private boolean dark;
+
+    @Override
+    protected void onCreate(Bundle bundle) {
+        Ui.applySelectedTheme(this);
+        super.onCreate(bundle);
+        dark = Ui.isDark(this);
+        content = Ui.installPage(this, "Release history", true).content;
+        List<GitHubRelease> cached = UpdatePreferences.releases(this);
+        if (cached.isEmpty()) {
+            showLoading();
+        } else {
+            render(cached, false);
+        }
+        refresh();
+    }
+
+    @Override
+    protected void onDestroy() {
+        executor.shutdownNow();
+        super.onDestroy();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+
+    private void showLoading() {
+        content.removeAllViews();
+        content.addView(Ui.text(this, "Loading published GitHub releases…", 16,
+                Ui.mainText(dark)));
+        ProgressBar progress = new ProgressBar(this);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(-2, -2);
+        params.setMargins(0, Ui.dp(this, 20), 0, 0);
+        content.addView(progress, params);
+    }
+
+    private void refresh() {
+        executor.execute(() -> {
+            try {
+                List<GitHubRelease> releases = ReleaseUpdateClient.check(getApplicationContext());
+                runOnUiThread(() -> render(releases, false));
+            } catch (Exception exception) {
+                List<GitHubRelease> cached = UpdatePreferences.releases(getApplicationContext());
+                runOnUiThread(() -> render(cached, true));
+            }
+        });
+    }
+
+    private void render(List<GitHubRelease> releases, boolean failed) {
+        content.removeAllViews();
+        LinearLayout notice = Ui.card(this, dark);
+        TextView current = Ui.text(this, "Installed version " + AppConstants.VERSION_NAME, 18,
+                Ui.mainText(dark));
+        current.setTypeface(Ui.mediumTypeface(this));
+        notice.addView(current);
+        String note = "Newer and matching releases are checksum- and signature-verified in the "
+                + "app. Older versions require uninstalling first, which removes local data and "
+                + "widgets.";
+        TextView detail = Ui.text(this, note, 13, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(-1, -2);
+        detailParams.setMargins(0, Ui.dp(this, 8), 0, 0);
+        notice.addView(detail, detailParams);
+        content.addView(notice);
+
+        if (failed) {
+            TextView warning = Ui.text(this,
+                    UpdatePreferences.lastError(this), 13, Ui.danger(dark));
+            LinearLayout.LayoutParams warningParams = new LinearLayout.LayoutParams(-1, -2);
+            warningParams.setMargins(Ui.dp(this, 4), Ui.dp(this, 16), 0, 0);
+            content.addView(warning, warningParams);
+        }
+        if (releases == null || releases.isEmpty()) {
+            LinearLayout empty = Ui.card(this, dark);
+            TextView title = Ui.text(this, "No installable releases yet", 18,
+                    Ui.mainText(dark));
+            title.setTypeface(Ui.mediumTypeface(this));
+            empty.addView(title);
+            TextView detailEmpty = Ui.text(this,
+                    "GitHub currently has no published release containing both the expected APK "
+                            + "and SHA256SUMS.txt.", 14, Ui.secondaryText(dark));
+            LinearLayout.LayoutParams emptyParams = new LinearLayout.LayoutParams(-1, -2);
+            emptyParams.setMargins(0, Ui.dp(this, 8), 0, 0);
+            empty.addView(detailEmpty, emptyParams);
+            LinearLayout.LayoutParams cardParams = new LinearLayout.LayoutParams(-1, -2);
+            cardParams.setMargins(0, Ui.dp(this, 20), 0, 0);
+            content.addView(empty, cardParams);
+            return;
+        }
+
+        TextView heading = Ui.text(this, "Published versions", 15, Ui.secondaryText(dark));
+        heading.setTypeface(Ui.mediumTypeface(this));
+        LinearLayout.LayoutParams headingParams = new LinearLayout.LayoutParams(-1, -2);
+        headingParams.setMargins(Ui.dp(this, 4), Ui.dp(this, 24), 0, Ui.dp(this, 10));
+        content.addView(heading, headingParams);
+        for (GitHubRelease release : releases) {
+            addRelease(release);
+        }
+    }
+
+    private void addRelease(GitHubRelease release) {
+        int comparison = ReleaseVersion.compare(release.version, AppConstants.VERSION_NAME);
+        LinearLayout card = Ui.card(this, dark);
+        String suffix = release.prerelease ? " · Prerelease"
+                : comparison > 0 ? " · Update"
+                : comparison == 0 ? " · Installed" : " · Older";
+        TextView title = Ui.text(this, release.name, 18, Ui.mainText(dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        String published = release.publishedAt.length() >= 10
+                ? release.publishedAt.substring(0, 10) : "Unknown date";
+        TextView summary = Ui.text(this, "v" + release.version + suffix + " · " + published,
+                13, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
+        summaryParams.setMargins(0, Ui.dp(this, 6), 0, Ui.dp(this, 14));
+        card.addView(summary, summaryParams);
+        Button action = Ui.button(this,
+                comparison < 0 ? "View downgrade" : comparison == 0 ? "View reinstall"
+                        : "View update", comparison > 0, dark);
+        action.setOnClickListener(view -> startActivity(new Intent(this, UpdateActivity.class)
+                .putExtra(UpdateActivity.EXTRA_VERSION, release.version)));
+        card.addView(action, new LinearLayout.LayoutParams(-1, Ui.dp(this, 54)));
+        LinearLayout.LayoutParams cardParams = new LinearLayout.LayoutParams(-1, -2);
+        cardParams.setMargins(0, 0, 0, Ui.dp(this, 14));
+        content.addView(card, cardParams);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java
@@ -1,0 +1,71 @@
+package dev.bennett.codexmeter;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.util.Locale;
+
+/** Checksum parsing and hashing for downloaded release APKs. */
+public final class ReleaseIntegrity {
+    private ReleaseIntegrity() {
+    }
+
+    public static String expectedSha256(String checksumFile, String fileName) {
+        if (checksumFile == null || fileName == null || fileName.contains("/")
+                || fileName.contains("\\") || fileName.trim().isEmpty()) {
+            return "";
+        }
+        for (String rawLine : checksumFile.split("\\r?\\n")) {
+            String line = rawLine.trim();
+            if (line.length() < 66) {
+                continue;
+            }
+            String digest = line.substring(0, 64);
+            if (!isSha256(digest)) {
+                continue;
+            }
+            String listedName = line.substring(64).trim();
+            if (listedName.startsWith("*")) {
+                listedName = listedName.substring(1);
+            }
+            if (fileName.equals(listedName)) {
+                return digest.toLowerCase(Locale.US);
+            }
+        }
+        return "";
+    }
+
+    public static String sha256(File file) throws Exception {
+        if (file == null || !file.isFile()) {
+            throw new IllegalArgumentException("Downloaded APK is missing.");
+        }
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] buffer = new byte[32 * 1024];
+        try (InputStream input = new FileInputStream(file)) {
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        StringBuilder result = new StringBuilder(64);
+        for (byte value : digest.digest()) {
+            result.append(String.format(Locale.US, "%02x", value & 0xff));
+        }
+        return result.toString();
+    }
+
+    private static boolean isSha256(String value) {
+        if (value.length() != 64) {
+            return false;
+        }
+        for (int index = 0; index < value.length(); index++) {
+            char character = Character.toLowerCase(value.charAt(index));
+            if (!(character >= '0' && character <= '9')
+                    && !(character >= 'a' && character <= 'f')) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java
@@ -16,6 +16,7 @@ public final class ReleaseIntegrity {
                 || fileName.contains("\\") || fileName.trim().isEmpty()) {
             return "";
         }
+        String found = "";
         for (String rawLine : checksumFile.split("\\r?\\n")) {
             String line = rawLine.trim();
             if (line.length() < 66) {
@@ -30,10 +31,13 @@ public final class ReleaseIntegrity {
                 listedName = listedName.substring(1);
             }
             if (fileName.equals(listedName)) {
-                return digest.toLowerCase(Locale.US);
+                if (!found.isEmpty()) {
+                    return "";
+                }
+                found = digest.toLowerCase(Locale.US);
             }
         }
-        return "";
+        return found;
     }
 
     public static String sha256(File file) throws Exception {

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
@@ -24,39 +24,55 @@ public final class ReleaseUpdateClient {
             app = context;
         }
         synchronized (LOCK) {
-            HttpsURLConnection connection = null;
             try {
-                connection = (HttpsURLConnection) new URL(RELEASES_URL).openConnection();
-                connection.setConnectTimeout(15_000);
-                connection.setReadTimeout(25_000);
-                connection.setInstanceFollowRedirects(false);
-                connection.setRequestProperty("Accept", "application/vnd.github+json");
-                connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28");
-                connection.setRequestProperty("User-Agent", AppConstants.userAgent());
-                String etag = UpdatePreferences.etag(app);
-                if (!etag.isEmpty()) {
-                    connection.setRequestProperty("If-None-Match", etag);
-                }
-                int status = connection.getResponseCode();
-                if (status == HttpsURLConnection.HTTP_NOT_MODIFIED) {
-                    UpdatePreferences.markNotModified(app);
-                    return UpdatePreferences.releases(app);
-                }
-                if (status != HttpsURLConnection.HTTP_OK) {
-                    String detail = read(connection.getErrorStream(), 16 * 1024);
-                    throw new IllegalStateException(githubError(status, detail));
-                }
-                String json = read(connection.getInputStream(), MAX_RESPONSE_BYTES);
-                GitHubReleaseParser.parse(json);
-                UpdatePreferences.saveSuccess(app, json, connection.getHeaderField("ETag"));
-                return UpdatePreferences.releases(app);
+                return request(app, true);
             } catch (Exception exception) {
                 UpdatePreferences.saveError(app, safeMessage(exception));
                 throw exception;
-            } finally {
-                if (connection != null) {
-                    connection.disconnect();
+            }
+        }
+    }
+
+    private static List<GitHubRelease> request(Context app, boolean conditional)
+            throws Exception {
+        HttpsURLConnection connection = null;
+        try {
+            connection = (HttpsURLConnection) new URL(RELEASES_URL).openConnection();
+            connection.setConnectTimeout(15_000);
+            connection.setReadTimeout(25_000);
+            connection.setInstanceFollowRedirects(true);
+            connection.setRequestProperty("Accept", "application/vnd.github+json");
+            connection.setRequestProperty("Accept-Encoding", "identity");
+            connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28");
+            connection.setRequestProperty("User-Agent", AppConstants.updaterUserAgent());
+            String etag = conditional ? UpdatePreferences.etag(app) : "";
+            if (!etag.isEmpty()) {
+                connection.setRequestProperty("If-None-Match", etag);
+            }
+            int status = connection.getResponseCode();
+            URL finalUrl = connection.getURL();
+            if (!"https".equalsIgnoreCase(finalUrl.getProtocol())
+                    || !"api.github.com".equalsIgnoreCase(finalUrl.getHost())) {
+                throw new SecurityException("GitHub redirected the update check to an untrusted host.");
+            }
+            if (status == HttpsURLConnection.HTTP_NOT_MODIFIED) {
+                if (!UpdatePreferences.hasUsableCache(app)) {
+                    UpdatePreferences.clearEtag(app);
+                    return request(app, false);
                 }
+                UpdatePreferences.markNotModified(app);
+                return UpdatePreferences.releases(app);
+            }
+            if (status != HttpsURLConnection.HTTP_OK) {
+                String detail = read(connection.getErrorStream(), 16 * 1024);
+                throw new IllegalStateException(githubError(status, detail));
+            }
+            String json = read(connection.getInputStream(), MAX_RESPONSE_BYTES);
+            UpdatePreferences.saveSuccess(app, json, connection.getHeaderField("ETag"));
+            return UpdatePreferences.releases(app);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
             }
         }
     }

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
@@ -1,0 +1,105 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.net.ssl.HttpsURLConnection;
+
+/** Public, unauthenticated GitHub release discovery client. */
+public final class ReleaseUpdateClient {
+    static final String RELEASES_URL =
+            "https://api.github.com/repos/thatjoshguy67/Codex-Meter/releases?per_page=30";
+    private static final int MAX_RESPONSE_BYTES = 512 * 1024;
+    private static final Object LOCK = new Object();
+
+    private ReleaseUpdateClient() {
+    }
+
+    public static List<GitHubRelease> check(Context context) throws Exception {
+        Context app = context.getApplicationContext();
+        if (app == null) {
+            app = context;
+        }
+        synchronized (LOCK) {
+            HttpsURLConnection connection = null;
+            try {
+                connection = (HttpsURLConnection) new URL(RELEASES_URL).openConnection();
+                connection.setConnectTimeout(15_000);
+                connection.setReadTimeout(25_000);
+                connection.setInstanceFollowRedirects(false);
+                connection.setRequestProperty("Accept", "application/vnd.github+json");
+                connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28");
+                connection.setRequestProperty("User-Agent", AppConstants.userAgent());
+                String etag = UpdatePreferences.etag(app);
+                if (!etag.isEmpty()) {
+                    connection.setRequestProperty("If-None-Match", etag);
+                }
+                int status = connection.getResponseCode();
+                if (status == HttpsURLConnection.HTTP_NOT_MODIFIED) {
+                    UpdatePreferences.markNotModified(app);
+                    return UpdatePreferences.releases(app);
+                }
+                if (status != HttpsURLConnection.HTTP_OK) {
+                    String detail = read(connection.getErrorStream(), 16 * 1024);
+                    throw new IllegalStateException(githubError(status, detail));
+                }
+                String json = read(connection.getInputStream(), MAX_RESPONSE_BYTES);
+                GitHubReleaseParser.parse(json);
+                UpdatePreferences.saveSuccess(app, json, connection.getHeaderField("ETag"));
+                return UpdatePreferences.releases(app);
+            } catch (Exception exception) {
+                UpdatePreferences.saveError(app, safeMessage(exception));
+                throw exception;
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+        }
+    }
+
+    private static String read(InputStream input, int limit) throws Exception {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream stream = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int total = 0;
+            int read;
+            while ((read = stream.read(buffer)) != -1) {
+                total += read;
+                if (total > limit) {
+                    throw new IllegalStateException("GitHub returned too much release metadata.");
+                }
+                output.write(buffer, 0, read);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static String githubError(int status, String detail) {
+        String message = "";
+        try {
+            message = new org.json.JSONObject(detail).optString("message", "");
+        } catch (Exception ignored) {
+        }
+        if (status == 403 || status == 429) {
+            return "GitHub temporarily limited update checks. Try again later.";
+        }
+        if (!message.isEmpty()) {
+            return "GitHub update check failed (" + status + "): " + message;
+        }
+        return "GitHub update check failed with HTTP " + status + ".";
+    }
+
+    static String safeMessage(Exception exception) {
+        String message = exception == null ? "" : exception.getMessage();
+        if (message == null || message.trim().isEmpty()) {
+            message = "Could not check GitHub releases.";
+        }
+        return message.length() <= 240 ? message : message.substring(0, 240);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
@@ -3,10 +3,10 @@ package dev.bennett.codexmeter;
 import android.content.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import javax.net.ssl.HttpsURLConnection;
 
 /** Public, unauthenticated GitHub release discovery client. */
 public final class ReleaseUpdateClient {
@@ -35,9 +35,11 @@ public final class ReleaseUpdateClient {
 
     private static List<GitHubRelease> request(Context app, boolean conditional)
             throws Exception {
-        HttpsURLConnection connection = null;
+        HttpURLConnection connection = null;
         try {
-            connection = (HttpsURLConnection) new URL(RELEASES_URL).openConnection();
+            String endpoint = BuildConfig.DEBUG ? BuildConfig.UPDATE_API_URL : RELEASES_URL;
+            boolean localDebugServer = isLocalDebugServer(endpoint);
+            connection = (HttpURLConnection) new URL(endpoint).openConnection();
             connection.setConnectTimeout(15_000);
             connection.setReadTimeout(25_000);
             connection.setInstanceFollowRedirects(true);
@@ -51,11 +53,10 @@ public final class ReleaseUpdateClient {
             }
             int status = connection.getResponseCode();
             URL finalUrl = connection.getURL();
-            if (!"https".equalsIgnoreCase(finalUrl.getProtocol())
-                    || !"api.github.com".equalsIgnoreCase(finalUrl.getHost())) {
+            if (!trustedApiUrl(finalUrl, localDebugServer)) {
                 throw new SecurityException("GitHub redirected the update check to an untrusted host.");
             }
-            if (status == HttpsURLConnection.HTTP_NOT_MODIFIED) {
+            if (status == HttpURLConnection.HTTP_NOT_MODIFIED) {
                 if (!UpdatePreferences.hasUsableCache(app)) {
                     UpdatePreferences.clearEtag(app);
                     return request(app, false);
@@ -63,7 +64,7 @@ public final class ReleaseUpdateClient {
                 UpdatePreferences.markNotModified(app);
                 return UpdatePreferences.releases(app);
             }
-            if (status != HttpsURLConnection.HTTP_OK) {
+            if (status != HttpURLConnection.HTTP_OK) {
                 String detail = read(connection.getErrorStream(), 16 * 1024);
                 throw new IllegalStateException(githubError(status, detail));
             }
@@ -75,6 +76,28 @@ public final class ReleaseUpdateClient {
                 connection.disconnect();
             }
         }
+    }
+
+    private static boolean isLocalDebugServer(String value) {
+        try {
+            URL url = new URL(value);
+            return BuildConfig.DEBUG
+                    && "http".equalsIgnoreCase(url.getProtocol())
+                    && "10.0.2.2".equals(url.getHost())
+                    && url.getPort() == 8765;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+
+    private static boolean trustedApiUrl(URL url, boolean localDebugServer) {
+        if (localDebugServer) {
+            return "http".equalsIgnoreCase(url.getProtocol())
+                    && "10.0.2.2".equals(url.getHost())
+                    && url.getPort() == 8765;
+        }
+        return "https".equalsIgnoreCase(url.getProtocol())
+                && "api.github.com".equalsIgnoreCase(url.getHost());
     }
 
     private static String read(InputStream input, int limit) throws Exception {

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateJobService.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateJobService.java
@@ -1,0 +1,60 @@
+package dev.bennett.codexmeter;
+
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/** Executes persisted release checks without keeping an Activity alive. */
+public final class ReleaseUpdateJobService extends JobService {
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private volatile Future<?> active;
+    private volatile JobParameters activeParameters;
+
+    @Override
+    public boolean onStartJob(JobParameters params) {
+        if (!UpdatePreferences.automaticChecks(this)) {
+            return false;
+        }
+        activeParameters = params;
+        active = executor.submit(() -> {
+            boolean retry = false;
+            try {
+                ReleaseUpdateClient.check(getApplicationContext());
+            } catch (Exception exception) {
+                retry = true;
+            } finally {
+                if (activeParameters == params) {
+                    activeParameters = null;
+                    active = null;
+                    jobFinished(params, retry);
+                }
+            }
+        });
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters params) {
+        Future<?> task = active;
+        if (activeParameters == params) {
+            activeParameters = null;
+            active = null;
+        }
+        if (task != null) {
+            task.cancel(true);
+        }
+        return UpdatePreferences.automaticChecks(this);
+    }
+
+    @Override
+    public void onDestroy() {
+        Future<?> task = active;
+        if (task != null) {
+            task.cancel(true);
+        }
+        executor.shutdownNow();
+        super.onDestroy();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateScheduler.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateScheduler.java
@@ -1,0 +1,75 @@
+package dev.bennett.codexmeter;
+
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
+import android.content.Context;
+import java.util.concurrent.TimeUnit;
+
+/** Schedules low-frequency GitHub checks under Android's battery and network policy. */
+public final class ReleaseUpdateScheduler {
+    private static final int PERIODIC_JOB_ID = 73400;
+    private static final int INITIAL_JOB_ID = 73401;
+    private static final long PERIOD = TimeUnit.DAYS.toMillis(1);
+    private static final long FLEX = TimeUnit.HOURS.toMillis(6);
+
+    private ReleaseUpdateScheduler() {
+    }
+
+    public static boolean ensureScheduled(Context context) {
+        Context app = application(context);
+        if (!UpdatePreferences.automaticChecks(app)) {
+            cancel(app);
+            return true;
+        }
+        try {
+            JobScheduler scheduler = (JobScheduler) app.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+            if (scheduler == null) {
+                return false;
+            }
+            boolean scheduled = true;
+            if (scheduler.getPendingJob(PERIODIC_JOB_ID) == null) {
+                JobInfo periodic = base(app, PERIODIC_JOB_ID)
+                        .setPeriodic(PERIOD, FLEX)
+                        .setPersisted(true)
+                        .build();
+                scheduled = scheduler.schedule(periodic) == JobScheduler.RESULT_SUCCESS;
+            }
+            if (UpdatePreferences.lastCheckMillis(app) == 0L
+                    && scheduler.getPendingJob(INITIAL_JOB_ID) == null) {
+                JobInfo initial = base(app, INITIAL_JOB_ID)
+                        .setMinimumLatency(0L)
+                        .setOverrideDeadline(TimeUnit.MINUTES.toMillis(5))
+                        .build();
+                scheduled = scheduler.schedule(initial) == JobScheduler.RESULT_SUCCESS
+                        && scheduled;
+            }
+            return scheduled;
+        } catch (RuntimeException exception) {
+            return false;
+        }
+    }
+
+    public static void cancel(Context context) {
+        Context app = application(context);
+        try {
+            JobScheduler scheduler = (JobScheduler) app.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+            if (scheduler != null) {
+                scheduler.cancel(PERIODIC_JOB_ID);
+                scheduler.cancel(INITIAL_JOB_ID);
+            }
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    private static JobInfo.Builder base(Context context, int jobId) {
+        return new JobInfo.Builder(jobId,
+                new ComponentName(context, ReleaseUpdateJobService.class))
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY);
+    }
+
+    private static Context application(Context context) {
+        Context app = context.getApplicationContext();
+        return app == null ? context : app;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateScheduler.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateScheduler.java
@@ -28,7 +28,11 @@ public final class ReleaseUpdateScheduler {
                 return false;
             }
             boolean scheduled = true;
-            if (scheduler.getPendingJob(PERIODIC_JOB_ID) == null) {
+            JobInfo existing = scheduler.getPendingJob(PERIODIC_JOB_ID);
+            if (existing == null || existing.getIntervalMillis() != PERIOD
+                    || existing.getFlexMillis() != FLEX
+                    || existing.getNetworkType() != JobInfo.NETWORK_TYPE_ANY
+                    || !existing.isPersisted()) {
                 JobInfo periodic = base(app, PERIODIC_JOB_ID)
                         .setPeriodic(PERIOD, FLEX)
                         .setPersisted(true)

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseVersion.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseVersion.java
@@ -1,0 +1,152 @@
+package dev.bennett.codexmeter;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/** Small SemVer-compatible comparator for GitHub release tags. */
+public final class ReleaseVersion implements Comparable<ReleaseVersion> {
+    private final List<BigInteger> numbers;
+    private final String prerelease;
+    private final String normalized;
+
+    private ReleaseVersion(List<BigInteger> numbers, String prerelease, String normalized) {
+        this.numbers = numbers;
+        this.prerelease = prerelease;
+        this.normalized = normalized;
+    }
+
+    public static ReleaseVersion parse(String value) {
+        if (value == null) {
+            return null;
+        }
+        String candidate = value.trim();
+        if (candidate.startsWith("v") || candidate.startsWith("V")) {
+            candidate = candidate.substring(1);
+        }
+        int buildIndex = candidate.indexOf('+');
+        if (buildIndex >= 0) {
+            candidate = candidate.substring(0, buildIndex);
+        }
+        String prerelease = "";
+        int prereleaseIndex = candidate.indexOf('-');
+        if (prereleaseIndex >= 0) {
+            prerelease = candidate.substring(prereleaseIndex + 1);
+            candidate = candidate.substring(0, prereleaseIndex);
+        }
+        String[] parts = candidate.split("\\.", -1);
+        if (parts.length < 2 || parts.length > 4 || !validPrerelease(prerelease)) {
+            return null;
+        }
+        ArrayList<BigInteger> numbers = new ArrayList<>();
+        StringBuilder normalized = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty() || !digits(part)) {
+                return null;
+            }
+            BigInteger number = new BigInteger(part);
+            numbers.add(number);
+            if (normalized.length() > 0) {
+                normalized.append('.');
+            }
+            normalized.append(number);
+        }
+        while (numbers.size() < 3) {
+            numbers.add(BigInteger.ZERO);
+            normalized.append(".0");
+        }
+        if (!prerelease.isEmpty()) {
+            normalized.append('-').append(prerelease.toLowerCase(Locale.US));
+        }
+        return new ReleaseVersion(numbers, prerelease.toLowerCase(Locale.US), normalized.toString());
+    }
+
+    public static int compare(String left, String right) {
+        ReleaseVersion leftVersion = parse(left);
+        ReleaseVersion rightVersion = parse(right);
+        if (leftVersion == null || rightVersion == null) {
+            throw new IllegalArgumentException("Invalid release version.");
+        }
+        return leftVersion.compareTo(rightVersion);
+    }
+
+    public String normalized() {
+        return normalized;
+    }
+
+    public boolean isPrerelease() {
+        return !prerelease.isEmpty();
+    }
+
+    @Override
+    public int compareTo(ReleaseVersion other) {
+        int count = Math.max(numbers.size(), other.numbers.size());
+        for (int index = 0; index < count; index++) {
+            BigInteger left = index < numbers.size() ? numbers.get(index) : BigInteger.ZERO;
+            BigInteger right = index < other.numbers.size() ? other.numbers.get(index) : BigInteger.ZERO;
+            int compared = left.compareTo(right);
+            if (compared != 0) {
+                return compared;
+            }
+        }
+        if (prerelease.isEmpty() != other.prerelease.isEmpty()) {
+            return prerelease.isEmpty() ? 1 : -1;
+        }
+        if (prerelease.isEmpty()) {
+            return 0;
+        }
+        String[] leftParts = prerelease.split("\\.");
+        String[] rightParts = other.prerelease.split("\\.");
+        int countParts = Math.max(leftParts.length, rightParts.length);
+        for (int index = 0; index < countParts; index++) {
+            if (index >= leftParts.length) {
+                return -1;
+            }
+            if (index >= rightParts.length) {
+                return 1;
+            }
+            String left = leftParts[index];
+            String right = rightParts[index];
+            boolean leftNumeric = digits(left);
+            boolean rightNumeric = digits(right);
+            int compared;
+            if (leftNumeric && rightNumeric) {
+                compared = new BigInteger(left).compareTo(new BigInteger(right));
+            } else if (leftNumeric != rightNumeric) {
+                compared = leftNumeric ? -1 : 1;
+            } else {
+                compared = left.compareTo(right);
+            }
+            if (compared != 0) {
+                return compared;
+            }
+        }
+        return 0;
+    }
+
+    private static boolean digits(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        for (int index = 0; index < value.length(); index++) {
+            if (value.charAt(index) < '0' || value.charAt(index) > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean validPrerelease(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            if (!(character >= 'a' && character <= 'z')
+                    && !(character >= 'A' && character <= 'Z')
+                    && !(character >= '0' && character <= '9')
+                    && character != '.' && character != '-') {
+                return false;
+            }
+        }
+        return !value.startsWith(".") && !value.endsWith(".") && !value.contains("..");
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
@@ -5,6 +5,8 @@ import android.appwidget.AppWidgetManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.util.Log;
@@ -13,11 +15,19 @@ import android.view.View;
 import android.widget.RemoteViews;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /* JADX INFO: loaded from: classes.dex */
 final class SamsungLockWidgetSupport {
     private static final ProviderSpec[] PROVIDERS = {
+            new ProviderSpec(SamsungLockSquareWidget.class, Shape.SQUARE, Style.NUMBERS, Metric.BOTH),
+            new ProviderSpec(SamsungLockWideWidget.class, Shape.WIDE, Style.NUMBERS, Metric.BOTH),
+            new ProviderSpec(SamsungLockRingsSquareWidget.class, Shape.SQUARE, Style.RINGS, Metric.BOTH),
+            new ProviderSpec(SamsungLockRingsWideWidget.class, Shape.WIDE, Style.RINGS, Metric.BOTH),
+            new ProviderSpec(SamsungLockDialsSquareWidget.class, Shape.SQUARE, Style.DIALS, Metric.BOTH),
             new ProviderSpec(SamsungLockDialsWideWidget.class, Shape.WIDE, Style.DIALS, Metric.BOTH),
+            new ProviderSpec(SamsungLockBarsSquareWidget.class, Shape.SQUARE, Style.BARS, Metric.BOTH),
+            new ProviderSpec(SamsungLockBarsWideWidget.class, Shape.WIDE, Style.BARS, Metric.BOTH),
             new ProviderSpec(SamsungLockFiveHourWidget.class, Shape.SQUARE, Style.DIALS, Metric.FIVE_HOUR),
             new ProviderSpec(SamsungLockWeeklyWidget.class, Shape.SQUARE, Style.DIALS, Metric.WEEKLY)
     };
@@ -104,6 +114,21 @@ final class SamsungLockWidgetSupport {
         return placedWidgets(context).size();
     }
 
+    static void enableAllProviders(Context context) {
+        Context app = application(context);
+        PackageManager packageManager = app.getPackageManager();
+        for (ProviderSpec providerSpec : PROVIDERS) {
+            try {
+                packageManager.setComponentEnabledSetting(
+                        new ComponentName(app, providerSpec.provider),
+                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                        PackageManager.DONT_KILL_APP);
+            } catch (RuntimeException exception) {
+                Log.w("CodexMeterLock", "Unable to re-enable a lock widget provider", exception);
+            }
+        }
+    }
+
     static List<LockInstance> placedWidgets(Context context) {
         ArrayList arrayList = new ArrayList();
         if (context != null) {
@@ -180,8 +205,19 @@ final class SamsungLockWidgetSupport {
                     lockWidgetOptionsLoadLockWidgetOptions, zIsSignedIn, i3);
             return single;
         }
-        remoteViewsBuildArcViews = buildArcViews(context, appWidgetManager, i, shape, Style.DIALS, zIsSignedIn, iRemaining, iRemaining2, lockWidgetOptionsLoadLockWidgetOptions, i3);
-        i2 = R.id.lock_graphic_root;
+        if (style == Style.NUMBERS) {
+            remoteViewsBuildArcViews = buildNumberViews(context, shape, zIsSignedIn, iRemaining,
+                    iRemaining2, lockWidgetOptionsLoadLockWidgetOptions, i3);
+            i2 = shape == Shape.SQUARE ? R.id.lock_square_root : R.id.lock_wide_root;
+        } else if (style == Style.BARS) {
+            remoteViewsBuildArcViews = buildNativeBarViews(context, shape, zIsSignedIn, iRemaining,
+                    iRemaining2, lockWidgetOptionsLoadLockWidgetOptions, i3);
+            i2 = R.id.lock_graphic_root;
+        } else {
+            remoteViewsBuildArcViews = buildArcViews(context, appWidgetManager, i, shape, style,
+                    zIsSignedIn, iRemaining, iRemaining2, lockWidgetOptionsLoadLockWidgetOptions, i3);
+            i2 = R.id.lock_graphic_root;
+        }
         applyCountdowns(remoteViewsBuildArcViews, shape, style, lockWidgetOptionsLoadLockWidgetOptions, usageSnapshotLoadSnapshot == null ? null : usageSnapshotLoadSnapshot.fiveHour, usageSnapshotLoadSnapshot == null ? null : usageSnapshotLoadSnapshot.weekly);
         remoteViewsBuildArcViews.setContentDescription(i2, contentDescription(zIsSignedIn, iRemaining, iRemaining2, style, lockWidgetOptionsLoadLockWidgetOptions, i3));
         applyOpenIntent(context, remoteViewsBuildArcViews, i2, i, shape, style, lockWidgetOptionsLoadLockWidgetOptions, zIsSignedIn, i3);
@@ -391,7 +427,17 @@ final class SamsungLockWidgetSupport {
 
     private static void applyOpenIntent(Context context, RemoteViews remoteViews, int i, int i2, Shape shape, Style style, LockWidgetOptions lockWidgetOptions, boolean z, int i3) {
         boolean z2 = lockWidgetOptions.showResetAction && z && i3 > 0;
-        Intent intentAddFlags = new Intent(context, (Class<?>) (z2 ? ResetCreditActivity.class : MainActivity.class)).addFlags(335544320);
+        String target = z2 ? "reset" : "open";
+        Intent intentAddFlags = new Intent(context,
+                (Class<?>) (z2 ? ResetCreditActivity.class : MainActivity.class))
+                .setAction("dev.bennett.codexmeter.action.LOCK_WIDGET_"
+                        + target.toUpperCase(Locale.US))
+                .setData(Uri.parse("codexmeter://widget/lock/v" + AppConstants.VERSION_CODE + "/"
+                        + i2 + "/"
+                        + shape.name().toLowerCase(Locale.US) + "/"
+                        + style.name().toLowerCase(Locale.US)
+                        + "/" + target))
+                .addFlags(335544320);
         if (i2 == 0) {
             i2 = 0;
         }

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -241,7 +241,8 @@ public final class SettingsActivity extends AppCompatActivity {
             GitHubRelease available = UpdatePreferences.availableUpdate(requireContext());
             GitHubRelease latest = UpdatePreferences.latestStable(requireContext());
             long checkedAt = UpdatePreferences.lastCheckMillis(requireContext());
-            StringBuilder summary = new StringBuilder("v").append(AppConstants.VERSION_NAME);
+            StringBuilder summary = new StringBuilder("v")
+                    .append(UpdatePreferences.installedVersion(requireContext()));
             if (available != null) {
                 summary.append(" installed · v").append(available.version).append(" available");
             } else if (checkedAt == 0L) {

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -7,6 +7,7 @@ import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.text.format.DateUtils;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -42,6 +43,7 @@ public final class SettingsActivity extends AppCompatActivity {
     public static final class SettingsFragment extends PreferenceFragmentCompat {
         private Preference permissionPreference;
         private Preference testNotificationPreference;
+        private Preference updateStatusPreference;
 
         @Override
         public void onCreatePreferences(Bundle bundle, String rootKey) {
@@ -50,6 +52,7 @@ public final class SettingsActivity extends AppCompatActivity {
             bindAccount();
             bindAppearance();
             bindRefresh();
+            bindUpdates();
             bindNotifications();
             findPreference("about_codex_meter").setOnPreferenceClickListener(preference -> {
                 Ui.startSecondaryActivity(requireActivity(), AboutActivity.class);
@@ -67,6 +70,7 @@ public final class SettingsActivity extends AppCompatActivity {
         public void onResume() {
             super.onResume();
             updatePermissionSummary();
+            updateUpdateSummary();
         }
 
         private void bindAccount() {
@@ -190,6 +194,62 @@ public final class SettingsActivity extends AppCompatActivity {
                 RefreshScheduler.schedulePeriodic(requireContext());
                 return true;
             });
+        }
+
+        private void bindUpdates() {
+            SwitchPreferenceCompat automatic = findPreference("automatic_update_checks_ui");
+            automatic.setPersistent(false);
+            automatic.setChecked(UpdatePreferences.automaticChecks(requireContext()));
+            automatic.setOnPreferenceChangeListener((preference, value) -> {
+                boolean enabled = (Boolean) value;
+                UpdatePreferences.setAutomaticChecks(requireContext(), enabled);
+                if (enabled) {
+                    ReleaseUpdateScheduler.ensureScheduled(requireContext());
+                } else {
+                    ReleaseUpdateScheduler.cancel(requireContext());
+                }
+                return true;
+            });
+            updateStatusPreference = findPreference("update_status");
+            findPreference("check_for_updates").setOnPreferenceClickListener(preference -> {
+                startActivity(new Intent(requireContext(), UpdateActivity.class)
+                        .putExtra(UpdateActivity.EXTRA_FORCE_CHECK, true));
+                return true;
+            });
+            findPreference("release_history").setOnPreferenceClickListener(preference -> {
+                Ui.startSecondaryActivity(requireActivity(), ReleaseHistoryActivity.class);
+                return true;
+            });
+            updateUpdateSummary();
+        }
+
+        private void updateUpdateSummary() {
+            if (updateStatusPreference == null || getContext() == null) {
+                return;
+            }
+            GitHubRelease available = UpdatePreferences.availableUpdate(requireContext());
+            GitHubRelease latest = UpdatePreferences.latestStable(requireContext());
+            long checkedAt = UpdatePreferences.lastCheckMillis(requireContext());
+            StringBuilder summary = new StringBuilder("v").append(AppConstants.VERSION_NAME);
+            if (available != null) {
+                summary.append(" installed · v").append(available.version).append(" available");
+            } else if (checkedAt == 0L) {
+                summary.append(" · Not checked yet");
+            } else if (latest == null) {
+                summary.append(" · No published releases");
+            } else {
+                summary.append(" · Up to date");
+            }
+            if (checkedAt > 0L) {
+                summary.append(" · Checked ").append(DateUtils.getRelativeTimeSpanString(
+                        checkedAt, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS,
+                        DateUtils.FORMAT_ABBREV_RELATIVE));
+            }
+            String error = UpdatePreferences.lastError(requireContext());
+            if (!error.isEmpty()) {
+                summary.append(" · ").append(error);
+            }
+            updateStatusPreference.setSummary(summary.toString());
         }
 
         private void bindNotifications() {

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -1,0 +1,305 @@
+package dev.bennett.codexmeter;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/** User-facing secure download and PackageInstaller hand-off flow. */
+public final class UpdateActivity extends AppCompatActivity {
+    public static final String EXTRA_VERSION = "release_version";
+    public static final String EXTRA_FORCE_CHECK = "force_check";
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private LinearLayout content;
+    private GitHubRelease release;
+    private ProgressBar progress;
+    private TextView status;
+    private boolean waitingForInstallPermission;
+    private boolean operationRunning;
+    private boolean dark;
+
+    @Override
+    protected void onCreate(Bundle bundle) {
+        Ui.applySelectedTheme(this);
+        super.onCreate(bundle);
+        dark = Ui.isDark(this);
+        content = Ui.installPage(this, "App update", true).content;
+        String requested = getIntent().getStringExtra(EXTRA_VERSION);
+        release = UpdatePreferences.findVersion(this, requested);
+        boolean force = getIntent().getBooleanExtra(EXTRA_FORCE_CHECK, false);
+        if (release == null || force) {
+            checkReleases(requested);
+        } else {
+            render();
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (waitingForInstallPermission && canInstallPackages()) {
+            waitingForInstallPermission = false;
+            beginInstall();
+            return;
+        }
+        if (status != null && !operationRunning) {
+            String error = UpdatePreferences.installError(this);
+            if (!error.isEmpty()) {
+                status.setText(error);
+                status.setTextColor(Ui.danger(dark));
+            }
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        executor.shutdownNow();
+        super.onDestroy();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+
+    private void checkReleases(String requestedVersion) {
+        operationRunning = true;
+        content.removeAllViews();
+        TextView checking = Ui.text(this, "Checking published GitHub releases…", 16,
+                Ui.mainText(dark));
+        content.addView(checking);
+        ProgressBar loading = new ProgressBar(this);
+        LinearLayout.LayoutParams loadingParams =
+                new LinearLayout.LayoutParams(-2, -2);
+        loadingParams.setMargins(0, Ui.dp(this, 20), 0, 0);
+        content.addView(loading, loadingParams);
+        executor.execute(() -> {
+            try {
+                List<GitHubRelease> releases = ReleaseUpdateClient.check(getApplicationContext());
+                GitHubRelease selected = GitHubReleaseParser.findVersion(releases, requestedVersion);
+                if (selected == null) {
+                    selected = GitHubReleaseParser.latestStable(releases);
+                }
+                GitHubRelease result = selected;
+                runOnUiThread(() -> {
+                    operationRunning = false;
+                    release = result;
+                    render();
+                });
+            } catch (Exception exception) {
+                runOnUiThread(() -> {
+                    operationRunning = false;
+                    renderError(ReleaseUpdateClient.safeMessage(exception));
+                });
+            }
+        });
+    }
+
+    private void render() {
+        content.removeAllViews();
+        if (release == null) {
+            String error = UpdatePreferences.lastError(this);
+            renderError(error.isEmpty()
+                    ? "No installable GitHub releases are published yet."
+                    : error);
+            return;
+        }
+        int comparison = ReleaseVersion.compare(release.version, AppConstants.VERSION_NAME);
+        LinearLayout card = Ui.card(this, dark);
+        TextView title = Ui.text(this,
+                comparison > 0 ? "Codex Meter " + release.version + " is available"
+                        : comparison == 0 ? "Codex Meter " + release.version
+                        : "Older release " + release.version,
+                20, Ui.mainText(dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        String detail = comparison > 0
+                ? "Installed: " + AppConstants.VERSION_NAME + " · Verified GitHub upgrade"
+                : comparison == 0
+                ? "This version is currently installed. You can verify and reinstall it."
+                : "Installed: " + AppConstants.VERSION_NAME
+                        + " · Android requires uninstalling before this downgrade.";
+        TextView summary = Ui.text(this, detail, 14, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
+        summaryParams.setMargins(0, Ui.dp(this, 8), 0, Ui.dp(this, 18));
+        card.addView(summary, summaryParams);
+
+        Button action = Ui.nativePrimaryButton(this,
+                comparison < 0 ? "Download older APK" : comparison == 0 ? "Verify and reinstall"
+                        : "Download and install");
+        action.setOnClickListener(view -> {
+            if (comparison < 0) {
+                confirmOlderDownload();
+            } else {
+                requestInstall();
+            }
+        });
+        card.addView(action, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
+
+        progress = new ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal);
+        progress.setMax(1000);
+        progress.setVisibility(View.GONE);
+        LinearLayout.LayoutParams progressParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 8));
+        progressParams.setMargins(0, Ui.dp(this, 18), 0, 0);
+        card.addView(progress, progressParams);
+        status = Ui.text(this, "", 13, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(-1, -2);
+        statusParams.setMargins(0, Ui.dp(this, 10), 0, 0);
+        card.addView(status, statusParams);
+        content.addView(card);
+
+        if (!release.notes.isEmpty()) {
+            TextView heading = Ui.text(this, "What’s new", 15, Ui.secondaryText(dark));
+            heading.setTypeface(Ui.mediumTypeface(this));
+            LinearLayout.LayoutParams headingParams = new LinearLayout.LayoutParams(-1, -2);
+            headingParams.setMargins(Ui.dp(this, 4), Ui.dp(this, 24), 0, Ui.dp(this, 10));
+            content.addView(heading, headingParams);
+            LinearLayout notesCard = Ui.card(this, dark);
+            notesCard.addView(Ui.text(this, release.notes, 14, Ui.mainText(dark)));
+            content.addView(notesCard);
+        }
+
+        Button history = Ui.button(this, "Release history", false, dark);
+        history.setOnClickListener(view ->
+                Ui.startSecondaryActivity(this, ReleaseHistoryActivity.class));
+        LinearLayout.LayoutParams historyParams =
+                new LinearLayout.LayoutParams(-1, Ui.dp(this, 56));
+        historyParams.setMargins(0, Ui.dp(this, 20), 0, 0);
+        content.addView(history, historyParams);
+    }
+
+    private void renderError(String message) {
+        content.removeAllViews();
+        LinearLayout card = Ui.card(this, dark);
+        TextView title = Ui.text(this, "Update check unavailable", 20, Ui.mainText(dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        TextView detail = Ui.text(this, message, 14, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(-1, -2);
+        detailParams.setMargins(0, Ui.dp(this, 8), 0, Ui.dp(this, 18));
+        card.addView(detail, detailParams);
+        Button retry = Ui.nativePrimaryButton(this, "Check again");
+        retry.setOnClickListener(view -> checkReleases(getIntent().getStringExtra(EXTRA_VERSION)));
+        card.addView(retry, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
+        content.addView(card);
+
+        Button history = Ui.button(this, "Release history", false, dark);
+        history.setOnClickListener(view ->
+                Ui.startSecondaryActivity(this, ReleaseHistoryActivity.class));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(-1, Ui.dp(this, 56));
+        params.setMargins(0, Ui.dp(this, 20), 0, 0);
+        content.addView(history, params);
+    }
+
+    private void requestInstall() {
+        if (operationRunning) {
+            return;
+        }
+        UpdatePreferences.setInstallError(this, "");
+        if (!canInstallPackages()) {
+            waitingForInstallPermission = true;
+            new AlertDialog.Builder(this)
+                    .setTitle("Allow app installs")
+                    .setMessage("Android requires permission for Codex Meter to hand its verified "
+                            + "GitHub APK to the system installer. You still approve every update.")
+                    .setNegativeButton("Cancel", (dialog, which) ->
+                            waitingForInstallPermission = false)
+                    .setPositiveButton("Open settings", (dialog, which) -> {
+                        try {
+                            startActivity(new Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                                    Uri.parse("package:" + getPackageName())));
+                        } catch (RuntimeException exception) {
+                            waitingForInstallPermission = false;
+                            Toast.makeText(this, "Could not open install permission settings.",
+                                    Toast.LENGTH_LONG).show();
+                        }
+                    })
+                    .show();
+            return;
+        }
+        beginInstall();
+    }
+
+    private boolean canInstallPackages() {
+        return getPackageManager().canRequestPackageInstalls();
+    }
+
+    private void beginInstall() {
+        if (operationRunning || release == null) {
+            return;
+        }
+        operationRunning = true;
+        progress.setVisibility(View.VISIBLE);
+        progress.setProgress(0);
+        status.setTextColor(Ui.secondaryText(dark));
+        status.setText("Downloading checksum and APK…");
+        executor.execute(() -> {
+            try {
+                UpdateInstaller.PreparedUpdate prepared = UpdateInstaller.prepare(
+                        getApplicationContext(), release, (downloaded, total) ->
+                                runOnUiThread(() -> {
+                                    if (progress != null && total > 0L) {
+                                        progress.setProgress((int) Math.min(1000L,
+                                                downloaded * 1000L / total));
+                                    }
+                                }));
+                runOnUiThread(() -> status.setText(
+                        "Verified. Opening Android’s install confirmation…"));
+                UpdateInstaller.commit(getApplicationContext(), prepared);
+                runOnUiThread(() -> {
+                    operationRunning = false;
+                    status.setText("Waiting for Android’s install confirmation.");
+                });
+            } catch (Exception exception) {
+                UpdatePreferences.setInstallError(getApplicationContext(),
+                        safeMessage(exception));
+                runOnUiThread(() -> {
+                    operationRunning = false;
+                    progress.setVisibility(View.GONE);
+                    status.setTextColor(Ui.danger(dark));
+                    status.setText(safeMessage(exception));
+                });
+            }
+        });
+    }
+
+    private void confirmOlderDownload() {
+        new AlertDialog.Builder(this)
+                .setTitle("Downgrade requires uninstalling")
+                .setMessage("Android blocks in-place downgrades for ordinary apps. Uninstalling "
+                        + "Codex Meter removes its account, settings, cached usage, and widgets. "
+                        + "The older APK will open in your browser so it remains available after "
+                        + "uninstalling.")
+                .setNegativeButton("Cancel", null)
+                .setPositiveButton("Open APK download", (dialog, which) -> {
+                    try {
+                        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(release.apkUrl)));
+                    } catch (RuntimeException exception) {
+                        Toast.makeText(this, "No browser can open the APK download.",
+                                Toast.LENGTH_LONG).show();
+                    }
+                })
+                .show();
+    }
+
+    private static String safeMessage(Exception exception) {
+        String message = exception == null ? "" : exception.getMessage();
+        if (message == null || message.trim().isEmpty()) {
+            message = "The update could not be prepared.";
+        }
+        return message.length() <= 240 ? message : message.substring(0, 240);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -245,7 +245,7 @@ public final class UpdateActivity extends AppCompatActivity {
         progress.setVisibility(View.VISIBLE);
         progress.setProgress(0);
         status.setTextColor(Ui.secondaryText(dark));
-        status.setText("Downloading checksum and APK…");
+        status.setText(R.string.update_downloading);
         executor.execute(() -> {
             try {
                 UpdateInstaller.PreparedUpdate prepared = UpdateInstaller.prepare(
@@ -256,12 +256,11 @@ public final class UpdateActivity extends AppCompatActivity {
                                                 downloaded * 1000L / total));
                                     }
                                 }));
-                runOnUiThread(() -> status.setText(
-                        "Verified. Opening Android’s install confirmation…"));
+                runOnUiThread(() -> status.setText(R.string.update_opening_installer));
                 UpdateInstaller.commit(getApplicationContext(), prepared);
                 runOnUiThread(() -> {
                     operationRunning = false;
-                    status.setText("Waiting for Android’s install confirmation.");
+                    status.setText(R.string.update_waiting_for_installer);
                 });
             } catch (Exception exception) {
                 UpdatePreferences.setInstallError(getApplicationContext(),

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -117,7 +117,8 @@ public final class UpdateActivity extends AppCompatActivity {
                     : error);
             return;
         }
-        int comparison = ReleaseVersion.compare(release.version, AppConstants.VERSION_NAME);
+        String installedVersion = UpdatePreferences.installedVersion(this);
+        int comparison = ReleaseVersion.compare(release.version, installedVersion);
         LinearLayout card = Ui.card(this, dark);
         TextView title = Ui.text(this,
                 comparison > 0 ? "Codex Meter " + release.version + " is available"
@@ -127,10 +128,10 @@ public final class UpdateActivity extends AppCompatActivity {
         title.setTypeface(Ui.mediumTypeface(this));
         card.addView(title);
         String detail = comparison > 0
-                ? "Installed: " + AppConstants.VERSION_NAME + " · Verified GitHub upgrade"
+                ? "Installed: " + installedVersion + " · Verified GitHub upgrade"
                 : comparison == 0
                 ? "This version is currently installed. You can verify and reinstall it."
-                : "Installed: " + AppConstants.VERSION_NAME
+                : "Installed: " + installedVersion
                         + " · Android requires uninstalling before this downgrade.";
         TextView summary = Ui.text(this, detail, 14, Ui.secondaryText(dark));
         LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -94,13 +94,13 @@ public final class UpdateActivity extends AppCompatActivity {
                     selected = GitHubReleaseParser.latestStable(releases);
                 }
                 GitHubRelease result = selected;
-                runOnUiThread(() -> {
+                postUi(() -> {
                     operationRunning = false;
                     release = result;
                     render();
                 });
             } catch (Exception exception) {
-                runOnUiThread(() -> {
+                postUi(() -> {
                     operationRunning = false;
                     renderError(ReleaseUpdateClient.safeMessage(exception));
                 });
@@ -250,22 +250,22 @@ public final class UpdateActivity extends AppCompatActivity {
             try {
                 UpdateInstaller.PreparedUpdate prepared = UpdateInstaller.prepare(
                         getApplicationContext(), release, (downloaded, total) ->
-                                runOnUiThread(() -> {
+                                postUi(() -> {
                                     if (progress != null && total > 0L) {
                                         progress.setProgress((int) Math.min(1000L,
                                                 downloaded * 1000L / total));
                                     }
                                 }));
-                runOnUiThread(() -> status.setText(R.string.update_opening_installer));
+                postUi(() -> status.setText(R.string.update_opening_installer));
                 UpdateInstaller.commit(getApplicationContext(), prepared);
-                runOnUiThread(() -> {
+                postUi(() -> {
                     operationRunning = false;
                     status.setText(R.string.update_waiting_for_installer);
                 });
             } catch (Exception exception) {
                 UpdatePreferences.setInstallError(getApplicationContext(),
                         safeMessage(exception));
-                runOnUiThread(() -> {
+                postUi(() -> {
                     operationRunning = false;
                     progress.setVisibility(View.GONE);
                     status.setTextColor(Ui.danger(dark));
@@ -300,5 +300,13 @@ public final class UpdateActivity extends AppCompatActivity {
             message = "The update could not be prepared.";
         }
         return message.length() <= 240 ? message : message.substring(0, 240);
+    }
+
+    private void postUi(Runnable action) {
+        runOnUiThread(() -> {
+            if (!isFinishing() && !isDestroyed()) {
+                action.run();
+            }
+        });
     }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateInstallReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateInstallReceiver.java
@@ -1,0 +1,53 @@
+package dev.bennett.codexmeter;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageInstaller;
+import android.os.Build;
+
+/** Bridges PackageInstaller status callbacks to the user-confirmation activity. */
+public final class UpdateInstallReceiver extends BroadcastReceiver {
+    public static final String EXTRA_VERSION = "update_version";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || !AppConstants.ACTION_INSTALL_STATUS.equals(intent.getAction())) {
+            return;
+        }
+        int status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS,
+                PackageInstaller.STATUS_FAILURE);
+        if (status == PackageInstaller.STATUS_PENDING_USER_ACTION) {
+            Intent confirmation;
+            if (Build.VERSION.SDK_INT >= 33) {
+                confirmation = intent.getParcelableExtra(Intent.EXTRA_INTENT, Intent.class);
+            } else {
+                @SuppressWarnings("deprecation")
+                Intent legacy = intent.getParcelableExtra(Intent.EXTRA_INTENT);
+                confirmation = legacy;
+            }
+            if (confirmation == null) {
+                UpdatePreferences.setInstallError(context,
+                        "Android did not provide an update confirmation screen.");
+                return;
+            }
+            try {
+                confirmation.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(confirmation);
+            } catch (RuntimeException exception) {
+                UpdatePreferences.setInstallError(context,
+                        "Could not open Android's update confirmation screen.");
+            }
+            return;
+        }
+        if (status == PackageInstaller.STATUS_SUCCESS) {
+            UpdatePreferences.setInstallError(context, "");
+            return;
+        }
+        String message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE);
+        if (message == null || message.trim().isEmpty()) {
+            message = "Android rejected the update (status " + status + ").";
+        }
+        UpdatePreferences.setInstallError(context, message);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateInstallReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateInstallReceiver.java
@@ -27,6 +27,7 @@ public final class UpdateInstallReceiver extends BroadcastReceiver {
                 confirmation = legacy;
             }
             if (confirmation == null) {
+                abandon(context, intent);
                 UpdatePreferences.setInstallError(context,
                         "Android did not provide an update confirmation screen.");
                 return;
@@ -35,6 +36,7 @@ public final class UpdateInstallReceiver extends BroadcastReceiver {
                 confirmation.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 context.startActivity(confirmation);
             } catch (RuntimeException exception) {
+                abandon(context, intent);
                 UpdatePreferences.setInstallError(context,
                         "Could not open Android's update confirmation screen.");
             }
@@ -49,5 +51,15 @@ public final class UpdateInstallReceiver extends BroadcastReceiver {
             message = "Android rejected the update (status " + status + ").";
         }
         UpdatePreferences.setInstallError(context, message);
+    }
+
+    private static void abandon(Context context, Intent intent) {
+        int sessionId = intent.getIntExtra(PackageInstaller.EXTRA_SESSION_ID, -1);
+        if (sessionId >= 0) {
+            try {
+                context.getPackageManager().getPackageInstaller().abandonSession(sessionId);
+            } catch (RuntimeException ignored) {
+            }
+        }
     }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateInstaller.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateInstaller.java
@@ -15,11 +15,11 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-import javax.net.ssl.HttpsURLConnection;
 
 /** Downloads, authenticates, and submits one release APK to Android's package installer. */
 public final class UpdateInstaller {
@@ -199,7 +199,7 @@ public final class UpdateInstaller {
     }
 
     private static String downloadText(String url, int limit) throws Exception {
-        HttpsURLConnection connection = open(url);
+        HttpURLConnection connection = open(url);
         try {
             requireOk(connection);
             try (InputStream input = connection.getInputStream();
@@ -223,7 +223,7 @@ public final class UpdateInstaller {
 
     private static void downloadFile(String url, File destination, long expected,
             ProgressListener listener) throws Exception {
-        HttpsURLConnection connection = open(url);
+        HttpURLConnection connection = open(url);
         try {
             requireOk(connection);
             long declared = connection.getContentLengthLong();
@@ -254,12 +254,12 @@ public final class UpdateInstaller {
         }
     }
 
-    private static HttpsURLConnection open(String value) throws Exception {
+    private static HttpURLConnection open(String value) throws Exception {
         URL url = new URL(value);
-        if (!"https".equalsIgnoreCase(url.getProtocol()) || !allowedHost(url.getHost())) {
+        if (!trustedDownloadUrl(url)) {
             throw new SecurityException("The release download URL is not trusted.");
         }
-        HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setConnectTimeout(20_000);
         connection.setReadTimeout(60_000);
         connection.setInstanceFollowRedirects(true);
@@ -269,13 +269,13 @@ public final class UpdateInstaller {
         return connection;
     }
 
-    private static void requireOk(HttpsURLConnection connection) throws Exception {
+    private static void requireOk(HttpURLConnection connection) throws Exception {
         int status = connection.getResponseCode();
         URL finalUrl = connection.getURL();
-        if (!"https".equalsIgnoreCase(finalUrl.getProtocol()) || !allowedHost(finalUrl.getHost())) {
+        if (!trustedDownloadUrl(finalUrl)) {
             throw new SecurityException("GitHub redirected the download to an untrusted host.");
         }
-        if (status != HttpsURLConnection.HTTP_OK) {
+        if (status != HttpURLConnection.HTTP_OK) {
             throw new IllegalStateException("GitHub download failed with HTTP " + status + ".");
         }
     }
@@ -289,6 +289,16 @@ public final class UpdateInstaller {
                 || normalized.endsWith(".github.com")
                 || "githubusercontent.com".equals(normalized)
                 || normalized.endsWith(".githubusercontent.com");
+    }
+
+    private static boolean trustedDownloadUrl(URL url) {
+        if ("https".equalsIgnoreCase(url.getProtocol()) && allowedHost(url.getHost())) {
+            return true;
+        }
+        return BuildConfig.DEBUG
+                && "http".equalsIgnoreCase(url.getProtocol())
+                && "10.0.2.2".equals(url.getHost())
+                && url.getPort() == 8765;
     }
 
     private static void copy(File source, File destination) throws Exception {

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateInstaller.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateInstaller.java
@@ -1,0 +1,330 @@
+package dev.bennett.codexmeter;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageInstaller;
+import android.content.pm.PackageManager;
+import android.content.pm.Signature;
+import android.os.Build;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import javax.net.ssl.HttpsURLConnection;
+
+/** Downloads, authenticates, and submits one release APK to Android's package installer. */
+public final class UpdateInstaller {
+    private static final long MAX_APK_BYTES = 150L * 1024L * 1024L;
+    private static final int MAX_CHECKSUM_BYTES = 64 * 1024;
+
+    public interface ProgressListener {
+        void onProgress(long downloaded, long total);
+    }
+
+    public static final class PreparedUpdate {
+        public final File apk;
+        public final String versionName;
+        public final long versionCode;
+
+        PreparedUpdate(File apk, String versionName, long versionCode) {
+            this.apk = apk;
+            this.versionName = versionName;
+            this.versionCode = versionCode;
+        }
+    }
+
+    public static final class DowngradeNotSupportedException extends Exception {
+        DowngradeNotSupportedException(String message) {
+            super(message);
+        }
+    }
+
+    private UpdateInstaller() {
+    }
+
+    public static PreparedUpdate prepare(Context context, GitHubRelease release,
+            ProgressListener listener) throws Exception {
+        if (release == null) {
+            throw new IllegalArgumentException("No GitHub release was selected.");
+        }
+        if (release.apkSize <= 0L || release.apkSize > MAX_APK_BYTES) {
+            throw new IllegalStateException("The release APK has an unsafe file size.");
+        }
+        String checksumFile = downloadText(release.checksumUrl, MAX_CHECKSUM_BYTES);
+        String expected = ReleaseIntegrity.expectedSha256(checksumFile, release.apkName);
+        if (expected.isEmpty()) {
+            throw new SecurityException("The release checksum does not list "
+                    + release.apkName + ".");
+        }
+        File directory = new File(context.getCacheDir(), "verified-updates");
+        if (!directory.exists() && !directory.mkdirs()) {
+            throw new IllegalStateException("Could not prepare update storage.");
+        }
+        File partial = new File(directory, release.apkName + ".part");
+        File apk = new File(directory, release.apkName);
+        deleteQuietly(partial);
+        deleteQuietly(apk);
+        try {
+            downloadFile(release.apkUrl, partial, release.apkSize, listener);
+            if (partial.length() != release.apkSize) {
+                throw new SecurityException("The APK size does not match the GitHub release.");
+            }
+            String actual = ReleaseIntegrity.sha256(partial);
+            if (!MessageDigestSupport.constantTimeEquals(expected, actual)) {
+                throw new SecurityException("The downloaded APK failed SHA-256 verification.");
+            }
+            if (!partial.renameTo(apk)) {
+                copy(partial, apk);
+                deleteQuietly(partial);
+            }
+            return verifyPackage(context, release, apk);
+        } catch (Exception exception) {
+            deleteQuietly(partial);
+            deleteQuietly(apk);
+            throw exception;
+        }
+    }
+
+    public static int commit(Context context, PreparedUpdate update) throws Exception {
+        if (update == null || update.apk == null || !update.apk.isFile()) {
+            throw new IllegalArgumentException("The verified update APK is missing.");
+        }
+        PackageInstaller installer = context.getPackageManager().getPackageInstaller();
+        PackageInstaller.SessionParams params =
+                new PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL);
+        params.setAppPackageName(context.getPackageName());
+        params.setSize(update.apk.length());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            params.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_REQUIRED);
+        }
+        int sessionId = installer.createSession(params);
+        PackageInstaller.Session session = null;
+        try {
+            session = installer.openSession(sessionId);
+            try (InputStream input = new FileInputStream(update.apk);
+                    OutputStream output = session.openWrite("base.apk", 0L, update.apk.length())) {
+                byte[] buffer = new byte[64 * 1024];
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, read);
+                }
+                session.fsync(output);
+            }
+            Intent result = new Intent(context, UpdateInstallReceiver.class)
+                    .setAction(AppConstants.ACTION_INSTALL_STATUS)
+                    .putExtra(UpdateInstallReceiver.EXTRA_VERSION, update.versionName);
+            PendingIntent callback = PendingIntent.getBroadcast(context, sessionId, result,
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+            IntentSender sender = callback.getIntentSender();
+            session.commit(sender);
+            return sessionId;
+        } catch (Exception exception) {
+            try {
+                installer.abandonSession(sessionId);
+            } catch (RuntimeException ignored) {
+            }
+            throw exception;
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    private static PreparedUpdate verifyPackage(Context context, GitHubRelease release, File apk)
+            throws Exception {
+        PackageManager manager = context.getPackageManager();
+        int flags = Build.VERSION.SDK_INT >= 28
+                ? PackageManager.GET_SIGNING_CERTIFICATES : PackageManager.GET_SIGNATURES;
+        PackageInfo archive = manager.getPackageArchiveInfo(apk.getAbsolutePath(), flags);
+        if (archive == null) {
+            throw new SecurityException("Android could not read the downloaded APK.");
+        }
+        if (!context.getPackageName().equals(archive.packageName)) {
+            throw new SecurityException("The APK package name is not Codex Meter.");
+        }
+        ReleaseVersion expected = ReleaseVersion.parse(release.version);
+        ReleaseVersion actual = ReleaseVersion.parse(archive.versionName);
+        if (expected == null || actual == null || expected.compareTo(actual) != 0) {
+            throw new SecurityException("The APK version does not match the selected release.");
+        }
+        PackageInfo installed = manager.getPackageInfo(context.getPackageName(), flags);
+        if (!sameSigners(signatures(installed), signatures(archive))) {
+            throw new SecurityException(
+                    "The APK signing certificate does not match this installation.");
+        }
+        long installedCode = Build.VERSION.SDK_INT >= 28
+                ? installed.getLongVersionCode() : installed.versionCode;
+        long archiveCode = Build.VERSION.SDK_INT >= 28
+                ? archive.getLongVersionCode() : archive.versionCode;
+        if (archiveCode < installedCode) {
+            throw new DowngradeNotSupportedException(
+                    "Android cannot install an older version over the current app.");
+        }
+        return new PreparedUpdate(apk, archive.versionName, archiveCode);
+    }
+
+    private static Signature[] signatures(PackageInfo info) {
+        if (Build.VERSION.SDK_INT >= 28 && info.signingInfo != null) {
+            return info.signingInfo.hasMultipleSigners()
+                    ? info.signingInfo.getApkContentsSigners()
+                    : info.signingInfo.getSigningCertificateHistory();
+        }
+        return info.signatures == null ? new Signature[0] : info.signatures;
+    }
+
+    private static boolean sameSigners(Signature[] installed, Signature[] archive) {
+        Set<String> installedValues = signatureValues(installed);
+        Set<String> archiveValues = signatureValues(archive);
+        if (installedValues.isEmpty() || archiveValues.isEmpty()) {
+            return false;
+        }
+        for (String signer : archiveValues) {
+            if (installedValues.contains(signer)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<String> signatureValues(Signature[] signatures) {
+        HashSet<String> result = new HashSet<>();
+        if (signatures != null) {
+            for (Signature signature : signatures) {
+                if (signature != null) {
+                    result.add(signature.toCharsString());
+                }
+            }
+        }
+        return result;
+    }
+
+    private static String downloadText(String url, int limit) throws Exception {
+        HttpsURLConnection connection = open(url);
+        try {
+            requireOk(connection);
+            try (InputStream input = connection.getInputStream();
+                    ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+                byte[] buffer = new byte[4096];
+                int total = 0;
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    total += read;
+                    if (total > limit) {
+                        throw new SecurityException("The checksum file is unexpectedly large.");
+                    }
+                    output.write(buffer, 0, read);
+                }
+                return output.toString(java.nio.charset.StandardCharsets.UTF_8.name());
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static void downloadFile(String url, File destination, long expected,
+            ProgressListener listener) throws Exception {
+        HttpsURLConnection connection = open(url);
+        try {
+            requireOk(connection);
+            long declared = connection.getContentLengthLong();
+            if (declared > MAX_APK_BYTES || (declared > 0L && declared != expected)) {
+                throw new SecurityException("The APK download size changed unexpectedly.");
+            }
+            try (InputStream input = connection.getInputStream();
+                    OutputStream output = new FileOutputStream(destination)) {
+                byte[] buffer = new byte[64 * 1024];
+                long total = 0L;
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    if (Thread.currentThread().isInterrupted()) {
+                        throw new InterruptedException("Update download canceled.");
+                    }
+                    total += read;
+                    if (total > expected || total > MAX_APK_BYTES) {
+                        throw new SecurityException("The APK download exceeded its expected size.");
+                    }
+                    output.write(buffer, 0, read);
+                    if (listener != null) {
+                        listener.onProgress(total, expected);
+                    }
+                }
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static HttpsURLConnection open(String value) throws Exception {
+        URL url = new URL(value);
+        if (!"https".equalsIgnoreCase(url.getProtocol()) || !allowedHost(url.getHost())) {
+            throw new SecurityException("The release download URL is not trusted.");
+        }
+        HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+        connection.setConnectTimeout(20_000);
+        connection.setReadTimeout(60_000);
+        connection.setInstanceFollowRedirects(true);
+        connection.setRequestProperty("Accept", "application/octet-stream");
+        connection.setRequestProperty("User-Agent", AppConstants.userAgent());
+        return connection;
+    }
+
+    private static void requireOk(HttpsURLConnection connection) throws Exception {
+        int status = connection.getResponseCode();
+        URL finalUrl = connection.getURL();
+        if (!"https".equalsIgnoreCase(finalUrl.getProtocol()) || !allowedHost(finalUrl.getHost())) {
+            throw new SecurityException("GitHub redirected the download to an untrusted host.");
+        }
+        if (status != HttpsURLConnection.HTTP_OK) {
+            throw new IllegalStateException("GitHub download failed with HTTP " + status + ".");
+        }
+    }
+
+    private static boolean allowedHost(String host) {
+        if (host == null) {
+            return false;
+        }
+        String normalized = host.toLowerCase(Locale.US);
+        return "github.com".equals(normalized)
+                || normalized.endsWith(".github.com")
+                || "githubusercontent.com".equals(normalized)
+                || normalized.endsWith(".githubusercontent.com");
+    }
+
+    private static void copy(File source, File destination) throws Exception {
+        try (InputStream input = new FileInputStream(source);
+                OutputStream output = new FileOutputStream(destination)) {
+            byte[] buffer = new byte[64 * 1024];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+        }
+    }
+
+    private static void deleteQuietly(File file) {
+        if (file != null && file.exists()) {
+            file.delete();
+        }
+    }
+
+    private static final class MessageDigestSupport {
+        static boolean constantTimeEquals(String left, String right) {
+            if (left == null || right == null) {
+                return false;
+            }
+            return java.security.MessageDigest.isEqual(
+                    left.toLowerCase(Locale.US).getBytes(java.nio.charset.StandardCharsets.US_ASCII),
+                    right.toLowerCase(Locale.US).getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+        }
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateInstaller.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateInstaller.java
@@ -158,7 +158,7 @@ public final class UpdateInstaller {
             throw new SecurityException("The APK version does not match the selected release.");
         }
         PackageInfo installed = manager.getPackageInfo(context.getPackageName(), flags);
-        if (!sameSigners(signatures(installed), signatures(archive))) {
+        if (!sameSigners(currentSigners(installed), currentSigners(archive))) {
             throw new SecurityException(
                     "The APK signing certificate does not match this installation.");
         }
@@ -173,11 +173,9 @@ public final class UpdateInstaller {
         return new PreparedUpdate(apk, archive.versionName, archiveCode);
     }
 
-    private static Signature[] signatures(PackageInfo info) {
+    private static Signature[] currentSigners(PackageInfo info) {
         if (Build.VERSION.SDK_INT >= 28 && info.signingInfo != null) {
-            return info.signingInfo.hasMultipleSigners()
-                    ? info.signingInfo.getApkContentsSigners()
-                    : info.signingInfo.getSigningCertificateHistory();
+            return info.signingInfo.getApkContentsSigners();
         }
         return info.signatures == null ? new Signature[0] : info.signatures;
     }
@@ -185,15 +183,7 @@ public final class UpdateInstaller {
     private static boolean sameSigners(Signature[] installed, Signature[] archive) {
         Set<String> installedValues = signatureValues(installed);
         Set<String> archiveValues = signatureValues(archive);
-        if (installedValues.isEmpty() || archiveValues.isEmpty()) {
-            return false;
-        }
-        for (String signer : archiveValues) {
-            if (installedValues.contains(signer)) {
-                return true;
-            }
-        }
-        return false;
+        return !installedValues.isEmpty() && installedValues.equals(archiveValues);
     }
 
     private static Set<String> signatureValues(Signature[] signatures) {
@@ -274,7 +264,8 @@ public final class UpdateInstaller {
         connection.setReadTimeout(60_000);
         connection.setInstanceFollowRedirects(true);
         connection.setRequestProperty("Accept", "application/octet-stream");
-        connection.setRequestProperty("User-Agent", AppConstants.userAgent());
+        connection.setRequestProperty("Accept-Encoding", "identity");
+        connection.setRequestProperty("User-Agent", AppConstants.updaterUserAgent());
         return connection;
     }
 

--- a/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
@@ -15,6 +15,9 @@ public final class UpdatePreferences {
     private static final String KEY_LAST_ERROR = "last_error";
     private static final String KEY_INSTALL_ERROR = "install_error";
     private static final int MAX_CACHE_LENGTH = 512 * 1024;
+    private static final Object CACHE_LOCK = new Object();
+    private static String cachedJson;
+    private static List<GitHubRelease> cachedReleases;
 
     private UpdatePreferences() {
     }
@@ -43,7 +46,7 @@ public final class UpdatePreferences {
         if (json == null || json.length() > MAX_CACHE_LENGTH) {
             throw new IllegalArgumentException("GitHub returned too much release metadata.");
         }
-        GitHubReleaseParser.parse(json);
+        List<GitHubRelease> parsed = GitHubReleaseParser.parse(json);
         SharedPreferences.Editor editor = prefs(context).edit()
                 .putString(KEY_RELEASES, json)
                 .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
@@ -54,6 +57,10 @@ public final class UpdatePreferences {
             editor.putString(KEY_ETAG, etag.trim());
         }
         editor.apply();
+        synchronized (CACHE_LOCK) {
+            cachedJson = json;
+            cachedReleases = parsed;
+        }
         broadcast(context);
     }
 
@@ -75,11 +82,39 @@ public final class UpdatePreferences {
 
     public static List<GitHubRelease> releases(Context context) {
         String json = prefs(context).getString(KEY_RELEASES, "[]");
+        synchronized (CACHE_LOCK) {
+            if (json.equals(cachedJson) && cachedReleases != null) {
+                return cachedReleases;
+            }
+        }
         try {
-            return GitHubReleaseParser.parse(json);
+            List<GitHubRelease> parsed = GitHubReleaseParser.parse(json);
+            synchronized (CACHE_LOCK) {
+                cachedJson = json;
+                cachedReleases = parsed;
+            }
+            return parsed;
         } catch (Exception exception) {
             return Collections.emptyList();
         }
+    }
+
+    public static boolean hasUsableCache(Context context) {
+        SharedPreferences preferences = prefs(context);
+        if (!preferences.contains(KEY_RELEASES)) {
+            return false;
+        }
+        String json = preferences.getString(KEY_RELEASES, "");
+        try {
+            GitHubReleaseParser.parse(json);
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+
+    public static void clearEtag(Context context) {
+        prefs(context).edit().remove(KEY_ETAG).apply();
     }
 
     public static GitHubRelease latestStable(Context context) {

--- a/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
@@ -1,0 +1,132 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import java.util.Collections;
+import java.util.List;
+
+/** Durable updater state, isolated from account and usage preferences. */
+public final class UpdatePreferences {
+    private static final String PREFS = "codex_meter_updates_v1";
+    private static final String KEY_AUTOMATIC = "automatic";
+    private static final String KEY_ETAG = "etag";
+    private static final String KEY_RELEASES = "releases";
+    private static final String KEY_LAST_CHECK = "last_check";
+    private static final String KEY_LAST_ERROR = "last_error";
+    private static final String KEY_INSTALL_ERROR = "install_error";
+    private static final int MAX_CACHE_LENGTH = 512 * 1024;
+
+    private UpdatePreferences() {
+    }
+
+    public static boolean automaticChecks(Context context) {
+        return prefs(context).getBoolean(KEY_AUTOMATIC, true);
+    }
+
+    public static void setAutomaticChecks(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_AUTOMATIC, enabled).apply();
+    }
+
+    public static long lastCheckMillis(Context context) {
+        return prefs(context).getLong(KEY_LAST_CHECK, 0L);
+    }
+
+    public static String etag(Context context) {
+        return prefs(context).getString(KEY_ETAG, "");
+    }
+
+    public static String lastError(Context context) {
+        return prefs(context).getString(KEY_LAST_ERROR, "");
+    }
+
+    public static void saveSuccess(Context context, String json, String etag) throws Exception {
+        if (json == null || json.length() > MAX_CACHE_LENGTH) {
+            throw new IllegalArgumentException("GitHub returned too much release metadata.");
+        }
+        GitHubReleaseParser.parse(json);
+        SharedPreferences.Editor editor = prefs(context).edit()
+                .putString(KEY_RELEASES, json)
+                .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
+                .remove(KEY_LAST_ERROR);
+        if (etag == null || etag.trim().isEmpty()) {
+            editor.remove(KEY_ETAG);
+        } else {
+            editor.putString(KEY_ETAG, etag.trim());
+        }
+        editor.commit();
+        broadcast(context);
+    }
+
+    public static void markNotModified(Context context) {
+        prefs(context).edit()
+                .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
+                .remove(KEY_LAST_ERROR)
+                .apply();
+        broadcast(context);
+    }
+
+    public static void saveError(Context context, String error) {
+        prefs(context).edit()
+                .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
+                .putString(KEY_LAST_ERROR, safe(error, "Could not check GitHub releases."))
+                .apply();
+        broadcast(context);
+    }
+
+    public static List<GitHubRelease> releases(Context context) {
+        String json = prefs(context).getString(KEY_RELEASES, "[]");
+        try {
+            return GitHubReleaseParser.parse(json);
+        } catch (Exception exception) {
+            return Collections.emptyList();
+        }
+    }
+
+    public static GitHubRelease latestStable(Context context) {
+        return GitHubReleaseParser.latestStable(releases(context));
+    }
+
+    public static GitHubRelease findVersion(Context context, String version) {
+        return GitHubReleaseParser.findVersion(releases(context), version);
+    }
+
+    public static GitHubRelease availableUpdate(Context context) {
+        GitHubRelease latest = latestStable(context);
+        return latest != null && latest.isNewerThan(AppConstants.VERSION_NAME) ? latest : null;
+    }
+
+    public static void setInstallError(Context context, String error) {
+        SharedPreferences.Editor editor = prefs(context).edit();
+        if (error == null || error.trim().isEmpty()) {
+            editor.remove(KEY_INSTALL_ERROR);
+        } else {
+            editor.putString(KEY_INSTALL_ERROR, safe(error, "Update installation failed."));
+        }
+        editor.apply();
+        broadcast(context);
+    }
+
+    public static String installError(Context context) {
+        return prefs(context).getString(KEY_INSTALL_ERROR, "");
+    }
+
+    private static SharedPreferences prefs(Context context) {
+        Context app = context.getApplicationContext();
+        return (app == null ? context : app).getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    private static void broadcast(Context context) {
+        context.sendBroadcast(new android.content.Intent(AppConstants.ACTION_RELEASES_UPDATED)
+                .setPackage(context.getPackageName())
+                .addFlags(android.content.Intent.FLAG_RECEIVER_REGISTERED_ONLY),
+                AppConstants.INTERNAL_PERMISSION);
+    }
+
+    private static String safe(String value, String fallback) {
+        String result = value == null ? "" : value.trim();
+        if (result.isEmpty()) {
+            result = fallback;
+        }
+        return result.length() <= 240 ? result : result.substring(0, 240);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
@@ -53,7 +53,7 @@ public final class UpdatePreferences {
         } else {
             editor.putString(KEY_ETAG, etag.trim());
         }
-        editor.commit();
+        editor.apply();
         broadcast(context);
     }
 

--- a/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
@@ -46,7 +46,7 @@ public final class UpdatePreferences {
         if (json == null || json.length() > MAX_CACHE_LENGTH) {
             throw new IllegalArgumentException("GitHub returned too much release metadata.");
         }
-        List<GitHubRelease> parsed = GitHubReleaseParser.parse(json);
+        List<GitHubRelease> parsed = GitHubReleaseParser.parse(json, BuildConfig.DEBUG);
         SharedPreferences.Editor editor = prefs(context).edit()
                 .putString(KEY_RELEASES, json)
                 .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
@@ -88,7 +88,7 @@ public final class UpdatePreferences {
             }
         }
         try {
-            List<GitHubRelease> parsed = GitHubReleaseParser.parse(json);
+            List<GitHubRelease> parsed = GitHubReleaseParser.parse(json, BuildConfig.DEBUG);
             synchronized (CACHE_LOCK) {
                 cachedJson = json;
                 cachedReleases = parsed;
@@ -106,7 +106,7 @@ public final class UpdatePreferences {
         }
         String json = preferences.getString(KEY_RELEASES, "");
         try {
-            GitHubReleaseParser.parse(json);
+            GitHubReleaseParser.parse(json, BuildConfig.DEBUG);
             return true;
         } catch (Exception exception) {
             return false;
@@ -127,7 +127,18 @@ public final class UpdatePreferences {
 
     public static GitHubRelease availableUpdate(Context context) {
         GitHubRelease latest = latestStable(context);
-        return latest != null && latest.isNewerThan(AppConstants.VERSION_NAME) ? latest : null;
+        return latest != null && latest.isNewerThan(installedVersion(context)) ? latest : null;
+    }
+
+    public static String installedVersion(Context context) {
+        try {
+            String version = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), 0).versionName;
+            return version == null || version.trim().isEmpty()
+                    ? AppConstants.VERSION_NAME : version;
+        } catch (Exception exception) {
+            return AppConstants.VERSION_NAME;
+        }
     }
 
     public static void setInstallError(Context context, String error) {

--- a/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -247,16 +248,21 @@ public final class WidgetRenderer {
             rootAction = PendingIntent.getBroadcast(context, 74000 + i,
                     new Intent(context, (Class<?>) WidgetRefreshReceiver.class)
                             .setAction(AppConstants.ACTION_REFRESH_WIDGET)
+                            .setData(widgetUri(i, "root-refresh"))
                             .putExtra("appWidgetId", i),
                     PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         } else if (WidgetOptions.TAP_USE_RESET.equals(tapAction)) {
             rootAction = PendingIntent.getActivity(context, 74000 + i,
                     new Intent(context, (Class<?>) ResetCreditActivity.class)
+                            .setAction("dev.bennett.codexmeter.action.WIDGET_RESET")
+                            .setData(widgetUri(i, "root-reset"))
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP),
                     PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         } else {
             rootAction = PendingIntent.getActivity(context, 74000 + i,
                     new Intent(context, (Class<?>) MainActivity.class)
+                            .setAction("dev.bennett.codexmeter.action.WIDGET_OPEN")
+                            .setData(widgetUri(i, "root-open"))
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP),
                     PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         }
@@ -265,14 +271,22 @@ public final class WidgetRenderer {
                 PendingIntent.getBroadcast(context, 75000 + i,
                         new Intent(context, (Class<?>) WidgetRefreshReceiver.class)
                                 .setAction(AppConstants.ACTION_REFRESH_WIDGET)
+                                .setData(widgetUri(i, "refresh"))
                                 .putExtra("appWidgetId", i),
                         PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
         remoteViews.setOnClickPendingIntent(R.id.reset_credit_button,
                 PendingIntent.getActivity(context, 76000 + i,
                         new Intent(context, (Class<?>) ResetCreditActivity.class)
+                                .setAction("dev.bennett.codexmeter.action.WIDGET_RESET")
+                                .setData(widgetUri(i, "reset"))
                                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
                                         | Intent.FLAG_ACTIVITY_CLEAR_TOP),
                         PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
+    }
+
+    private static Uri widgetUri(int appWidgetId, String action) {
+        return Uri.parse("codexmeter://widget/home/v" + AppConstants.VERSION_CODE + "/"
+                + appWidgetId + "/" + action);
     }
 
     private static void renderBars(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState, Bundle bundle) {

--- a/app/src/main/java/dev/bennett/codexmeter/WidgetRepairJobService.java
+++ b/app/src/main/java/dev/bennett/codexmeter/WidgetRepairJobService.java
@@ -1,0 +1,54 @@
+package dev.bennett.codexmeter;
+
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/** Performs post-upgrade widget bitmap and PendingIntent repair outside receiver/UI threads. */
+public final class WidgetRepairJobService extends JobService {
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private volatile Future<?> active;
+    private volatile JobParameters parameters;
+
+    @Override
+    public boolean onStartJob(JobParameters params) {
+        parameters = params;
+        active = executor.submit(() -> {
+            try {
+                WidgetUpgradeRepair.perform(getApplicationContext());
+            } finally {
+                if (parameters == params) {
+                    parameters = null;
+                    active = null;
+                    jobFinished(params, false);
+                }
+            }
+        });
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters params) {
+        Future<?> task = active;
+        if (parameters == params) {
+            parameters = null;
+            active = null;
+        }
+        if (task != null) {
+            task.cancel(true);
+        }
+        return true;
+    }
+
+    @Override
+    public void onDestroy() {
+        Future<?> task = active;
+        if (task != null) {
+            task.cancel(true);
+        }
+        executor.shutdownNow();
+        super.onDestroy();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/WidgetUpgradeRepair.java
+++ b/app/src/main/java/dev/bennett/codexmeter/WidgetUpgradeRepair.java
@@ -1,5 +1,7 @@
 package dev.bennett.codexmeter;
 
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageInfo;
@@ -9,7 +11,9 @@ import java.io.File;
 
 /** Rebinds widget components and RemoteViews after APK replacement or restore. */
 public final class WidgetUpgradeRepair {
+    private static final int JOB_ID = 73500;
     private static final String PREFS = "codex_meter_migrations_v1";
+    private static final String KEY_CLEAN_AFTER_REPLACE = "clean_after_replace";
     private static final String KEY_REPAIRED_VERSION = "widget_repaired_version";
 
     private WidgetUpgradeRepair() {
@@ -18,17 +22,52 @@ public final class WidgetUpgradeRepair {
     public static void runIfNeeded(Context context) {
         Context app = application(context);
         long version = versionCode(app);
-        long repaired = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-                .getLong(KEY_REPAIRED_VERSION, -1L);
-        if (version <= 0L || repaired != version) {
-            repair(app, version);
+        android.content.SharedPreferences preferences =
+                app.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        long repaired = preferences.getLong(KEY_REPAIRED_VERSION, -1L);
+        if (preferences.getBoolean(KEY_CLEAN_AFTER_REPLACE, false)
+                || version <= 0L || repaired != version) {
+            schedule(app);
         }
     }
 
     public static void afterPackageReplaced(Context context) {
         Context app = application(context);
-        repair(app, versionCode(app));
-        clearVerifiedDownloads(app);
+        app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .edit().putBoolean(KEY_CLEAN_AFTER_REPLACE, true).apply();
+        schedule(app);
+    }
+
+    static void perform(Context context) {
+        Context app = application(context);
+        android.content.SharedPreferences preferences =
+                app.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        boolean clean = preferences.getBoolean(KEY_CLEAN_AFTER_REPLACE, false);
+        long version = versionCode(app);
+        long repaired = preferences.getLong(KEY_REPAIRED_VERSION, -1L);
+        if (clean || version <= 0L || repaired != version) {
+            repair(app, version);
+        }
+        if (clean) {
+            clearVerifiedDownloads(app);
+            preferences.edit().remove(KEY_CLEAN_AFTER_REPLACE).apply();
+        }
+    }
+
+    private static void schedule(Context context) {
+        try {
+            JobScheduler scheduler = (JobScheduler) context.getSystemService(
+                    Context.JOB_SCHEDULER_SERVICE);
+            if (scheduler != null) {
+                JobInfo job = new JobInfo.Builder(JOB_ID,
+                        new ComponentName(context, WidgetRepairJobService.class))
+                        .setMinimumLatency(0L)
+                        .setOverrideDeadline(60_000L)
+                        .build();
+                scheduler.schedule(job);
+            }
+        } catch (RuntimeException ignored) {
+        }
     }
 
     private static void repair(Context context, long version) {

--- a/app/src/main/java/dev/bennett/codexmeter/WidgetUpgradeRepair.java
+++ b/app/src/main/java/dev/bennett/codexmeter/WidgetUpgradeRepair.java
@@ -43,7 +43,7 @@ public final class WidgetUpgradeRepair {
         WidgetRenderer.updateAll(context);
         if (version > 0L) {
             context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-                    .edit().putLong(KEY_REPAIRED_VERSION, version).commit();
+                    .edit().putLong(KEY_REPAIRED_VERSION, version).apply();
         }
     }
 

--- a/app/src/main/java/dev/bennett/codexmeter/WidgetUpgradeRepair.java
+++ b/app/src/main/java/dev/bennett/codexmeter/WidgetUpgradeRepair.java
@@ -1,0 +1,77 @@
+package dev.bennett.codexmeter;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import java.io.File;
+
+/** Rebinds widget components and RemoteViews after APK replacement or restore. */
+public final class WidgetUpgradeRepair {
+    private static final String PREFS = "codex_meter_migrations_v1";
+    private static final String KEY_REPAIRED_VERSION = "widget_repaired_version";
+
+    private WidgetUpgradeRepair() {
+    }
+
+    public static void runIfNeeded(Context context) {
+        Context app = application(context);
+        long version = versionCode(app);
+        long repaired = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .getLong(KEY_REPAIRED_VERSION, -1L);
+        if (version <= 0L || repaired != version) {
+            repair(app, version);
+        }
+    }
+
+    public static void afterPackageReplaced(Context context) {
+        Context app = application(context);
+        repair(app, versionCode(app));
+        clearVerifiedDownloads(app);
+    }
+
+    private static void repair(Context context, long version) {
+        try {
+            context.getPackageManager().setComponentEnabledSetting(
+                    new ComponentName(context, CodexUsageWidget.class),
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                    PackageManager.DONT_KILL_APP);
+        } catch (RuntimeException ignored) {
+        }
+        SamsungLockWidgetSupport.enableAllProviders(context);
+        WidgetRenderer.updateAll(context);
+        if (version > 0L) {
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                    .edit().putLong(KEY_REPAIRED_VERSION, version).commit();
+        }
+    }
+
+    private static long versionCode(Context context) {
+        try {
+            PackageInfo info = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), 0);
+            return Build.VERSION.SDK_INT >= 28 ? info.getLongVersionCode() : info.versionCode;
+        } catch (Exception exception) {
+            return 0L;
+        }
+    }
+
+    private static void clearVerifiedDownloads(Context context) {
+        File directory = new File(context.getCacheDir(), "verified-updates");
+        File[] files = directory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file != null) {
+                    file.delete();
+                }
+            }
+        }
+        directory.delete();
+    }
+
+    private static Context application(Context context) {
+        Context app = context.getApplicationContext();
+        return app == null ? context : app;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,9 @@
     <string name="oauth_channel_name">ChatGPT sign-in</string>
     <string name="refresh">Refresh</string>
     <string name="refreshing">Refreshing…</string>
+    <string name="update_downloading">Downloading checksum and APK…</string>
+    <string name="update_opening_installer">Verified. Opening Android’s install confirmation…</string>
+    <string name="update_waiting_for_installer">Waiting for Android’s install confirmation.</string>
     <string name="weekly">Weekly</string>
     <string name="widget_description">Adaptive bars, rings, and dials for five-hour and weekly Codex usage</string>
     <string name="widget_name">Codex usage</string>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -32,6 +32,28 @@
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="App updates">
+        <SwitchPreferenceCompat
+            android:key="automatic_update_checks_ui"
+            android:title="Check automatically"
+            android:summary="Check signed GitHub releases about once a day" />
+        <Preference
+            android:key="update_status"
+            android:title="Installed version"
+            app:iconSpaceReserved="false"
+            app:selectable="false" />
+        <Preference
+            android:key="check_for_updates"
+            android:title="Check for updates"
+            android:summary="Check GitHub now"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="release_history"
+            android:title="Advanced release history"
+            android:summary="View available versions and downgrade requirements"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="Notifications">
         <SwitchPreferenceCompat
             android:key="notifications_allowed_ui"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -35,6 +35,10 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingFlow.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthBrowserPage.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseVersion.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubRelease.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
@@ -54,6 +58,10 @@ grep -q 'android:scheme="codexmeter"' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'OnboardingActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ResetAlertReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'MY_PACKAGE_REPLACED' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'android.permission.REQUEST_INSTALL_PACKAGES' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'ReleaseUpdateJobService' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'UpdateInstallReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'ReleaseHistoryActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 
 grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"
 grep -q 'app:expandable="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"
@@ -82,6 +90,18 @@ for style in rings dials bars; do
   done
 done
 
+for provider in \
+  SamsungLockSquareWidget SamsungLockWideWidget \
+  SamsungLockRingsSquareWidget SamsungLockRingsWideWidget \
+  SamsungLockDialsSquareWidget SamsungLockDialsWideWidget \
+  SamsungLockBarsSquareWidget SamsungLockBarsWideWidget \
+  SamsungLockFiveHourWidget SamsungLockWeeklyWidget; do
+  grep -q "android:name=\"dev.bennett.codexmeter.$provider\"" \
+    "$ROOT/app/src/main/AndroidManifest.xml"
+  grep -q "$provider.class" \
+    "$ROOT/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java"
+done
+
 grep -R -q 'android:widgetCategory="0x2000"' "$ROOT/app/src/main/res/xml/samsung_lock_"*_info.xml
 grep -R -q 'app:widgetStyle="monotone"' "$ROOT/app/src/main/res/xml/samsung_lock_"*_info.xml
 ! grep -R -q 'com.samsung.systemui.permission.FACE_WIDGET' "$ROOT/app/src/main"
@@ -96,4 +116,4 @@ grep -q 'Ui.nativePrimaryButton' \
 grep -q 'OAuthBrowserPage.render' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthService.java"
 
-echo "Parser, OAuth, onboarding, reset-credit, countdown, alert, and Samsung widget source checks passed."
+echo "Parser, updater, OAuth, onboarding, reset-credit, alert, and widget source checks passed."

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -60,6 +60,7 @@ grep -q 'ResetAlertReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'MY_PACKAGE_REPLACED' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'android.permission.REQUEST_INSTALL_PACKAGES' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ReleaseUpdateJobService' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'WidgetRepairJobService' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'UpdateInstallReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ReleaseHistoryActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -318,6 +318,9 @@ public final class ParserSelfTest {
                 "unsafe checksum filename rejected");
         check(ReleaseIntegrity.expectedSha256("not-a-checksum", "app.apk").isEmpty(),
                 "malformed checksum rejected");
+        check(ReleaseIntegrity.expectedSha256(checksums + digest
+                        + "  CodexMeter-2.2.0.apk\n", "CodexMeter-2.2.0.apk").isEmpty(),
+                "duplicate APK checksum rejected");
     }
 
     private static String jwt(String payload) {

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -18,7 +18,10 @@ public final class ParserSelfTest {
         testWidgetOptions();
         testOnboardingFlow();
         testOAuthBrowserPage();
-        System.out.println("All parser, OAuth, onboarding, and widget-option self-tests passed.");
+        testReleaseVersions();
+        testGitHubReleases();
+        testReleaseChecksums();
+        System.out.println("All parser, updater, OAuth, onboarding, and widget-option self-tests passed.");
     }
 
     private static void testStandardUsage() throws Exception {
@@ -240,6 +243,81 @@ public final class ParserSelfTest {
 
         String escapedScript = OAuthBrowserPage.javascriptString("x'\\\n\u2028");
         check("x\\'\\\\\\n\\u2028".equals(escapedScript), "browser script escaping");
+    }
+
+    private static void testReleaseVersions() {
+        check(ReleaseVersion.compare("v2.2.0", "2.1.9") > 0,
+                "release tag version ordering");
+        check(ReleaseVersion.compare("2.1", "2.1.0") == 0,
+                "short release version normalization");
+        check(ReleaseVersion.compare("3.0.0", "3.0.0-rc.2") > 0,
+                "stable release follows prerelease");
+        check(ReleaseVersion.compare("3.0.0-rc.10", "3.0.0-rc.2") > 0,
+                "numeric prerelease ordering");
+        check(ReleaseVersion.parse("release-2.0") == null,
+                "invalid release tag rejected");
+    }
+
+    private static void testGitHubReleases() throws Exception {
+        String json = "["
+                + releaseJson("v2.2.0", false, false, true, true)
+                + "," + releaseJson("v3.0.0-beta.1", false, true, true, true)
+                + "," + releaseJson("v9.0.0", true, false, true, true)
+                + "," + releaseJson("v2.3.0", false, false, true, false)
+                + "]";
+        java.util.List<GitHubRelease> releases = GitHubReleaseParser.parse(json);
+        check(releases.size() == 2, "only complete published releases accepted");
+        check("3.0.0-beta.1".equals(releases.get(0).version),
+                "release history sorted semantically");
+        GitHubRelease latest = GitHubReleaseParser.latestStable(releases);
+        check(latest != null && "2.2.0".equals(latest.version),
+                "automatic updates exclude prereleases");
+        check(latest.isNewerThan("2.1.0"), "new release detected");
+        check(GitHubReleaseParser.findVersion(releases, "v2.2") == latest,
+                "release version lookup normalized");
+        check(GitHubReleaseParser.parse("[]").isEmpty(), "empty release history accepted");
+        check(!GitHubReleaseParser.isGitHubHttps("http://github.com/file.apk"),
+                "non-HTTPS release URL rejected");
+        check(!GitHubReleaseParser.isGitHubHttps("https://github.com.evil.example/file.apk"),
+                "lookalike GitHub host rejected");
+    }
+
+    private static String releaseJson(String tag, boolean draft, boolean prerelease,
+            boolean apk, boolean checksum) {
+        String normalized = tag.startsWith("v") ? tag.substring(1) : tag;
+        StringBuilder assets = new StringBuilder();
+        if (apk) {
+            assets.append("{\"name\":\"CodexMeter-").append(normalized)
+                    .append(".apk\",\"size\":123,\"browser_download_url\":")
+                    .append("\"https://github.com/thatjoshguy67/Codex-Meter/releases/download/")
+                    .append(tag).append("/CodexMeter-").append(normalized).append(".apk\"}");
+        }
+        if (checksum) {
+            if (assets.length() > 0) assets.append(',');
+            assets.append("{\"name\":\"SHA256SUMS.txt\",\"size\":90,")
+                    .append("\"browser_download_url\":")
+                    .append("\"https://github.com/thatjoshguy67/Codex-Meter/releases/download/")
+                    .append(tag).append("/SHA256SUMS.txt\"}");
+        }
+        return "{\"tag_name\":\"" + tag + "\",\"name\":\"Codex Meter " + normalized
+                + "\",\"body\":\"Changes\",\"published_at\":\"2026-07-13T00:00:00Z\","
+                + "\"html_url\":\"https://github.com/thatjoshguy67/Codex-Meter/releases/tag/"
+                + tag + "\",\"draft\":" + draft + ",\"prerelease\":" + prerelease
+                + ",\"assets\":[" + assets + "]}";
+    }
+
+    private static void testReleaseChecksums() {
+        String digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        String checksums = digest + "  CodexMeter-2.2.0.apk\n"
+                + "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                + "  other.apk\n";
+        check(digest.equals(ReleaseIntegrity.expectedSha256(
+                        checksums, "CodexMeter-2.2.0.apk")),
+                "matching APK checksum selected");
+        check(ReleaseIntegrity.expectedSha256(checksums, "../other.apk").isEmpty(),
+                "unsafe checksum filename rejected");
+        check(ReleaseIntegrity.expectedSha256("not-a-checksum", "app.apk").isEmpty(),
+                "malformed checksum rejected");
     }
 
     private static String jwt(String payload) {

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -321,6 +321,14 @@ public final class ParserSelfTest {
                 "non-HTTPS release URL rejected");
         check(!GitHubReleaseParser.isGitHubHttps("https://github.com.evil.example/file.apk"),
                 "lookalike GitHub host rejected");
+        String localFixture = "[" + releaseJson(
+                "v2.2.0", false, false, true, true).replace(
+                "https://github.com/thatjoshguy67/Codex-Meter",
+                "http://10.0.2.2:8765") + "]";
+        check(GitHubReleaseParser.parse(localFixture).isEmpty(),
+                "local fixture rejected by production parser");
+        check(GitHubReleaseParser.parse(localFixture, true).size() == 1,
+                "local fixture accepted only in explicit debug mode");
     }
 
     private static String releaseJson(String tag, boolean draft, boolean prerelease,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add persisted daily GitHub release discovery, dashboard availability, manual checks, and advanced release history
- verify HTTPS/local-debug trust boundaries, file size, SHA-256, package identity, version code, and signer before PackageInstaller handoff
- restore historical widget providers, version PendingIntents, migrate restored options, and repair widgets asynchronously after replacement
- merge latest `main` reset-credit expiry work while preserving both receiver/scheduler paths
- add a debug-only local release fixture so real 2.1.0 → 2.2.0 emulator updates can be demonstrated without weakening release builds
- fix release-history toolbar and Android back navigation found during emulator testing

## Emulator walkthrough
[codex_meter_update_discovery_and_permission.mp4](https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcodex_meter_update_discovery_and_permission.mp4)
Widget launch, update discovery/details/history, fixed back navigation, per-app install permission, and verified download.

[Android native update confirmation](https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fandroid_native_update_confirmation.webp)

[codex_meter_android_package_replacement.mp4](https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcodex_meter_android_package_replacement.mp4)
Android native confirmation and package replacement. The trailing white cube is the recorder outro; device uptime and ADB connectivity remain uninterrupted.

[codex_meter_post_update_version_and_widget.mp4](https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcodex_meter_post_update_version_and_widget.mp4)
Settings reports v2.2.0 up to date; the original widget remains bound and opens the updated app.

[Installed version 2.2.0 verified](https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fupdated_version_2_2_verified.webp)
[Widget survived package update](https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwidget_survived_update.webp)

## Validation
- `./run-tests.sh` passes updater, expiry-reminder, OAuth, onboarding, parser, and widget regressions
- `./build.sh` builds and verifies the production release APK with APK Signature Scheme v2
- `./lint.sh` succeeds with no updater-specific findings
- API 30 software emulator remains online after the in-app update with package versionCode 12/versionName 2.2.0
- Android AppWidgetService retains widget ID 4, its Launcher host callback, and live RemoteViews after replacement
- pull request is mergeable against latest `main`

[emulator_update_validation.log](https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Femulator_update_validation.log)
[emulator_update_validation.log](https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Femulator_update_validation.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cf95a2c-8de2-4d21-96d1-0fb827edea89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

