### PR TITLE
Add Now Bar live usage monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Version 2.1 adds a resumable One UI first-run experience, a modern browser retur
 
 Samsung lock-screen widgets can display the remaining time until each usage window resets. The countdown is driven locally by Android `Chronometer` views using the reset timestamp already cached from the usage response; it does not repeatedly contact the server merely to update seconds or minutes.
 
+### Live usage monitor
+
+Settings includes an optional, user-started live usage monitor that runs only until the next available usage reset. It shows the real five-hour and weekly allowance values, marks a missing window as unavailable, and refreshes whenever the app receives new usage data. Android 16 can promote the notification as a Live Update, while compatible Samsung firmware can also surface it in the Now Bar. The monitor can be stopped at any time and is cleared when the user signs out.
+
 ### Reset alerts
 
 Users can choose silent, notification-sound, or alarm-sound alerts for the five-hour limit, weekly limit, or both. Alerts can be conditional on the most recently observed allowance being below a selected threshold. Android schedules the notification for the cached reset time and performs a normal background refresh after the alert fires.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
@@ -141,6 +142,9 @@
             android:exported="false"/>
         <receiver
             android:name="dev.bennett.codexmeter.ResetCreditExpiryReceiver"
+            android:exported="false"/>
+        <receiver
+            android:name="dev.bennett.codexmeter.NowBarActionReceiver"
             android:exported="false"/>
         <receiver
             android:name="dev.bennett.codexmeter.BootReceiver"

--- a/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -58,6 +58,7 @@ public final class AppPreferences {
 
     public static void clearSnapshot(Context context) {
         prefs(context).edit().remove(KEY_SNAPSHOT).remove(KEY_ERROR).remove(KEY_ERROR_AT).remove(KEY_RESET_CREDITS).remove(KEY_RESET_ERROR).remove(KEY_RESET_ERROR_AT).apply();
+        NowBarManager.stop(context);
         ResetNotificationManager.clearState(context);
         ResetCreditExpiryScheduler.cancelAll(context);
     }

--- a/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
@@ -14,6 +14,7 @@ public final class BootReceiver extends BroadcastReceiver {
             ResetAlertScheduler.scheduleFromSnapshot(context, AppPreferences.loadSnapshot(context));
             ResetCreditExpiryScheduler.scheduleFromSnapshot(context,
                     AppPreferences.loadResetCredits(context));
+            NowBarManager.restore(context);
             WidgetRenderer.updateAll(context);
         }
     }

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarActionReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarActionReceiver.java
@@ -1,0 +1,18 @@
+package dev.bennett.codexmeter;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/** Handles the explicit actions attached to the finite Now Bar Live Update. */
+public final class NowBarActionReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent == null ? "" : intent.getAction();
+        if (NowBarManager.ACTION_STOP.equals(action) || NowBarManager.ACTION_END.equals(action)) {
+            NowBarManager.stop(context);
+        } else if (NowBarManager.ACTION_REFRESH.equals(action)) {
+            RefreshScheduler.scheduleImmediate(context);
+        }
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -1,0 +1,346 @@
+package dev.bennett.codexmeter;
+
+import android.app.AlarmManager;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.graphics.Color;
+import android.graphics.drawable.Icon;
+import android.os.Build;
+import android.util.Log;
+import androidx.annotation.RequiresApi;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+/** Posts a finite, user-initiated Live Update that Samsung may surface in the Now Bar. */
+public final class NowBarManager {
+    static final String ACTION_END = "dev.bennett.codexmeter.action.NOW_BAR_END";
+    static final String ACTION_REFRESH = "dev.bennett.codexmeter.action.NOW_BAR_REFRESH";
+    static final String ACTION_STOP = "dev.bennett.codexmeter.action.NOW_BAR_STOP";
+
+    private static final String CHANNEL_ID = "codex_live_monitor";
+    private static final String EXTRA_REQUEST_PROMOTED_ONGOING = "android.requestPromotedOngoing";
+    private static final String SAMSUNG_ONGOING_PREFIX = "android.ongoingActivityNoti.";
+    private static final String KEY_ACTIVE = "active";
+    private static final String KEY_PREVIEW = "preview";
+    private static final String KEY_UNTIL = "until";
+    private static final int NOTIFICATION_ID = 8610;
+    private static final int REQUEST_END = 8611;
+    private static final int REQUEST_REFRESH = 8612;
+    private static final int REQUEST_STOP = 8613;
+    private static final String PREFS = "codex_meter_now_bar_v1";
+    private static final String TAG = "CodexNowBar";
+
+    private NowBarManager() {
+    }
+
+    public static synchronized boolean start(Context context) {
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
+        if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
+            return false;
+        }
+        long now = System.currentTimeMillis();
+        long until = snapshot.nextResetMillis(now);
+        if (until <= now) return false;
+        saveState(context, false, until);
+        if (post(context, snapshot, until, false)) return true;
+        stop(context);
+        return false;
+    }
+
+    public static synchronized boolean startPreview(Context context) {
+        long now = System.currentTimeMillis();
+        long until = now + TimeUnit.MINUTES.toMillis(20);
+        UsageSnapshot preview = new UsageSnapshot("plus", true, false, null,
+                new UsageWindow(18, TimeUnit.DAYS.toSeconds(7),
+                        TimeUnit.DAYS.toSeconds(4), (now + TimeUnit.DAYS.toMillis(4)) / 1000L),
+                now);
+        saveState(context, true, until);
+        if (post(context, preview, until, true)) return true;
+        stop(context);
+        return false;
+    }
+
+    public static synchronized void onUsageUpdated(Context context, UsageSnapshot snapshot) {
+        if (!hasStoredActiveState(context) || isPreview(context)) return;
+        if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
+            stop(context);
+            return;
+        }
+        long now = System.currentTimeMillis();
+        long until = activeUntil(context);
+        if (until <= now) {
+            stop(context);
+            return;
+        }
+        if (!post(context, snapshot, until, false)) stop(context);
+    }
+
+    public static synchronized void restore(Context context) {
+        if (!hasStoredActiveState(context)) return;
+        long until = activeUntil(context);
+        if (until <= System.currentTimeMillis()) {
+            stop(context);
+            return;
+        }
+        if (isPreview(context)) {
+            if (!startPreviewWithEnd(context, until)) stop(context);
+            return;
+        }
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
+        if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
+            stop(context);
+        } else {
+            if (!post(context, snapshot, until, false)) stop(context);
+        }
+    }
+
+    private static boolean startPreviewWithEnd(Context context, long until) {
+        long now = System.currentTimeMillis();
+        UsageSnapshot preview = new UsageSnapshot("plus", true, false, null,
+                new UsageWindow(18, TimeUnit.DAYS.toSeconds(7), 0L, 0L), now);
+        return post(context, preview, until, true);
+    }
+
+    public static synchronized void stop(Context context) {
+        state(context).edit().clear().apply();
+        NotificationManager manager = manager(context);
+        if (manager != null) {
+            try {
+                manager.cancel(NOTIFICATION_ID);
+            } catch (RuntimeException exception) {
+                Log.w(TAG, "Could not cancel live monitor notification", exception);
+            }
+        }
+        AlarmManager alarms = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (alarms != null) {
+            try {
+                alarms.cancel(endIntent(context));
+            } catch (RuntimeException exception) {
+                Log.w(TAG, "Could not cancel live monitor expiry", exception);
+            }
+        }
+    }
+
+    public static boolean isActive(Context context) {
+        return state(context).getBoolean(KEY_ACTIVE, false)
+                && activeUntil(context) > System.currentTimeMillis();
+    }
+
+    public static boolean isPreview(Context context) {
+        return state(context).getBoolean(KEY_PREVIEW, false);
+    }
+
+    public static long activeUntil(Context context) {
+        return state(context).getLong(KEY_UNTIL, 0L);
+    }
+
+    public static boolean canPostNotifications(Context context) {
+        NotificationManager manager = manager(context);
+        return manager != null && manager.areNotificationsEnabled()
+                && (Build.VERSION.SDK_INT < 33
+                || context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+                == PackageManager.PERMISSION_GRANTED);
+    }
+
+    public static boolean canPostPromotedNotifications(Context context) {
+        NotificationManager manager = manager(context);
+        return Build.VERSION.SDK_INT >= 36 && manager != null
+                && Api36.canPostPromotedNotifications(manager);
+    }
+
+    private static boolean post(Context context, UsageSnapshot snapshot, long until,
+            boolean preview) {
+        NotificationManager manager = manager(context);
+        if (manager == null || !canPostNotifications(context)) return false;
+        try {
+            createChannel(manager);
+        } catch (RuntimeException exception) {
+            Log.w(TAG, "Could not create live monitor notification channel", exception);
+            return false;
+        }
+
+        long now = System.currentTimeMillis();
+        UsageWindow fiveHour = snapshot == null ? null : snapshot.fiveHour;
+        UsageWindow weekly = snapshot == null ? null : snapshot.weekly;
+        UsageWindow progressWindow = fiveHour != null ? fiveHour : weekly;
+        int remaining = progressWindow == null ? 0 : progressWindow.remainingPercent();
+        int used = progressWindow == null ? 0 : progressWindow.usedPercent;
+        String fiveHourText = limitText("5-hour", fiveHour);
+        String weeklyText = limitText("Weekly", weekly);
+        String title = "Codex usage";
+        String text = fiveHourText + " · " + weeklyText;
+        String subText = preview ? "Now Bar preview" : "Until the next usage reset";
+
+        Intent open = new Intent(context, MainActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent contentIntent = PendingIntent.getActivity(context, 8614, open,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent stopIntent = PendingIntent.getBroadcast(context, REQUEST_STOP,
+                new Intent(context, NowBarActionReceiver.class).setAction(ACTION_STOP),
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent refreshIntent = PendingIntent.getBroadcast(context, REQUEST_REFRESH,
+                new Intent(context, NowBarActionReceiver.class).setAction(ACTION_REFRESH),
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        Notification.Builder builder = new Notification.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_oui_alarm)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setSubText(subText)
+                .setProgress(100, used, false)
+                .setContentIntent(contentIntent)
+                .setDeleteIntent(stopIntent)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setCategory(Notification.CATEGORY_STATUS)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
+                .setShowWhen(true)
+                .setWhen(until)
+                .setUsesChronometer(true)
+                .setChronometerCountDown(true)
+                .setTimeoutAfter(Math.max(1L, until - now))
+                .addAction(new Notification.Action.Builder(null, "Stop", stopIntent).build());
+        if (!preview) {
+            builder.addAction(new Notification.Action.Builder(null, "Refresh", refreshIntent).build());
+        }
+        builder.getExtras().putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true);
+        if (Build.VERSION.SDK_INT >= 36) {
+            Api36.applyLiveUpdateStyle(builder, used,
+                    (fiveHour == null ? "W " : "") + remaining + "%");
+        }
+        addSamsungOngoingActivityExtras(context, builder, fiveHour, weekly, used);
+        final Notification notification;
+        try {
+            notification = builder.build();
+        } catch (RuntimeException exception) {
+            Log.w(TAG, "Could not build live monitor notification", exception);
+            return false;
+        }
+        boolean promotable = Build.VERSION.SDK_INT >= 36
+                && Api36.hasPromotableCharacteristics(notification);
+        Log.i(TAG, "Posting live monitor: promotable=" + promotable
+                + " allowed=" + canPostPromotedNotifications(context)
+                + " preview=" + preview + " remaining=" + remaining);
+        try {
+            manager.notify(NOTIFICATION_ID, notification);
+        } catch (RuntimeException exception) {
+            Log.w(TAG, "Could not post live monitor notification", exception);
+            try {
+                manager.cancel(NOTIFICATION_ID);
+            } catch (RuntimeException ignored) {
+            }
+            return false;
+        }
+        try {
+            scheduleEnd(context, until);
+        } catch (RuntimeException exception) {
+            // setTimeoutAfter() remains the primary expiry path if an OEM rejects the backup alarm.
+            Log.w(TAG, "Could not schedule live monitor backup expiry", exception);
+        }
+        return true;
+    }
+
+    private static void addSamsungOngoingActivityExtras(Context context,
+            Notification.Builder builder, UsageWindow fiveHour, UsageWindow weekly, int used) {
+        Icon icon = Icon.createWithResource(context, R.drawable.ic_oui_alarm);
+        String fiveHourText = limitText("5-hour", fiveHour);
+        String weeklyText = limitText("Weekly", weekly);
+        int focusRemaining = fiveHour != null ? fiveHour.remainingPercent()
+                : weekly == null ? 0 : weekly.remainingPercent();
+
+        builder.getExtras().putInt(SAMSUNG_ONGOING_PREFIX + "style", 1);
+        builder.getExtras().putParcelable(SAMSUNG_ONGOING_PREFIX + "chipIcon", icon);
+        builder.getExtras().putInt(SAMSUNG_ONGOING_PREFIX + "chipBgColor",
+                Color.rgb(56, 122, 255));
+        builder.getExtras().putCharSequence(SAMSUNG_ONGOING_PREFIX + "chipExpandedText",
+                "Codex · " + (fiveHour == null ? "Weekly " : "5-hour ")
+                        + focusRemaining + "%");
+        builder.getExtras().putCharSequence(SAMSUNG_ONGOING_PREFIX + "primaryInfo",
+                fiveHourText + " · " + weeklyText);
+        builder.getExtras().putCharSequence(SAMSUNG_ONGOING_PREFIX + "secondaryInfo",
+                "Both usage windows");
+        builder.getExtras().putString(SAMSUNG_ONGOING_PREFIX + "description",
+                "Codex usage limits");
+        builder.getExtras().putInt(SAMSUNG_ONGOING_PREFIX + "progress", used);
+        builder.getExtras().putInt(SAMSUNG_ONGOING_PREFIX + "progressMax", 100);
+        builder.getExtras().putParcelable(SAMSUNG_ONGOING_PREFIX + "nowbarIcon", icon);
+        builder.getExtras().putString(SAMSUNG_ONGOING_PREFIX + "nowbarPrimaryInfo",
+                fiveHourText);
+        builder.getExtras().putString(SAMSUNG_ONGOING_PREFIX + "nowbarSecondaryInfo",
+                weeklyText);
+        builder.getExtras().putString(SAMSUNG_ONGOING_PREFIX + "nowbarIconType", "progress");
+    }
+
+    private static String limitText(String label, UsageWindow window) {
+        return label + ": " + (window == null ? "unavailable"
+                : window.remainingPercent() + "% left");
+    }
+
+    private static void createChannel(NotificationManager manager) {
+        NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                "Codex live monitor", NotificationManager.IMPORTANCE_LOW);
+        channel.setDescription("A user-started Codex allowance monitor that ends at the next reset");
+        channel.setSound(null, null);
+        channel.enableVibration(false);
+        channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);
+        manager.createNotificationChannel(channel);
+    }
+
+    private static void scheduleEnd(Context context, long until) {
+        AlarmManager alarms = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (alarms != null) alarms.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, until,
+                endIntent(context));
+    }
+
+    private static PendingIntent endIntent(Context context) {
+        return PendingIntent.getBroadcast(context, REQUEST_END,
+                new Intent(context, NowBarActionReceiver.class).setAction(ACTION_END),
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    }
+
+    private static NotificationManager manager(Context context) {
+        return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    private static SharedPreferences state(Context context) {
+        return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    private static void saveState(Context context, boolean preview, long until) {
+        state(context).edit().putBoolean(KEY_ACTIVE, true).putBoolean(KEY_PREVIEW, preview)
+                .putLong(KEY_UNTIL, until).apply();
+    }
+
+    private static boolean hasStoredActiveState(Context context) {
+        return state(context).getBoolean(KEY_ACTIVE, false);
+    }
+
+    /** Keeps API 36 class references out of code paths verified on older Android releases. */
+    @RequiresApi(36)
+    private static final class Api36 {
+        static void applyLiveUpdateStyle(Notification.Builder builder, int used,
+                String criticalText) {
+            Notification.ProgressStyle style = new Notification.ProgressStyle()
+                    .setProgress(used)
+                    .setStyledByProgress(true)
+                    .setProgressSegments(Collections.singletonList(
+                            new Notification.ProgressStyle.Segment(100)
+                                    .setColor(Color.rgb(56, 122, 255))));
+            builder.setStyle(style).setShortCriticalText(criticalText);
+        }
+
+        static boolean canPostPromotedNotifications(NotificationManager manager) {
+            return manager.canPostPromotedNotifications();
+        }
+
+        static boolean hasPromotableCharacteristics(Notification notification) {
+            return notification.hasPromotableCharacteristics();
+        }
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -2,6 +2,7 @@ package dev.bennett.codexmeter;
 
 import android.app.NotificationManager;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
@@ -53,6 +54,8 @@ public final class SettingsActivity extends AppCompatActivity {
         private Preference expiryTimesPreference;
         private Preference permissionPreference;
         private Preference testNotificationPreference;
+        private SwitchPreferenceCompat nowBarMonitorPreference;
+        private Preference nowBarPermissionPreference;
 
         @Override
         public void onCreatePreferences(Bundle bundle, String rootKey) {
@@ -62,6 +65,7 @@ public final class SettingsActivity extends AppCompatActivity {
             bindAppearance();
             bindRefresh();
             bindNotifications();
+            bindNowBar();
             findPreference("about_codex_meter").setOnPreferenceClickListener(preference -> {
                 Ui.startSecondaryActivity(requireActivity(), AboutActivity.class);
                 return true;
@@ -78,6 +82,7 @@ public final class SettingsActivity extends AppCompatActivity {
         public void onResume() {
             super.onResume();
             updatePermissionSummary();
+            updateNowBarSummary();
         }
 
         private void bindAccount() {
@@ -437,6 +442,103 @@ public final class SettingsActivity extends AppCompatActivity {
         private void scheduleResetCreditExpiryReminders() {
             ResetNotificationManager.onResetCreditExpirySettingsChanged(requireContext(),
                     AppPreferences.loadResetCredits(requireContext()));
+        }
+
+        private void bindNowBar() {
+            nowBarMonitorPreference = findPreference("now_bar_monitor_ui");
+            nowBarMonitorPreference.setPersistent(false);
+            nowBarMonitorPreference.setOnPreferenceChangeListener((preference, value) -> {
+                boolean enabled = (Boolean) value;
+                if (!enabled) {
+                    NowBarManager.stop(requireContext());
+                    updateNowBarSummary();
+                    return true;
+                }
+                if (!ensureNotificationPermission()) return false;
+                boolean started = NowBarManager.start(requireContext());
+                if (!started) {
+                    Toast.makeText(requireContext(),
+                            "Refresh your signed-in usage before starting the monitor.",
+                            Toast.LENGTH_LONG).show();
+                }
+                updateNowBarSummary();
+                return started;
+            });
+
+            Preference preview = findPreference("now_bar_preview");
+            preview.setVisible((requireContext().getApplicationInfo().flags
+                    & ApplicationInfo.FLAG_DEBUGGABLE) != 0);
+            preview.setOnPreferenceClickListener(preference -> {
+                if (!ensureNotificationPermission()) return true;
+                boolean started = NowBarManager.startPreview(requireContext());
+                Toast.makeText(requireContext(), started
+                        ? "Sample Live Update started for 20 minutes."
+                        : "Allow notifications first.",
+                        started ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG).show();
+                updateNowBarSummary();
+                return true;
+            });
+
+            nowBarPermissionPreference = findPreference("now_bar_permission");
+            nowBarPermissionPreference.setOnPreferenceClickListener(preference -> {
+                if (Build.VERSION.SDK_INT >= 36) {
+                    Intent promotion = new Intent(Settings.ACTION_APP_NOTIFICATION_PROMOTION_SETTINGS)
+                            .putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName());
+                    try {
+                        startActivity(promotion);
+                        return true;
+                    } catch (RuntimeException ignored) {
+                    }
+                }
+                startActivity(new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                        .putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName()));
+                return true;
+            });
+            updateNowBarSummary();
+        }
+
+        private boolean ensureNotificationPermission() {
+            if (Build.VERSION.SDK_INT >= 33
+                    && requireContext().checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+                    != PackageManager.PERMISSION_GRANTED) {
+                requestPermissions(new String[]{"android.permission.POST_NOTIFICATIONS"}, 8602);
+                Toast.makeText(requireContext(),
+                        "Allow notifications, then start the monitor again.", Toast.LENGTH_LONG).show();
+                return false;
+            }
+            if (NowBarManager.canPostNotifications(requireContext())) return true;
+            Toast.makeText(requireContext(),
+                    "Enable app notifications, then start the monitor again.",
+                    Toast.LENGTH_LONG).show();
+            return false;
+        }
+
+        private void updateNowBarSummary() {
+            if (nowBarMonitorPreference == null || getContext() == null) return;
+            boolean active = NowBarManager.isActive(requireContext());
+            nowBarMonitorPreference.setChecked(active);
+            if (active) {
+                String kind = NowBarManager.isPreview(requireContext()) ? "Sample preview" : "Live monitor";
+                nowBarMonitorPreference.setSummary(kind + " active · ends "
+                        + UsageFormat.absolute(requireContext(), NowBarManager.activeUntil(requireContext()),
+                        System.currentTimeMillis()));
+            } else {
+                nowBarMonitorPreference.setSummary(
+                        "Show remaining Codex allowance until the next available usage reset");
+            }
+            if (nowBarPermissionPreference != null) {
+                String summary;
+                if (!NowBarManager.canPostNotifications(requireContext())) {
+                    summary = "App notifications disabled · tap to enable";
+                } else if (Build.VERSION.SDK_INT < 36) {
+                    summary = "Notifications allowed · Live display depends on your device";
+                } else if (NowBarManager.canPostPromotedNotifications(requireContext())) {
+                    summary = "Live notifications allowed";
+                } else {
+                    summary = "Live notifications not allowed · tap to enable";
+                }
+                nowBarPermissionPreference.setSummary(summary);
+            }
         }
 
         private void setNotificationsEnabled(boolean enabled) {

--- a/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
@@ -49,6 +49,7 @@ public final class UsageApi {
             if (!AppPreferences.saveSnapshot(context, usageSnapshot)) {
                 throw new Exception("Usage was received, but it could not be saved on this device.");
             }
+            NowBarManager.onUsageUpdated(context, usageSnapshot);
             ResetNotificationManager.onUsageUpdated(context, previousSnapshot, usageSnapshot);
             try {
                 ResetAlertScheduler.scheduleFromSnapshot(context, usageSnapshot);

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -75,6 +75,22 @@
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="Now Bar">
+        <SwitchPreferenceCompat
+            android:key="now_bar_monitor_ui"
+            android:title="Monitor until reset"
+            android:summary="Show remaining Codex allowance until the next available usage reset" />
+        <Preference
+            android:key="now_bar_preview"
+            android:title="Start sample preview"
+            android:summary="Show a 20-minute sample activity for device testing"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="now_bar_permission"
+            android:title="Live notification access"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="Privacy">
         <Preference
             android:icon="@drawable/ic_oui_privacy"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,6 +55,8 @@ grep -q 'android.permission.SCHEDULE_EXACT_ALARM' "$ROOT/app/src/main/AndroidMan
 grep -q 'android:scheme="codexmeter"' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'OnboardingActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ResetAlertReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'android.permission.POST_PROMOTED_NOTIFICATIONS' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'NowBarActionReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'MY_PACKAGE_REPLACED' "$ROOT/app/src/main/AndroidManifest.xml"
 
 grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"
@@ -79,6 +81,18 @@ grep -q '"Use reset", useReset' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java"
 grep -q 'EXTRA_PROMPT_USE_RESET' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarActionReceiver.java"
+grep -q 'Build.VERSION.SDK_INT >= 36' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'nowbarPrimaryInfo' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'setDeleteIntent(stopIntent)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'hasStoredActiveState' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'NowBarManager.onUsageUpdated' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageApi.java"
 
 grep -R -q '<Chronometer' "$ROOT/app/src/main/res/layout/widget_lock_"*.xml
 grep -q 'setChronometerCountDown' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -15,6 +15,7 @@ public final class ParserSelfTest {
         testPrimaryLimitWinsOverAdditional();
         testMalformedWindowIgnored();
         testZeroDurationWindowIgnored();
+        testNextResetSelection();
         testCelebrationDetection();
         testResetCreditExpiryReminders();
         testJwtMerge();
@@ -88,6 +89,26 @@ public final class ParserSelfTest {
         UsageSnapshot snapshot = UsageParser.parse(json, 1L);
         check(snapshot.fiveHour == null && snapshot.weekly == null,
                 "zero-duration usage window ignored");
+    }
+
+    private static void testNextResetSelection() {
+        long now = 1_000_000L;
+        UsageWindow fiveHour = new UsageWindow(10, 18_000L, 0L, 1_100L);
+        UsageWindow weekly = new UsageWindow(20, 604_800L, 0L, 1_200L);
+        check(new UsageSnapshot("pro", true, false, fiveHour, weekly, now)
+                        .nextResetMillis(now) == 1_100_000L,
+                "earliest active reset ends the live monitor");
+        check(new UsageSnapshot("pro", true, false, null, weekly, now)
+                        .nextResetMillis(now) == 1_200_000L,
+                "weekly-only account still has a monitor end time");
+
+        UsageWindow expiredFiveHour = new UsageWindow(10, 18_000L, 0L, 900L);
+        check(new UsageSnapshot("pro", true, false, expiredFiveHour, weekly, now)
+                        .nextResetMillis(now) == 1_200_000L,
+                "expired five-hour reset falls back to weekly");
+        check(new UsageSnapshot("pro", true, false, expiredFiveHour, null, now)
+                        .nextResetMillis(now) == 0L,
+                "no future reset does not create an unbounded monitor");
     }
 
     private static void testCelebrationDetection() {


### PR DESCRIPTION
## Summary

- add an optional, user-started live usage monitor under Settings
- show real five-hour and weekly allowance values, including a clear unavailable state when either window is absent
- use Android 16 promoted ongoing notifications plus Samsung ongoing-activity fields for split collapsed text and combined expanded text
- refresh the notification with new usage snapshots and restore it after reboot or app update
- stop cleanly on reset expiry, user dismissal, explicit Stop, notification failure, or sign-out
- retain a standard notification fallback on Android versions below API 36

## Why

Codex Meter already exposes allowance data through its dashboard and widgets, but it had no finite live-notification surface for Samsung's Now Bar. Samsung reads different fields for the collapsed and expanded cards, so the implementation supplies both split window values for the collapsed card and one combined line for the expanded card.

## Edge-case audit

- weekly-only snapshots remain usable and display the missing five-hour window as unavailable
- expired five-hour windows fall back to a future weekly reset
- snapshots without a future reset cannot create an unbounded monitor
- API 36-only notification classes are isolated behind a guarded helper
- failed posts roll back persisted active state
- expired persisted state is cleared during refresh or restore
- user dismissal clears state so a later usage refresh does not recreate the update
- synchronized lifecycle methods prevent Stop and refresh from racing
- sample values are restricted to debuggable builds; release notifications use cached account usage

## Validation

- `./run-tests.sh`
- `./gradlew :app:assembleDebug :app:lintRelease --no-daemon`
- rebased and revalidated against `main` after reset-credit expiry reminders landed
- installed the side-by-side debug build on a Samsung SM-S928W
- verified `PROMOTED_ONGOING`, real five-hour and weekly fields, combined expanded text, split collapsed text, and restoration after an in-place app update
