### PR TITLE
Render release-note Markdown and flag pre-2.3.0 as irreversible

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
@@ -1,11 +1,13 @@
 package dev.bennett.codexmeter;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.widget.Toast;
 import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
 import java.util.List;
@@ -81,9 +83,13 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
                 Ui.mainText(dark));
         current.setTypeface(Ui.mediumTypeface(this));
         notice.addView(current);
-        String note = "Newer and matching releases are checksum- and signature-verified in the "
-                + "app. Older versions require uninstalling first, which removes local data and "
-                + "widgets.";
+        String note = "Newer and matching releases from Codex Meter "
+                + ReleaseUpdatePolicy.FIRST_IN_APP_UPDATE_VERSION
+                + " onward are checksum- and signature-verified in the app. Releases before "
+                + ReleaseUpdatePolicy.FIRST_IN_APP_UPDATE_VERSION
+                + " are irreversible and must be installed from GitHub because those builds lack "
+                + "working in-app updates. Other older versions still require uninstalling first, "
+                + "which removes local data and widgets.";
         TextView detail = Ui.text(this, note, 13, Ui.secondaryText(dark));
         LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(-1, -2);
         detailParams.setMargins(0, Ui.dp(this, 8), 0, 0);
@@ -128,8 +134,10 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
     private void addRelease(GitHubRelease release) {
         int comparison = ReleaseVersion.compare(release.version,
                 UpdatePreferences.installedVersion(this));
+        boolean irreversible = ReleaseUpdatePolicy.isIrreversible(release.version);
         LinearLayout card = Ui.card(this, dark);
         String suffix = release.prerelease ? " · Prerelease"
+                : irreversible ? " · Irreversible"
                 : comparison > 0 ? " · Update"
                 : comparison == 0 ? " · Installed" : " · Older";
         TextView title = Ui.text(this, release.name, 18, Ui.mainText(dark));
@@ -138,18 +146,63 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
         String published = release.publishedAt.length() >= 10
                 ? release.publishedAt.substring(0, 10) : "Unknown date";
         TextView summary = Ui.text(this, "v" + release.version + suffix + " · " + published,
-                13, Ui.secondaryText(dark));
+                13, irreversible ? Ui.danger(dark) : Ui.secondaryText(dark));
         LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
-        summaryParams.setMargins(0, Ui.dp(this, 6), 0, Ui.dp(this, 14));
+        summaryParams.setMargins(0, Ui.dp(this, 6), 0, Ui.dp(this, irreversible ? 8 : 14));
         card.addView(summary, summaryParams);
-        Button action = Ui.button(this,
-                comparison < 0 ? "View downgrade" : comparison == 0 ? "View reinstall"
-                        : "View update", comparison > 0, dark);
-        action.setOnClickListener(view -> startActivity(new Intent(this, UpdateActivity.class)
-                .putExtra(UpdateActivity.EXTRA_VERSION, release.version)));
-        card.addView(action, new LinearLayout.LayoutParams(-1, Ui.dp(this, 54)));
+
+        if (irreversible) {
+            TextView irreversibleNote = Ui.text(this,
+                    ReleaseUpdatePolicy.irreversibleSummary()
+                            + ". Update manually from the GitHub release page.",
+                    13, Ui.secondaryText(dark));
+            LinearLayout.LayoutParams irreversibleParams = new LinearLayout.LayoutParams(-1, -2);
+            irreversibleParams.setMargins(0, 0, 0, Ui.dp(this, 14));
+            card.addView(irreversibleNote, irreversibleParams);
+        }
+
+        if (!release.notes.isEmpty()) {
+            TextView notesHeading = Ui.text(this, "What’s new", 13, Ui.secondaryText(dark));
+            notesHeading.setTypeface(Ui.mediumTypeface(this));
+            LinearLayout.LayoutParams notesHeadingParams = new LinearLayout.LayoutParams(-1, -2);
+            notesHeadingParams.setMargins(0, 0, 0, Ui.dp(this, 8));
+            card.addView(notesHeading, notesHeadingParams);
+            card.addView(ReleaseNotesUi.create(this, release.notes, dark));
+            LinearLayout.LayoutParams spacer = new LinearLayout.LayoutParams(-1, Ui.dp(this, 14));
+            android.widget.Space space = new android.widget.Space(this);
+            card.addView(space, spacer);
+        }
+
+        if (irreversible) {
+            Button github = Ui.nativePrimaryButton(this, "Open on GitHub");
+            github.setOnClickListener(view -> openUrl(release.pageUrl));
+            card.addView(github, new LinearLayout.LayoutParams(-1, Ui.dp(this, 54)));
+            Button details = Ui.button(this, "View release details", false, dark);
+            details.setOnClickListener(view -> startActivity(new Intent(this, UpdateActivity.class)
+                    .putExtra(UpdateActivity.EXTRA_VERSION, release.version)));
+            LinearLayout.LayoutParams detailsParams =
+                    new LinearLayout.LayoutParams(-1, Ui.dp(this, 54));
+            detailsParams.setMargins(0, Ui.dp(this, 10), 0, 0);
+            card.addView(details, detailsParams);
+        } else {
+            Button action = Ui.button(this,
+                    comparison < 0 ? "View downgrade" : comparison == 0 ? "View reinstall"
+                            : "View update", comparison > 0, dark);
+            action.setOnClickListener(view -> startActivity(new Intent(this, UpdateActivity.class)
+                    .putExtra(UpdateActivity.EXTRA_VERSION, release.version)));
+            card.addView(action, new LinearLayout.LayoutParams(-1, Ui.dp(this, 54)));
+        }
         LinearLayout.LayoutParams cardParams = new LinearLayout.LayoutParams(-1, -2);
         cardParams.setMargins(0, 0, 0, Ui.dp(this, 14));
         content.addView(card, cardParams);
+    }
+
+    private void openUrl(String url) {
+        try {
+            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+        } catch (RuntimeException exception) {
+            Toast.makeText(this, "No browser can open the GitHub release page.",
+                    Toast.LENGTH_LONG).show();
+        }
     }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java
@@ -1,0 +1,237 @@
+package dev.bennett.codexmeter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Converts the GitHub release-note Markdown subset used by Codex Meter into HTML that
+ * {@code android.text.Html} can render inside TextViews.
+ */
+public final class ReleaseNotesMarkdown {
+    private static final Pattern HTML_COMMENT = Pattern.compile("<!--.*?-->", Pattern.DOTALL);
+    private static final Pattern BOLD = Pattern.compile("\\*\\*(.+?)\\*\\*|__(.+?)__");
+    private static final Pattern ITALIC = Pattern.compile("(?<!\\*)\\*(?!\\*)(.+?)(?<!\\*)\\*(?!\\*)|_(.+?)_");
+    private static final Pattern INLINE_CODE = Pattern.compile("`([^`]+)`");
+    private static final Pattern LINK = Pattern.compile("\\[([^\\]]+)\\]\\(([^)\\s]+)\\)");
+    private static final Pattern AUTOLINK = Pattern.compile(
+            "(?<![\"'>])(https?://[\\w.-]+(?:/[\\w\\-./?%&=+#~:@,]*)?)");
+
+    private ReleaseNotesMarkdown() {
+    }
+
+    public static String toHtml(String markdown) {
+        String source = markdown == null ? "" : markdown.replace("\r\n", "\n").replace('\r', '\n');
+        source = HTML_COMMENT.matcher(source).replaceAll("");
+        source = source.trim();
+        if (source.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder html = new StringBuilder();
+        String[] lines = source.split("\n", -1);
+        int index = 0;
+        while (index < lines.length) {
+            String line = lines[index];
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                index++;
+                continue;
+            }
+            if (isHorizontalRule(trimmed)) {
+                html.append("<hr>");
+                index++;
+                continue;
+            }
+            int headingLevel = headingLevel(trimmed);
+            if (headingLevel > 0) {
+                String text = trimmed.substring(headingLevel).trim();
+                html.append("<p><b>").append(inline(text)).append("</b></p>");
+                index++;
+                continue;
+            }
+            if (isUnorderedItem(trimmed)) {
+                html.append("<ul>");
+                while (index < lines.length && isUnorderedItem(lines[index].trim())) {
+                    html.append("<li>").append(inline(stripUnorderedMarker(lines[index].trim())))
+                            .append("</li>");
+                    index++;
+                }
+                html.append("</ul>");
+                continue;
+            }
+            if (isOrderedItem(trimmed)) {
+                html.append("<ol>");
+                while (index < lines.length && isOrderedItem(lines[index].trim())) {
+                    html.append("<li>").append(inline(stripOrderedMarker(lines[index].trim())))
+                            .append("</li>");
+                    index++;
+                }
+                html.append("</ol>");
+                continue;
+            }
+
+            List<String> paragraph = new ArrayList<>();
+            while (index < lines.length) {
+                String candidate = lines[index].trim();
+                if (candidate.isEmpty()
+                        || isHorizontalRule(candidate)
+                        || headingLevel(candidate) > 0
+                        || isUnorderedItem(candidate)
+                        || isOrderedItem(candidate)) {
+                    break;
+                }
+                paragraph.add(candidate);
+                index++;
+            }
+            html.append("<p>");
+            for (int part = 0; part < paragraph.size(); part++) {
+                if (part > 0) {
+                    html.append("<br>");
+                }
+                html.append(inline(paragraph.get(part)));
+            }
+            html.append("</p>");
+        }
+        return html.toString();
+    }
+
+    private static String inline(String text) {
+        String escaped = escapeHtml(text == null ? "" : text);
+        escaped = replaceAll(LINK, escaped, matcher -> {
+            String label = matcher.group(1);
+            String url = unescapeBasicEntities(matcher.group(2));
+            if (!isSafeUrl(url)) {
+                return matcher.group(0);
+            }
+            return "<a href=\"" + escapeAttribute(url) + "\">" + label + "</a>";
+        });
+        escaped = replaceAll(INLINE_CODE, escaped, matcher ->
+                "<code>" + matcher.group(1) + "</code>");
+        escaped = replaceAll(BOLD, escaped, matcher -> {
+            String value = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+            return "<b>" + value + "</b>";
+        });
+        escaped = replaceAll(ITALIC, escaped, matcher -> {
+            String value = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+            return "<i>" + value + "</i>";
+        });
+        escaped = replaceAll(AUTOLINK, escaped, matcher -> {
+            String displayed = matcher.group(1);
+            String url = unescapeBasicEntities(displayed);
+            if (!isSafeUrl(url) || urlContainsHtml(url)) {
+                return displayed;
+            }
+            return "<a href=\"" + escapeAttribute(url) + "\">" + displayed + "</a>";
+        });
+        return escaped;
+    }
+
+    private static String unescapeBasicEntities(String value) {
+        return value.replace("&amp;", "&")
+                .replace("&quot;", "\"")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">");
+    }
+
+    private interface Replacer {
+        String replace(Matcher matcher);
+    }
+
+    private static String replaceAll(Pattern pattern, String input, Replacer replacer) {
+        Matcher matcher = pattern.matcher(input);
+        StringBuffer buffer = new StringBuffer();
+        while (matcher.find()) {
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacer.replace(matcher)));
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    private static boolean isSafeUrl(String url) {
+        if (url == null) {
+            return false;
+        }
+        String lower = url.toLowerCase(Locale.US);
+        return lower.startsWith("https://") || lower.startsWith("http://");
+    }
+
+    private static boolean urlContainsHtml(String url) {
+        return url.indexOf('<') >= 0 || url.indexOf('>') >= 0 || url.indexOf('"') >= 0;
+    }
+
+    private static int headingLevel(String trimmed) {
+        int level = 0;
+        while (level < trimmed.length() && trimmed.charAt(level) == '#') {
+            level++;
+        }
+        if (level == 0 || level > 6 || level >= trimmed.length() || trimmed.charAt(level) != ' ') {
+            return 0;
+        }
+        return level;
+    }
+
+    private static boolean isHorizontalRule(String trimmed) {
+        return "---".equals(trimmed) || "***".equals(trimmed) || "___".equals(trimmed)
+                || "----".equals(trimmed) || "*****".equals(trimmed);
+    }
+
+    private static boolean isUnorderedItem(String trimmed) {
+        return trimmed.startsWith("- ") || trimmed.startsWith("* ") || trimmed.startsWith("+ ");
+    }
+
+    private static String stripUnorderedMarker(String trimmed) {
+        return trimmed.substring(2).trim();
+    }
+
+    private static boolean isOrderedItem(String trimmed) {
+        int index = 0;
+        while (index < trimmed.length() && trimmed.charAt(index) >= '0'
+                && trimmed.charAt(index) <= '9') {
+            index++;
+        }
+        return index > 0 && index + 1 < trimmed.length()
+                && trimmed.charAt(index) == '.'
+                && trimmed.charAt(index + 1) == ' ';
+    }
+
+    private static String stripOrderedMarker(String trimmed) {
+        int index = 0;
+        while (index < trimmed.length() && trimmed.charAt(index) >= '0'
+                && trimmed.charAt(index) <= '9') {
+            index++;
+        }
+        return trimmed.substring(index + 2).trim();
+    }
+
+    private static String escapeHtml(String value) {
+        StringBuilder builder = new StringBuilder(value.length() + 16);
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            switch (character) {
+                case '&':
+                    builder.append("&amp;");
+                    break;
+                case '<':
+                    builder.append("&lt;");
+                    break;
+                case '>':
+                    builder.append("&gt;");
+                    break;
+                case '"':
+                    builder.append("&quot;");
+                    break;
+                default:
+                    builder.append(character);
+                    break;
+            }
+        }
+        return builder.toString();
+    }
+
+    private static String escapeAttribute(String value) {
+        return escapeHtml(value).replace("'", "&#39;");
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesUi.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesUi.java
@@ -1,0 +1,36 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import android.os.Build;
+import android.text.Html;
+import android.text.method.LinkMovementMethod;
+import android.widget.TextView;
+
+/** Shared TextView wiring for rendered GitHub release notes. */
+public final class ReleaseNotesUi {
+    private ReleaseNotesUi() {
+    }
+
+    public static TextView create(Context context, String markdown, boolean dark) {
+        TextView view = Ui.text(context, "", 14, Ui.mainText(dark));
+        apply(view, markdown);
+        return view;
+    }
+
+    public static void apply(TextView view, String markdown) {
+        String html = ReleaseNotesMarkdown.toHtml(markdown);
+        if (html.isEmpty()) {
+            view.setText("");
+            return;
+        }
+        CharSequence rendered;
+        if (Build.VERSION.SDK_INT >= 24) {
+            rendered = Html.fromHtml(html, Html.FROM_HTML_MODE_COMPACT);
+        } else {
+            rendered = Html.fromHtml(html);
+        }
+        view.setText(rendered);
+        view.setMovementMethod(LinkMovementMethod.getInstance());
+        view.setLinksClickable(true);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java
@@ -1,0 +1,32 @@
+package dev.bennett.codexmeter;
+
+/**
+ * In-app update policy gates. Builds before {@link #FIRST_IN_APP_UPDATE_VERSION} pointed at a
+ * stale update source or had no updater at all, so installing or remaining on them requires a
+ * manual GitHub APK install and cannot be reversed through the in-app flow.
+ */
+public final class ReleaseUpdatePolicy {
+    /** First release with a working in-app updater against the canonical repository. */
+    public static final String FIRST_IN_APP_UPDATE_VERSION = "2.3.0";
+
+    private ReleaseUpdatePolicy() {
+    }
+
+    /** True when {@code version} is strictly older than {@link #FIRST_IN_APP_UPDATE_VERSION}. */
+    public static boolean isIrreversible(String version) {
+        ReleaseVersion candidate = ReleaseVersion.parse(version);
+        ReleaseVersion threshold = ReleaseVersion.parse(FIRST_IN_APP_UPDATE_VERSION);
+        return candidate != null && threshold != null && candidate.compareTo(threshold) < 0;
+    }
+
+    public static String irreversibleSummary() {
+        return "Irreversible · Manual GitHub update required";
+    }
+
+    public static String irreversibleDetail() {
+        return "Builds before Codex Meter " + FIRST_IN_APP_UPDATE_VERSION
+                + " lack working in-app updates against the canonical repository. Install or "
+                + "recover from this release only via its GitHub release page; the app cannot "
+                + "upgrade you back afterward.";
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -119,6 +119,7 @@ public final class UpdateActivity extends AppCompatActivity {
         }
         String installedVersion = UpdatePreferences.installedVersion(this);
         int comparison = ReleaseVersion.compare(release.version, installedVersion);
+        boolean irreversible = ReleaseUpdatePolicy.isIrreversible(release.version);
         LinearLayout card = Ui.card(this, dark);
         TextView title = Ui.text(this,
                 comparison > 0 ? "Codex Meter " + release.version + " is available"
@@ -127,39 +128,61 @@ public final class UpdateActivity extends AppCompatActivity {
                 20, Ui.mainText(dark));
         title.setTypeface(Ui.mediumTypeface(this));
         card.addView(title);
-        String detail = comparison > 0
-                ? "Installed: " + installedVersion + " · Verified GitHub upgrade"
-                : comparison == 0
-                ? "This version is currently installed. You can verify and reinstall it."
-                : "Installed: " + installedVersion
-                        + " · Android requires uninstalling before this downgrade.";
-        TextView summary = Ui.text(this, detail, 14, Ui.secondaryText(dark));
+        String detail;
+        if (irreversible) {
+            detail = ReleaseUpdatePolicy.irreversibleSummary()
+                    + " · Installed: " + installedVersion;
+        } else if (comparison > 0) {
+            detail = "Installed: " + installedVersion + " · Verified GitHub upgrade";
+        } else if (comparison == 0) {
+            detail = "This version is currently installed. You can verify and reinstall it.";
+        } else {
+            detail = "Installed: " + installedVersion
+                    + " · Android requires uninstalling before this downgrade.";
+        }
+        TextView summary = Ui.text(this, detail, 14,
+                irreversible ? Ui.danger(dark) : Ui.secondaryText(dark));
         LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
         summaryParams.setMargins(0, Ui.dp(this, 8), 0, Ui.dp(this, 18));
         card.addView(summary, summaryParams);
 
-        Button action = Ui.nativePrimaryButton(this,
-                comparison < 0 ? "Download older APK" : comparison == 0 ? "Verify and reinstall"
-                        : "Download and install");
-        action.setOnClickListener(view -> {
-            if (comparison < 0) {
-                confirmOlderDownload();
-            } else {
-                requestInstall();
-            }
-        });
-        card.addView(action, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
+        if (irreversible) {
+            TextView irreversibleDetail = Ui.text(this, ReleaseUpdatePolicy.irreversibleDetail(),
+                    13, Ui.secondaryText(dark));
+            LinearLayout.LayoutParams irreversibleParams = new LinearLayout.LayoutParams(-1, -2);
+            irreversibleParams.setMargins(0, 0, 0, Ui.dp(this, 18));
+            card.addView(irreversibleDetail, irreversibleParams);
+            Button github = Ui.nativePrimaryButton(this, "Open on GitHub");
+            github.setOnClickListener(view -> openReleasePage());
+            card.addView(github, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
+            progress = null;
+            status = null;
+        } else {
+            Button action = Ui.nativePrimaryButton(this,
+                    comparison < 0 ? "Download older APK"
+                            : comparison == 0 ? "Verify and reinstall"
+                            : "Download and install");
+            action.setOnClickListener(view -> {
+                if (comparison < 0) {
+                    confirmOlderDownload();
+                } else {
+                    requestInstall();
+                }
+            });
+            card.addView(action, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
 
-        progress = new ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal);
-        progress.setMax(1000);
-        progress.setVisibility(View.GONE);
-        LinearLayout.LayoutParams progressParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 8));
-        progressParams.setMargins(0, Ui.dp(this, 18), 0, 0);
-        card.addView(progress, progressParams);
-        status = Ui.text(this, "", 13, Ui.secondaryText(dark));
-        LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(-1, -2);
-        statusParams.setMargins(0, Ui.dp(this, 10), 0, 0);
-        card.addView(status, statusParams);
+            progress = new ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal);
+            progress.setMax(1000);
+            progress.setVisibility(View.GONE);
+            LinearLayout.LayoutParams progressParams =
+                    new LinearLayout.LayoutParams(-1, Ui.dp(this, 8));
+            progressParams.setMargins(0, Ui.dp(this, 18), 0, 0);
+            card.addView(progress, progressParams);
+            status = Ui.text(this, "", 13, Ui.secondaryText(dark));
+            LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(-1, -2);
+            statusParams.setMargins(0, Ui.dp(this, 10), 0, 0);
+            card.addView(status, statusParams);
+        }
         content.addView(card);
 
         if (!release.notes.isEmpty()) {
@@ -169,7 +192,7 @@ public final class UpdateActivity extends AppCompatActivity {
             headingParams.setMargins(Ui.dp(this, 4), Ui.dp(this, 24), 0, Ui.dp(this, 10));
             content.addView(heading, headingParams);
             LinearLayout notesCard = Ui.card(this, dark);
-            notesCard.addView(Ui.text(this, release.notes, 14, Ui.mainText(dark)));
+            notesCard.addView(ReleaseNotesUi.create(this, release.notes, dark));
             content.addView(notesCard);
         }
 
@@ -206,7 +229,8 @@ public final class UpdateActivity extends AppCompatActivity {
     }
 
     private void requestInstall() {
-        if (operationRunning) {
+        if (operationRunning || release == null
+                || ReleaseUpdatePolicy.isIrreversible(release.version)) {
             return;
         }
         UpdatePreferences.setInstallError(this, "");
@@ -239,7 +263,8 @@ public final class UpdateActivity extends AppCompatActivity {
     }
 
     private void beginInstall() {
-        if (operationRunning || release == null) {
+        if (operationRunning || release == null
+                || ReleaseUpdatePolicy.isIrreversible(release.version)) {
             return;
         }
         operationRunning = true;
@@ -293,6 +318,19 @@ public final class UpdateActivity extends AppCompatActivity {
                     }
                 })
                 .show();
+    }
+
+    private void openReleasePage() {
+        String url = release == null ? "" : release.pageUrl;
+        if (url.isEmpty() && release != null) {
+            url = release.apkUrl;
+        }
+        try {
+            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+        } catch (RuntimeException exception) {
+            Toast.makeText(this, "No browser can open the GitHub release page.",
+                    Toast.LENGTH_LONG).show();
+        }
     }
 
     private static String safeMessage(Exception exception) {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -42,6 +42,8 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubRelease.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
@@ -71,6 +73,20 @@ grep -q 'ReleaseUpdateJobService' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'WidgetRepairJobService' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'UpdateInstallReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ReleaseHistoryActivity' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'ReleaseNotesMarkdown.toHtml' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesUi.java"
+grep -q 'ReleaseNotesUi.create' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java"
+grep -q 'ReleaseNotesUi.create' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java"
+grep -q 'FIRST_IN_APP_UPDATE_VERSION = "2.3.0"' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java"
+grep -q 'isIrreversible' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java"
+grep -q 'Open on GitHub' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java"
+grep -q 'Open on GitHub' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java"
 grep -q 'com.samsung.android.support.ongoing_activity' "$ROOT/app/src/main/AndroidManifest.xml"
 
 grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -27,6 +27,8 @@ public final class ParserSelfTest {
         testReleaseVersions();
         testGitHubReleases();
         testReleaseChecksums();
+        testReleaseNotesMarkdown();
+        testReleaseUpdatePolicy();
         System.out.println("All parser, updater, OAuth, onboarding, and widget-option self-tests passed.");
     }
 
@@ -416,6 +418,59 @@ public final class ParserSelfTest {
         check(ReleaseIntegrity.expectedSha256(checksums + digest
                         + "  CodexMeter-2.2.0.apk\n", "CodexMeter-2.2.0.apk").isEmpty(),
                 "duplicate APK checksum rejected");
+    }
+
+    private static void testReleaseNotesMarkdown() {
+        String html = ReleaseNotesMarkdown.toHtml("### Fixed\n\n"
+                + "- Improved reset-duration contrast (#23).\n"
+                + "- Restored in-app update discovery (#24).\n\n"
+                + "### Development\n\n"
+                + "- Centralized production GitHub release URLs (#24).\n\n"
+                + "**Full Changelog**: https://github.com/example/Codex-Meter/compare/v2.2.0...v2.3.0 "
+                + "<!-- pragma: allowlist secret -->");
+        check(html.contains("<p><b>Fixed</b></p>"), "markdown heading rendered");
+        check(html.contains("<ul>"), "markdown list opened");
+        check(html.contains("<li>Improved reset-duration contrast (#23).</li>"),
+                "markdown bullet rendered");
+        check(html.contains("<li>Restored in-app update discovery (#24).</li>"),
+                "second markdown bullet rendered");
+        check(html.contains("<p><b>Development</b></p>"), "second markdown heading rendered");
+        check(html.contains("<b>Full Changelog</b>"), "markdown bold rendered");
+        check(html.contains("<a href=\"https://github.com/example/Codex-Meter/compare/v2.2.0...v2.3.0\">"),
+                "markdown autolink rendered");
+        check(!html.contains("pragma"), "html comments stripped from release notes");
+        check(!html.contains("###"), "raw heading markers removed");
+        check(!html.contains("- Improved"), "raw bullet markers removed");
+
+        String linked = ReleaseNotesMarkdown.toHtml("See [the release](https://github.com/example/x).");
+        check(linked.contains("<a href=\"https://github.com/example/x\">the release</a>"),
+                "markdown link rendered");
+        check(ReleaseNotesMarkdown.toHtml("").isEmpty(), "empty notes stay empty");
+        check(ReleaseNotesMarkdown.toHtml("[bad](javascript:alert(1))")
+                        .contains("javascript:alert(1)"),
+                "unsafe markdown links stay plain text");
+        check(!ReleaseNotesMarkdown.toHtml("[bad](javascript:alert(1))").contains("<a "),
+                "unsafe markdown links are not anchored");
+    }
+
+    private static void testReleaseUpdatePolicy() {
+        check(ReleaseUpdatePolicy.isIrreversible("2.2.0"),
+                "pre-2.3.0 release is irreversible");
+        check(ReleaseUpdatePolicy.isIrreversible("v2.1.0"),
+                "tagged pre-2.3.0 release is irreversible");
+        check(ReleaseUpdatePolicy.isIrreversible("2.2.9"),
+                "latest pre-threshold release is irreversible");
+        check(!ReleaseUpdatePolicy.isIrreversible("2.3.0"),
+                "first in-app update release is reversible");
+        check(!ReleaseUpdatePolicy.isIrreversible("2.3.1"),
+                "post-threshold release is reversible");
+        check(!ReleaseUpdatePolicy.isIrreversible("not-a-version"),
+                "invalid versions are not flagged irreversible");
+        check(ReleaseUpdatePolicy.irreversibleSummary().contains("Manual GitHub"),
+                "irreversible summary mentions GitHub");
+        check(ReleaseUpdatePolicy.irreversibleDetail()
+                        .contains(ReleaseUpdatePolicy.FIRST_IN_APP_UPDATE_VERSION),
+                "irreversible detail cites threshold version");
     }
 
     private static String jwt(String payload) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Renders GitHub release-note Markdown (headings, lists, bold/italic, links, autolinks) in the App update **What's new** section instead of dumping raw markup.
- Shows the same rendered notes on each card in **Release history** so older changelogs are readable in-app.
- Treats every release **before 2.3.0** as irreversible: in-app install is blocked and users are sent to the GitHub release page, because those builds lacked a working in-app updater against the canonical repo.

## Verification
- `./run-tests.sh` passes, including new coverage for `ReleaseNotesMarkdown` and `ReleaseUpdatePolicy`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-204b1f42-217d-4e9a-ae0c-b03194af7abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-204b1f42-217d-4e9a-ae0c-b03194af7abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

