### PR TITLE
Fix usage-card reset contrast and hide 100% countdowns

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
@@ -393,13 +393,16 @@ final class SamsungLockWidgetSupport {
 
     private static UsageWindow earlierWindow(UsageWindow usageWindow, UsageWindow usageWindow2) {
         long jCurrentTimeMillis = System.currentTimeMillis();
-        long jResetAtMillis = usageWindow == null ? 0L : usageWindow.resetAtMillis();
-        long jResetAtMillis2 = usageWindow2 != null ? usageWindow2.resetAtMillis() : 0L;
+        boolean showPrimary = usageWindow != null && usageWindow.showsResetCountdown();
+        boolean showSecondary = usageWindow2 != null && usageWindow2.showsResetCountdown();
+        long jResetAtMillis = showPrimary ? usageWindow.resetAtMillis() : 0L;
+        long jResetAtMillis2 = showSecondary ? usageWindow2.resetAtMillis() : 0L;
         if (jResetAtMillis > jCurrentTimeMillis) {
-            return (jResetAtMillis2 <= jCurrentTimeMillis || jResetAtMillis <= jResetAtMillis2) ? usageWindow : usageWindow2;
+            return (jResetAtMillis2 <= jCurrentTimeMillis || jResetAtMillis <= jResetAtMillis2)
+                    ? usageWindow : usageWindow2;
         }
         if (jResetAtMillis2 <= jCurrentTimeMillis) {
-            usageWindow2 = null;
+            return null;
         }
         return usageWindow2;
     }
@@ -407,7 +410,8 @@ final class SamsungLockWidgetSupport {
     private static void applyCountdown(RemoteViews remoteViews, int i, boolean z, UsageWindow usageWindow) {
         long jCurrentTimeMillis = System.currentTimeMillis();
         long jResetAtMillis = usageWindow == null ? 0L : usageWindow.resetAtMillis();
-        if (!z || jResetAtMillis <= jCurrentTimeMillis) {
+        if (!z || usageWindow == null || !usageWindow.showsResetCountdown()
+                || jResetAtMillis <= jCurrentTimeMillis) {
             remoteViews.setViewVisibility(i, View.GONE);
             return;
         }

--- a/app/src/main/java/dev/bennett/codexmeter/UsageFormat.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UsageFormat.java
@@ -43,7 +43,8 @@ public final class UsageFormat {
     }
 
     public static String reset(Context context, UsageWindow usageWindow, String str, long j) {
-        if (usageWindow == null || WidgetOptions.RESET_HIDDEN.equals(str)) {
+        if (usageWindow == null || WidgetOptions.RESET_HIDDEN.equals(str)
+                || !usageWindow.showsResetCountdown()) {
             return "";
         }
         long jResetAtMillis = usageWindow.resetAtMillis();

--- a/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
@@ -103,17 +103,19 @@ public final class UsageWaveView extends View {
         fillPaint.setColor(Ui.desaturatedAccent(getContext(), dark));
         canvas.drawPath(fillPath, fillPaint);
 
-        titlePaint.setColor(Ui.mainText(dark));
+        int foreground = Ui.mainText(dark);
+        titlePaint.setColor(foreground);
         titlePaint.setTextSize(20f * density);
-        resetPaint.setColor(Ui.secondaryText(dark));
+        // Reset duration must match title/percent contrast (black light / white dark).
+        resetPaint.setColor(foreground);
         resetPaint.setTextSize(14f * density);
         canvas.drawText(title, 12f * density, 34f * density, titlePaint);
-        canvas.drawText(resetTop, 12f * density, 67f * density, resetPaint);
-        if (!resetBottom.isEmpty()) {
-            canvas.drawText(resetBottom, 12f * density, 87f * density, resetPaint);
+        if (!resetTop.isEmpty()) {
+            canvas.drawText(resetTop, 12f * density, 67f * density, resetPaint);
+            if (!resetBottom.isEmpty()) {
+                canvas.drawText(resetBottom, 12f * density, 87f * density, resetPaint);
+            }
         }
-
-        int foreground = Ui.mainText(dark);
         float rightCenter = getWidth() - 48f * density;
         if (icon != null) {
             int size = Math.round(36f * density);

--- a/app/src/main/java/dev/bennett/codexmeter/UsageWindow.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UsageWindow.java
@@ -21,6 +21,14 @@ public final class UsageWindow {
         return clamp(100 - this.usedPercent);
     }
 
+    /**
+     * Full windows keep drifting the reset clock without real consumption.
+     * Hide countdown/reset labels until remaining drops to 99% or less.
+     */
+    public boolean showsResetCountdown() {
+        return remainingPercent() <= 99;
+    }
+
     public long resetAtMillis() {
         if (this.resetAtEpochSeconds > 0) {
             return this.resetAtEpochSeconds * 1000;

--- a/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -696,7 +696,8 @@ public final class WidgetRenderer {
     }
 
     public static String shortReset(Context context, UsageWindow usageWindow, String str, long j) {
-        if (usageWindow == null || WidgetOptions.RESET_HIDDEN.equals(str)) {
+        if (usageWindow == null || WidgetOptions.RESET_HIDDEN.equals(str)
+                || !usageWindow.showsResetCountdown()) {
             return "";
         }
         long jResetAtMillis = usageWindow.resetAtMillis();
@@ -809,8 +810,12 @@ public final class WidgetRenderer {
         }
 
         private static ResetCountdown nextReset(UsageSnapshot snapshot, long now) {
-            long fiveHourReset = resetAt(snapshot == null ? null : snapshot.fiveHour, now);
-            long weeklyReset = resetAt(snapshot == null ? null : snapshot.weekly, now);
+            UsageWindow fiveHour = snapshot == null ? null : snapshot.fiveHour;
+            UsageWindow weekly = snapshot == null ? null : snapshot.weekly;
+            long fiveHourReset = (fiveHour != null && fiveHour.showsResetCountdown())
+                    ? resetAt(fiveHour, now) : 0L;
+            long weeklyReset = (weekly != null && weekly.showsResetCountdown())
+                    ? resetAt(weekly, now) : 0L;
             long resetAt;
             long windowDuration;
             if (fiveHourReset > now && (weeklyReset <= now || fiveHourReset <= weeklyReset)) {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -141,9 +141,15 @@ grep -q 'Ui.nativePrimaryButton' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java"
 grep -q 'OAuthBrowserPage.render' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthService.java"
-grep -q 'titlePaint.setColor(Ui.mainText(dark));' \
+grep -q 'titlePaint.setColor(foreground);' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java"
-grep -q 'resetPaint.setColor(Ui.secondaryText(dark));' \
+grep -q 'resetPaint.setColor(foreground);' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java"
+grep -q 'showsResetCountdown' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWindow.java"
+grep -q '!usageWindow.showsResetCountdown()' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageFormat.java"
+! grep -q 'resetPaint.setColor(Ui.secondaryText(dark));' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java"
 ! grep -q 'titlePaint.setColor(0xFF000000)' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -18,6 +18,7 @@ public final class ParserSelfTest {
         testNextResetSelection();
         testCelebrationDetection();
         testResetCreditExpiryReminders();
+        testFullWindowHidesResetCountdown();
         testJwtMerge();
         testPkce();
         testWidgetOptions();
@@ -27,6 +28,18 @@ public final class ParserSelfTest {
         testGitHubReleases();
         testReleaseChecksums();
         System.out.println("All parser, updater, OAuth, onboarding, and widget-option self-tests passed.");
+    }
+
+    private static void testFullWindowHidesResetCountdown() {
+        UsageWindow full = new UsageWindow(0, 18000L, 600L, 2000000000L);
+        UsageWindow almostFull = new UsageWindow(1, 18000L, 600L, 2000000000L);
+        UsageWindow used = new UsageWindow(37, 18000L, 600L, 2000000000L);
+        check(full.remainingPercent() == 100, "full window remaining");
+        check(!full.showsResetCountdown(), "100% remaining hides drifting reset countdown");
+        check(almostFull.remainingPercent() == 99, "1% used is 99% remaining");
+        check(almostFull.showsResetCountdown(), "99% remaining still shows reset countdown");
+        check(used.showsResetCountdown(), "partial usage shows reset countdown");
+        System.out.println("Reset-countdown demo: hide at 100% remaining, show again at 99% or less.");
     }
 
     private static void testStandardUsage() throws Exception {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Dashboard wave cards now paint reset duration with **main text color** (black in light mode, near-white in dark mode) instead of muted secondary gray.
- Reset countdowns are **hidden while remaining is 100%** (the drifting full-window clock) and return at **99% or less**, including home widgets and lock-screen chronometers.

## Why
Full rate-limit windows keep sliding the reset timestamp without real consumption, so showing “Resets in …” at 100% is misleading. Secondary gray on the light blue fill was also poor contrast after the prior dark-mode text pass.

## Demo screenshots
These are fidelity mocks of the dashboard cards (no emulator in this environment). Pixel sampling confirms before = secondary gray `(132,132,135)`, after light = black `(0,0,0)`, after dark = main text `(248,248,250)`.

### Contrast: before vs after (light)
[Before: gray reset text](https://cursor.com/agents/bc-712e15de-7d96-4e6a-8d17-e905dc459e6d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flight-reset-contrast-before.png)
[After: black reset text](https://cursor.com/agents/bc-712e15de-7d96-4e6a-8d17-e905dc459e6d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flight-reset-contrast-after.png)

### Dark mode reset text
[Dark mode near-white reset text](https://cursor.com/agents/bc-712e15de-7d96-4e6a-8d17-e905dc459e6d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdark-reset-contrast-after.png)

### Hide at 100%, show at 99%
[Both at 100%: countdown hidden](https://cursor.com/agents/bc-712e15de-7d96-4e6a-8d17-e905dc459e6d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhide-countdown-at-100.png)
[At 99%: countdown returns](https://cursor.com/agents/bc-712e15de-7d96-4e6a-8d17-e905dc459e6d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fshow-countdown-at-99.png)

### Comparison strip
[Side-by-side comparison of all fixes](https://cursor.com/agents/bc-712e15de-7d96-4e6a-8d17-e905dc459e6d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fusage-card-fixes-comparison.png)

## Test plan
- [x] `./run-tests.sh` (includes new `showsResetCountdown` self-test + source greps)
- [ ] On device/emulator light mode: confirm reset duration matches title/percent blackness
- [ ] On device/emulator dark mode: confirm reset duration is near-white like other primary labels
- [ ] With both windows at 100%: confirm no “Resets in …” on dashboard cards
- [ ] Drop to 99% or less on either window: confirm countdown reappears for that window only
- [ ] Spot-check home widget reset labels and lock-screen chronometers follow the same rule


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-712e15de-7d96-4e6a-8d17-e905dc459e6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-712e15de-7d96-4e6a-8d17-e905dc459e6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

