### PR TITLE
Prepare Codex Meter 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 2.2.0 — 2026-07-14
+
+### Added
+
+- Configurable reset-credit expiry reminders with multiple custom lead times, per-credit scheduling, reboot restoration, and automatic cancellation after sign-out or redemption (#15).
+- A reminder action that opens the existing in-app confirmation before redeeming an expiring reset credit (#15).
+- Secure in-app update discovery with daily checks, a dashboard update card, manual checks, and release history (#16).
+- Verified APK installation that checks HTTPS trust, file size, SHA-256 integrity, package identity, version code, and signing certificate before handing an update to Android (#16).
+- Upgrade recovery that preserves widget providers and options, then repairs existing widgets asynchronously after package replacement (#16).
+- An optional live usage monitor showing real five-hour and weekly allowance values in Android 16 Live Updates and compatible Samsung Now Bar surfaces, with a standard notification fallback on earlier Android versions (#18).
+
+### Changed
+
+- The live usage monitor refreshes from new usage snapshots, restores after reboot or app replacement, marks unavailable windows clearly, and stops at the next valid reset or when dismissed, stopped, or signed out (#18).
+- Reset-credit expiry reminders revalidate credit state immediately before notifying and coalesce duplicate scheduling state (#15).
+
+### Fixed
+
+- Dashboard usage-card labels now use theme-aware foreground colors and remain readable in dark mode (#19).
+- Release-history toolbar and Android back navigation now return through the update flow correctly (#16).
+- Expired five-hour usage windows no longer prevent the live monitor from falling back to a future weekly reset (#18).
+
+### Development
+
+- Added a debug-only local release fixture for end-to-end updater testing without weakening production update trust (#16).
+- Expanded regression coverage for expiry-reminder planning, release parsing and integrity checks, widget upgrade repair, live-monitor lifecycle, and dark-mode usage labels (#15, #16, #18, #19).
+
+### New Contributors
+
+- @Robertg761 made their first contribution in https://github.com/BenItBuhner/Codex-Meter/pull/18. <!-- pragma: allowlist secret -->
+
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.1.0...v2.2.0 <!-- pragma: allowlist secret -->
+
 ## 2.1.0 — 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Codex Meter is an unofficial native Android application and widget for viewing the Codex allowance attached to a signed-in ChatGPT account. It displays the rolling five-hour and weekly limits, reset times, reset credits, home-screen widgets, Samsung One UI lock-screen widgets, and optional reset notifications.
 
-## Version 2.1.0
+## Version 2.2.0
 
-Version 2.1 adds a resumable One UI first-run experience, a modern browser return page for OAuth sign-in, and optional notifications for unexpected allowance refills and reset-credit increases. It also brings the Settings screen into one-hand reach and consolidates local-data and privacy details there.
+Version 2.2 adds configurable reset-credit expiry reminders, secure in-app update discovery and verified installation, upgrade recovery for existing widgets, and an optional live usage monitor for Android 16 and compatible Samsung Now Bar surfaces. Dashboard usage labels also remain readable in dark mode.
 
 ### Live countdowns
 
@@ -68,7 +68,7 @@ Requirements:
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.1.0`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
+Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.2.0`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
 
 ## Platform stability
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 11
-        versionName = "2.1.0"
+        versionCode = 12
+        versionName = "2.2.0"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 11;
-    public static final String VERSION_NAME = "2.1.0";
+    public static final int VERSION_CODE = 12;
+    public static final String VERSION_NAME = "2.2.0";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.1.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.2.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.1.0"
+VERSION_NAME="2.2.0"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -46,12 +46,12 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.1.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 11' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.1.0"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 11' "$ROOT/app/build.gradle.kts"
-grep -q 'codex-meter-android/2.1.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.1.0"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.2.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 12' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.2.0"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 12' "$ROOT/app/build.gradle.kts"
+grep -q 'codex-meter-android/2.2.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.2.0"' "$ROOT/build.sh"
 
 grep -q 'android.permission.ACCESS_NETWORK_STATE' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'android.permission.POST_NOTIFICATIONS' "$ROOT/app/src/main/AndroidManifest.xml"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump the Android, runtime, user-agent, and build artifact versions to 2.2.0 (`versionCode` 12)
- add complete release notes for PRs #15, #16, #18, and #19, including first-contributor credit for @Robertg761
- update the README release highlights and tag example for `v2.2.0`
- retain the existing tag-triggered CI path that builds, verifies, signs, and publishes the APK and SHA-256 checksums

## Release process
After this PR is merged, create and push the `v2.2.0` tag at the merge commit. The existing `Build Codex Meter APK` workflow will validate the tag/version match, run tests and lint, build and verify the signed APK, extract the 2.2.0 changelog section, and publish the GitHub release.

## Validation
- `./run-tests.sh` passes all core self-tests and source-level release consistency checks
- `./build.sh` builds and verifies `CodexMeter-2.2.0.apk` with APK Signature Scheme v2
- `./lint.sh` completes successfully
- APK metadata reports package `dev.bennett.codexmeter`, `versionCode=12`, and `versionName=2.2.0`; `SHA256SUMS.txt` verifies successfully
- the workflow-equivalent release-note extraction includes every merged PR since `v2.1.0` and Robert's first-contributor attribution

[release_2_2_validation_final.log](https://cursor.com/agents/bc-fec269fc-b231-4298-8a26-7a7edcdae181/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frelease_2_2_validation_final.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fec269fc-b231-4298-8a26-7a7edcdae181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fec269fc-b231-4298-8a26-7a7edcdae181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

