### PR TITLE
Prepare Codex Meter 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.3.0 — 2026-07-14
+
+### Fixed
+
+- Rebuilt the Android 16 live usage notification on a dedicated default-importance channel, removed conflicting legacy Samsung metadata, and exposed actual Live Update promotion state for compatible Samsung Now Bar surfaces (#21).
+- Improved reset-duration contrast on dashboard usage cards and hid misleading reset countdowns while a usage window remains completely unused, including home and lock-screen widgets (#23).
+- Restored in-app update discovery and project links by pointing them at the canonical repository instead of a stale fork (#24).
+
+### Development
+
+- Centralized production GitHub release URLs and added regression guards that prevent the stale update source from being reintroduced (#24).
+
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.2.0...v2.3.0 <!-- pragma: allowlist secret -->
+
 ## 2.2.0 — 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Codex Meter is an unofficial native Android application and widget for viewing the Codex allowance attached to a signed-in ChatGPT account. It displays the rolling five-hour and weekly limits, reset times, reset credits, home-screen widgets, Samsung One UI lock-screen widgets, and optional reset notifications.
 
-## Version 2.2.0
+## Version 2.3.0
 
-Version 2.2 adds configurable reset-credit expiry reminders, secure in-app update discovery and verified installation, upgrade recovery for existing widgets, and an optional live usage monitor for Android 16 and compatible Samsung Now Bar surfaces. Dashboard usage labels also remain readable in dark mode.
+Version 2.3 improves Android 16 Live Update promotion on compatible Samsung devices, fixes reset-label contrast and misleading full-window countdowns, and restores secure release discovery from the canonical GitHub repository.
 
 ### Live countdowns
 
@@ -68,7 +68,7 @@ Requirements:
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.2.0`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
+Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.3.0`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
 
 ## Platform stability
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 12
-        versionName = "2.2.0"
+        versionCode = 13
+        versionName = "2.3.0"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
             versionName = it
         }
         val updateApiUrl = providers.gradleProperty("demoUpdateUrl").orNull
-            ?: "https://api.github.com/repos/thatjoshguy67/Codex-Meter/releases?per_page=30"
+            ?: "https://api.github.com/repos/BenItBuhner/Codex-Meter/releases?per_page=30" // pragma: allowlist secret
         buildConfigField("String", "UPDATE_API_URL",
             "\"${updateApiUrl.replace("\\", "\\\\").replace("\"", "\\\"")}\"")
     }

--- a/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
@@ -62,7 +62,8 @@ public final class AboutActivity extends AppCompatActivity {
             return true;
         }
         if (item.getItemId() == MENU_GITHUB) {
-            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/thatjoshguy67/Codex-Meter")));
+            startActivity(new Intent(Intent.ACTION_VIEW,
+                    Uri.parse(GitHubReleaseSource.REPOSITORY_URL)));
             return true;
         }
         if (item.getItemId() == MENU_APP_INFO) {

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 12;
-    public static final String VERSION_NAME = "2.2.0";
+    public static final int VERSION_CODE = 13;
+    public static final String VERSION_NAME = "2.3.0";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.2.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.3.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseSource.java
+++ b/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseSource.java
@@ -1,0 +1,12 @@
+package dev.bennett.codexmeter;
+
+/** Canonical production repository used for release discovery and project links. */
+public final class GitHubReleaseSource {
+    public static final String REPOSITORY_URL =
+            "https://github.com/BenItBuhner/Codex-Meter"; // pragma: allowlist secret
+    public static final String RELEASES_API_URL =
+            "https://api.github.com/repos/BenItBuhner/Codex-Meter/releases?per_page=30"; // pragma: allowlist secret
+
+    private GitHubReleaseSource() {
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
@@ -10,8 +10,6 @@ import java.util.List;
 
 /** Public, unauthenticated GitHub release discovery client. */
 public final class ReleaseUpdateClient {
-    static final String RELEASES_URL =
-            "https://api.github.com/repos/thatjoshguy67/Codex-Meter/releases?per_page=30";
     private static final int MAX_RESPONSE_BYTES = 512 * 1024;
     private static final Object LOCK = new Object();
 
@@ -37,7 +35,8 @@ public final class ReleaseUpdateClient {
             throws Exception {
         HttpURLConnection connection = null;
         try {
-            String endpoint = BuildConfig.DEBUG ? BuildConfig.UPDATE_API_URL : RELEASES_URL;
+            String endpoint = BuildConfig.DEBUG
+                    ? BuildConfig.UPDATE_API_URL : GitHubReleaseSource.RELEASES_API_URL;
             boolean localDebugServer = isLocalDebugServer(endpoint);
             connection = (HttpURLConnection) new URL(endpoint).openConnection();
             connection.setConnectTimeout(15_000);

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.2.0"
+VERSION_NAME="2.3.0"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -47,12 +47,12 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.2.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 12' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.2.0"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 12' "$ROOT/app/build.gradle.kts"
-grep -q 'codex-meter-android/2.2.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.2.0"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.3.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 13' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.3.0"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 13' "$ROOT/app/build.gradle.kts"
+grep -q 'codex-meter-android/2.3.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.3.0"' "$ROOT/build.sh"
 grep -q 'BenItBuhner/Codex-Meter/releases?per_page=30' "$ROOT/app/build.gradle.kts" # pragma: allowlist secret
 ! grep -R -q 'thatjoshguy67/Codex-Meter' \
   "$ROOT/app/src" "$ROOT/app/build.gradle.kts"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -38,6 +38,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingFlow.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthBrowserPage.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseVersion.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseSource.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubRelease.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java" \
@@ -52,6 +53,9 @@ grep -q 'versionName = "2.2.0"' "$ROOT/app/build.gradle.kts"
 grep -q 'versionCode = 12' "$ROOT/app/build.gradle.kts"
 grep -q 'codex-meter-android/2.2.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
 grep -q 'VERSION_NAME="2.2.0"' "$ROOT/build.sh"
+grep -q 'BenItBuhner/Codex-Meter/releases?per_page=30' "$ROOT/app/build.gradle.kts" # pragma: allowlist secret
+! grep -R -q 'thatjoshguy67/Codex-Meter' \
+  "$ROOT/app/src" "$ROOT/app/build.gradle.kts"
 
 grep -q 'android.permission.ACCESS_NETWORK_STATE' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'android.permission.POST_NOTIFICATIONS' "$ROOT/app/src/main/AndroidManifest.xml"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -338,6 +338,12 @@ public final class ParserSelfTest {
     }
 
     private static void testGitHubReleases() throws Exception {
+        check("https://github.com/BenItBuhner/Codex-Meter".equals( // pragma: allowlist secret
+                        GitHubReleaseSource.REPOSITORY_URL),
+                "canonical release repository");
+        check("https://api.github.com/repos/BenItBuhner/Codex-Meter/releases?per_page=30" // pragma: allowlist secret
+                        .equals(GitHubReleaseSource.RELEASES_API_URL),
+                "canonical release API endpoint");
         String json = "["
                 + releaseJson("v2.2.0", false, false, true, true)
                 + "," + releaseJson("v3.0.0-beta.1", false, true, true, true)
@@ -361,7 +367,7 @@ public final class ParserSelfTest {
                 "lookalike GitHub host rejected");
         String localFixture = "[" + releaseJson(
                 "v2.2.0", false, false, true, true).replace(
-                "https://github.com/thatjoshguy67/Codex-Meter",
+                GitHubReleaseSource.REPOSITORY_URL,
                 "http://10.0.2.2:8765") + "]";
         check(GitHubReleaseParser.parse(localFixture).isEmpty(),
                 "local fixture rejected by production parser");
@@ -376,19 +382,21 @@ public final class ParserSelfTest {
         if (apk) {
             assets.append("{\"name\":\"CodexMeter-").append(normalized)
                     .append(".apk\",\"size\":123,\"browser_download_url\":")
-                    .append("\"https://github.com/thatjoshguy67/Codex-Meter/releases/download/")
+                    .append("\"").append(GitHubReleaseSource.REPOSITORY_URL)
+                    .append("/releases/download/")
                     .append(tag).append("/CodexMeter-").append(normalized).append(".apk\"}");
         }
         if (checksum) {
             if (assets.length() > 0) assets.append(',');
             assets.append("{\"name\":\"SHA256SUMS.txt\",\"size\":90,")
                     .append("\"browser_download_url\":")
-                    .append("\"https://github.com/thatjoshguy67/Codex-Meter/releases/download/")
+                    .append("\"").append(GitHubReleaseSource.REPOSITORY_URL)
+                    .append("/releases/download/")
                     .append(tag).append("/SHA256SUMS.txt\"}");
         }
         return "{\"tag_name\":\"" + tag + "\",\"name\":\"Codex Meter " + normalized
                 + "\",\"body\":\"Changes\",\"published_at\":\"2026-07-13T00:00:00Z\","
-                + "\"html_url\":\"https://github.com/thatjoshguy67/Codex-Meter/releases/tag/"
+                + "\"html_url\":\"" + GitHubReleaseSource.REPOSITORY_URL + "/releases/tag/"
                 + tag + "\",\"draft\":" + draft + ",\"prerelease\":" + prerelease
                 + ",\"assets\":[" + assets + "]}";
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix in-app release discovery by replacing the stale fork with the canonical GitHub repository.
- Prepare Codex Meter 2.3.0 with version code 13 across Gradle, runtime constants, build tooling, and release checks.
- Add release notes covering every post-v2.2.0 change from PRs #21, #23, and #24.
- Refresh current-version documentation and retain regression guards for the canonical release source.

## Testing
- `./run-tests.sh`
- `./build.sh`
- `./lint.sh`
- Verified `CodexMeter-2.3.0.apk` reports package `dev.bennett.codexmeter`, version code 13, version name 2.3.0, a valid local-build signature, and a matching SHA-256 checksum.
- Inspected all compiled DEX files and confirmed the 2.3.0 user agent and canonical updater endpoint are embedded with no stale-fork URL.
- Confirmed `v2.3.0` does not already exist and the tag-triggered release workflow accepts that exact Gradle version.

## Release
After merge, create and push annotated tag `v2.3.0`; the existing tag workflow will build with the persistent release certificate, generate `SHA256SUMS.txt`, and publish the GitHub release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcef623c-887b-4354-918e-f3390d217334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcef623c-887b-4354-918e-f3390d217334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

