### PR TITLE
Fix dashboard text colors in dark mode

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
@@ -84,6 +84,7 @@ public final class UsageWaveView extends View {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
         float density = getResources().getDisplayMetrics().density;
+        boolean dark = Ui.isDark(getContext());
         float edge = getWidth() * percent / 100f;
         float amplitude = 8f * density;
         fillPath.reset();
@@ -99,12 +100,12 @@ public final class UsageWaveView extends View {
         }
         fillPath.lineTo(0, getHeight());
         fillPath.close();
-        fillPaint.setColor(Ui.desaturatedAccent(getContext(), Ui.isDark(getContext())));
+        fillPaint.setColor(Ui.desaturatedAccent(getContext(), dark));
         canvas.drawPath(fillPath, fillPaint);
 
-        titlePaint.setColor(0xFF000000);
+        titlePaint.setColor(Ui.mainText(dark));
         titlePaint.setTextSize(20f * density);
-        resetPaint.setColor(0x99000000);
+        resetPaint.setColor(Ui.secondaryText(dark));
         resetPaint.setTextSize(14f * density);
         canvas.drawText(title, 12f * density, 34f * density, titlePaint);
         canvas.drawText(resetTop, 12f * density, 67f * density, resetPaint);
@@ -112,7 +113,6 @@ public final class UsageWaveView extends View {
             canvas.drawText(resetBottom, 12f * density, 87f * density, resetPaint);
         }
 
-        boolean dark = Ui.isDark(getContext());
         int foreground = Ui.mainText(dark);
         float rightCenter = getWidth() - 48f * density;
         if (icon != null) {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -127,5 +127,11 @@ grep -q 'Ui.nativePrimaryButton' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java"
 grep -q 'OAuthBrowserPage.render' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthService.java"
+grep -q 'titlePaint.setColor(Ui.mainText(dark));' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java"
+grep -q 'resetPaint.setColor(Ui.secondaryText(dark));' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java"
+! grep -q 'titlePaint.setColor(0xFF000000)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java"
 
 echo "Parser, updater, OAuth, onboarding, reset-credit, alert, and widget source checks passed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use theme-aware primary and secondary text colors for usage-card labels.
- Add regression checks preventing hardcoded black title text.

## Walkthrough
[Codex Meter dashboard with corrected dark-mode text](https://cursor.com/agents/bc-1778387a-ba76-4924-ba9c-bb5277010f11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcodex_dark_mode_fixed_retry.png)

[codex_dark_mode_text_correction.mp4](https://cursor.com/agents/bc-1778387a-ba76-4924-ba9c-bb5277010f11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcodex_dark_mode_text_correction.mp4)

The Android 16 emulator runs in system night mode; both left labels now match the readable light foreground hierarchy used on the right.

## Testing
- `./run-tests.sh`
- `./build.sh`
- `./lint.sh`
- `./gradlew :app:assembleDebug --console=plain`
- Android 16 API 36 emulator render in system night mode

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1778387a-ba76-4924-ba9c-bb5277010f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1778387a-ba76-4924-ba9c-bb5277010f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

