### PR TITLE
Add configurable Now Bar auto-start on low usage thresholds

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -59,6 +59,7 @@ public final class AppPreferences {
     public static void clearSnapshot(Context context) {
         prefs(context).edit().remove(KEY_SNAPSHOT).remove(KEY_ERROR).remove(KEY_ERROR_AT).remove(KEY_RESET_CREDITS).remove(KEY_RESET_ERROR).remove(KEY_RESET_ERROR_AT).apply();
         NowBarManager.stop(context);
+        NowBarPreferences.clearSuppression(context);
         ResetNotificationManager.clearState(context);
         ResetCreditExpiryScheduler.cancelAll(context);
     }

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarActionReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarActionReceiver.java
@@ -9,8 +9,10 @@ public final class NowBarActionReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         String action = intent == null ? "" : intent.getAction();
-        if (NowBarManager.ACTION_STOP.equals(action) || NowBarManager.ACTION_END.equals(action)) {
-            NowBarManager.stop(context);
+        if (NowBarManager.ACTION_STOP.equals(action)) {
+            NowBarManager.stop(context, true);
+        } else if (NowBarManager.ACTION_END.equals(action)) {
+            NowBarManager.stop(context, false);
         } else if (NowBarManager.ACTION_REFRESH.equals(action)) {
             RefreshScheduler.scheduleImmediate(context);
         }

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java
@@ -1,0 +1,51 @@
+package dev.bennett.codexmeter;
+
+/**
+ * Pure helpers for deciding when the live usage monitor should auto-start.
+ * Mirrors the low-usage notification metric and remaining-percentage threshold rules.
+ */
+public final class NowBarAutoStart {
+    public static final String METRIC_BOTH = "both";
+    public static final String METRIC_FIVE_HOUR = "five_hour";
+    public static final String METRIC_WEEKLY = "weekly";
+
+    private NowBarAutoStart() {
+    }
+
+    public static String normalizeMetric(String metric) {
+        if (METRIC_FIVE_HOUR.equals(metric) || METRIC_WEEKLY.equals(metric)) {
+            return metric;
+        }
+        return METRIC_BOTH;
+    }
+
+    public static boolean isValidThreshold(int threshold) {
+        return threshold == 10 || threshold == 25 || threshold == 50
+                || threshold == 75 || threshold == 100;
+    }
+
+    public static int normalizeThreshold(int threshold) {
+        return isValidThreshold(threshold) ? threshold : 25;
+    }
+
+    /**
+     * Returns true when auto-start is enabled and any watched usage window's remaining
+     * percentage is at or below the configured threshold.
+     */
+    public static boolean shouldStart(boolean enabled, String metric, int threshold,
+            UsageWindow fiveHour, UsageWindow weekly) {
+        if (!enabled || !isValidThreshold(threshold)) return false;
+        String normalized = normalizeMetric(metric);
+        if (!METRIC_WEEKLY.equals(normalized)
+                && fiveHour != null
+                && fiveHour.remainingPercent() <= threshold) {
+            return true;
+        }
+        if (!METRIC_FIVE_HOUR.equals(normalized)
+                && weekly != null
+                && weekly.remainingPercent() <= threshold) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -21,7 +21,11 @@ import androidx.annotation.RequiresApi;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-/** Posts a finite, user-initiated Live Update that Samsung may surface in the Now Bar. */
+/**
+ * Posts a finite Live Update that Samsung may surface in the Now Bar.
+ * Users can start it manually, or it can auto-start when remaining allowance hits a
+ * configured threshold (same metric/threshold pattern as low-usage notifications).
+ */
 public final class NowBarManager {
     static final String ACTION_END = "dev.bennett.codexmeter.action.NOW_BAR_END";
     static final String ACTION_REFRESH = "dev.bennett.codexmeter.action.NOW_BAR_REFRESH";
@@ -50,9 +54,10 @@ public final class NowBarManager {
         long now = System.currentTimeMillis();
         long until = snapshot.nextResetMillis(now);
         if (until <= now) return false;
+        NowBarPreferences.clearSuppression(context);
         saveState(context, false, until);
         if (post(context, snapshot, until, false)) return true;
-        stop(context);
+        stop(context, false);
         return false;
     }
 
@@ -63,44 +68,65 @@ public final class NowBarManager {
                 new UsageWindow(18, TimeUnit.DAYS.toSeconds(7),
                         TimeUnit.DAYS.toSeconds(4), (now + TimeUnit.DAYS.toMillis(4)) / 1000L),
                 now);
+        NowBarPreferences.clearSuppression(context);
         saveState(context, true, until);
         if (post(context, preview, until, true)) return true;
-        stop(context);
+        stop(context, false);
         return false;
     }
 
     public static synchronized void onUsageUpdated(Context context, UsageSnapshot snapshot) {
-        if (!hasStoredActiveState(context) || isPreview(context)) return;
-        if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
-            stop(context);
+        if (isPreview(context)) return;
+        if (hasStoredActiveState(context)) {
+            if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
+                stop(context, false);
+                return;
+            }
+            long now = System.currentTimeMillis();
+            long until = activeUntil(context);
+            if (until <= now) {
+                stop(context, false);
+                return;
+            }
+            if (!post(context, snapshot, until, false)) stop(context, false);
             return;
         }
-        long now = System.currentTimeMillis();
-        long until = activeUntil(context);
-        if (until <= now) {
-            stop(context);
-            return;
-        }
-        if (!post(context, snapshot, until, false)) stop(context);
+        maybeAutoStart(context, snapshot);
+    }
+
+    /**
+     * Starts the live monitor when auto-start is enabled, notifications are allowed,
+     * the user has not dismissed the current window, and remaining usage meets the threshold.
+     */
+    public static synchronized boolean maybeAutoStart(Context context, UsageSnapshot snapshot) {
+        if (context == null || isActive(context) || isPreview(context)) return false;
+        if (!NowBarPreferences.isAutoStartEnabled(context)) return false;
+        if (NowBarPreferences.isSuppressed(context)) return false;
+        if (!canPostNotifications(context)) return false;
+        if (!NowBarPreferences.meetsThreshold(context, snapshot)) return false;
+        return start(context);
     }
 
     public static synchronized void restore(Context context) {
-        if (!hasStoredActiveState(context)) return;
-        long until = activeUntil(context);
-        if (until <= System.currentTimeMillis()) {
-            stop(context);
-            return;
+        if (hasStoredActiveState(context)) {
+            long until = activeUntil(context);
+            if (until <= System.currentTimeMillis()) {
+                stop(context, false);
+            } else if (isPreview(context)) {
+                if (!startPreviewWithEnd(context, until)) stop(context, false);
+                else return;
+            } else {
+                UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
+                if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
+                    stop(context, false);
+                } else if (!post(context, snapshot, until, false)) {
+                    stop(context, false);
+                } else {
+                    return;
+                }
+            }
         }
-        if (isPreview(context)) {
-            if (!startPreviewWithEnd(context, until)) stop(context);
-            return;
-        }
-        UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
-        if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
-            stop(context);
-        } else {
-            if (!post(context, snapshot, until, false)) stop(context);
-        }
+        maybeAutoStart(context, AppPreferences.loadSnapshot(context));
     }
 
     private static boolean startPreviewWithEnd(Context context, long until) {
@@ -111,7 +137,17 @@ public final class NowBarManager {
     }
 
     public static synchronized void stop(Context context) {
+        stop(context, true);
+    }
+
+    public static synchronized void stop(Context context, boolean suppressAutoRestart) {
+        long until = activeUntil(context);
+        boolean wasActive = hasStoredActiveState(context);
         state(context).edit().clear().apply();
+        if (suppressAutoRestart && wasActive && until > System.currentTimeMillis()) {
+            // Respect an explicit stop/dismiss until the window would have ended anyway.
+            NowBarPreferences.markSuppressedUntil(context, until);
+        }
         NotificationManager manager = manager(context);
         if (manager != null) {
             try {
@@ -268,7 +304,8 @@ public final class NowBarManager {
     private static void createChannel(NotificationManager manager) {
         NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
                 "Codex live monitor", NotificationManager.IMPORTANCE_DEFAULT);
-        channel.setDescription("A user-started Codex allowance monitor that ends at the next reset");
+        channel.setDescription(
+                "Codex allowance monitor that ends at the next reset; may start from Settings or when remaining usage hits your threshold");
         channel.setSound(null, null);
         channel.enableVibration(false);
         channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java
@@ -1,0 +1,74 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * User settings for automatically starting the live usage monitor when allowance
+ * remaining drops to a configured threshold — same metric/threshold pattern as
+ * {@link ResetAlertPreferences} low-usage alerts.
+ */
+public final class NowBarPreferences {
+    private static final String KEY_AUTO_ENABLED = "auto_enabled";
+    private static final String KEY_METRIC = "metric";
+    private static final String KEY_SUPPRESS_UNTIL = "suppress_until";
+    private static final String KEY_THRESHOLD = "threshold";
+    private static final String PREFS = "codex_meter_now_bar_prefs_v1";
+
+    private NowBarPreferences() {
+    }
+
+    private static SharedPreferences prefs(Context context) {
+        return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    public static boolean isAutoStartEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_AUTO_ENABLED, false);
+    }
+
+    public static String getMetric(Context context) {
+        return NowBarAutoStart.normalizeMetric(prefs(context).getString(KEY_METRIC,
+                NowBarAutoStart.METRIC_BOTH));
+    }
+
+    public static int getThreshold(Context context) {
+        return NowBarAutoStart.normalizeThreshold(prefs(context).getInt(KEY_THRESHOLD, 25));
+    }
+
+    public static void save(Context context, boolean autoEnabled, String metric, int threshold) {
+        prefs(context).edit()
+                .putBoolean(KEY_AUTO_ENABLED, autoEnabled)
+                .putString(KEY_METRIC, NowBarAutoStart.normalizeMetric(metric))
+                .putInt(KEY_THRESHOLD, NowBarAutoStart.normalizeThreshold(threshold))
+                .apply();
+    }
+
+    public static void setAutoStartEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_AUTO_ENABLED, enabled).apply();
+    }
+
+    public static boolean meetsThreshold(Context context, UsageSnapshot snapshot) {
+        if (snapshot == null) return false;
+        long now = System.currentTimeMillis();
+        return NowBarAutoStart.shouldStart(isAutoStartEnabled(context), getMetric(context),
+                getThreshold(context),
+                UsageSnapshot.currentWindow(snapshot.fiveHour, now),
+                UsageSnapshot.currentWindow(snapshot.weekly, now));
+    }
+
+    public static boolean isSuppressed(Context context) {
+        return prefs(context).getLong(KEY_SUPPRESS_UNTIL, 0L) > System.currentTimeMillis();
+    }
+
+    public static void markSuppressedUntil(Context context, long untilMillis) {
+        if (untilMillis <= System.currentTimeMillis()) {
+            clearSuppression(context);
+            return;
+        }
+        prefs(context).edit().putLong(KEY_SUPPRESS_UNTIL, untilMillis).apply();
+    }
+
+    public static void clearSuppression(Context context) {
+        prefs(context).edit().remove(KEY_SUPPRESS_UNTIL).apply();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -56,6 +56,9 @@ public final class SettingsActivity extends AppCompatActivity {
         private Preference permissionPreference;
         private Preference testNotificationPreference;
         private SwitchPreferenceCompat nowBarMonitorPreference;
+        private SwitchPreferenceCompat nowBarAutoStartPreference;
+        private ListPreference nowBarMetricPreference;
+        private ListPreference nowBarThresholdPreference;
         private Preference nowBarPermissionPreference;
         private Preference updateStatusPreference;
 
@@ -511,7 +514,7 @@ public final class SettingsActivity extends AppCompatActivity {
             nowBarMonitorPreference.setOnPreferenceChangeListener((preference, value) -> {
                 boolean enabled = (Boolean) value;
                 if (!enabled) {
-                    NowBarManager.stop(requireContext());
+                    NowBarManager.stop(requireContext(), true);
                     updateNowBarSummary();
                     return true;
                 }
@@ -528,6 +531,39 @@ public final class SettingsActivity extends AppCompatActivity {
                     settingsView.postDelayed(this::updateNowBarSummary, 1500L);
                 }
                 return started;
+            });
+
+            nowBarAutoStartPreference = findPreference("now_bar_auto_start_ui");
+            nowBarAutoStartPreference.setPersistent(false);
+            nowBarAutoStartPreference.setChecked(
+                    NowBarPreferences.isAutoStartEnabled(requireContext()));
+            nowBarAutoStartPreference.setOnPreferenceChangeListener((preference, value) -> {
+                boolean enabled = (Boolean) value;
+                if (enabled && !ensureNotificationPermission()) return false;
+                saveNowBarAutoStart(enabled, NowBarPreferences.getMetric(requireContext()),
+                        NowBarPreferences.getThreshold(requireContext()));
+                return true;
+            });
+
+            nowBarMetricPreference = findPreference("now_bar_metric_ui");
+            nowBarMetricPreference.setPersistent(false);
+            nowBarMetricPreference.setValue(NowBarPreferences.getMetric(requireContext()));
+            nowBarMetricPreference.setOnPreferenceChangeListener((preference, value) -> {
+                saveNowBarAutoStart(NowBarPreferences.isAutoStartEnabled(requireContext()),
+                        String.valueOf(value),
+                        NowBarPreferences.getThreshold(requireContext()));
+                return true;
+            });
+
+            nowBarThresholdPreference = findPreference("now_bar_threshold_ui");
+            nowBarThresholdPreference.setPersistent(false);
+            nowBarThresholdPreference.setValue(
+                    String.valueOf(NowBarPreferences.getThreshold(requireContext())));
+            nowBarThresholdPreference.setOnPreferenceChangeListener((preference, value) -> {
+                saveNowBarAutoStart(NowBarPreferences.isAutoStartEnabled(requireContext()),
+                        NowBarPreferences.getMetric(requireContext()),
+                        Integer.parseInt(String.valueOf(value)));
+                return true;
             });
 
             Preference preview = findPreference("now_bar_preview");
@@ -559,7 +595,30 @@ public final class SettingsActivity extends AppCompatActivity {
                         .putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName()));
                 return true;
             });
+            updateNowBarAutoStartEnabledState();
             updateNowBarSummary();
+        }
+
+        private void saveNowBarAutoStart(boolean enabled, String metric, int threshold) {
+            NowBarPreferences.save(requireContext(), enabled, metric, threshold);
+            updateNowBarAutoStartEnabledState();
+            if (enabled) {
+                NowBarPreferences.clearSuppression(requireContext());
+                boolean started = NowBarManager.maybeAutoStart(requireContext(),
+                        AppPreferences.loadSnapshot(requireContext()));
+                if (started) {
+                    Toast.makeText(requireContext(),
+                            "Live monitor started from the current usage threshold.",
+                            Toast.LENGTH_SHORT).show();
+                }
+            }
+            updateNowBarSummary();
+        }
+
+        private void updateNowBarAutoStartEnabledState() {
+            boolean enabled = NowBarPreferences.isAutoStartEnabled(requireContext());
+            if (nowBarMetricPreference != null) nowBarMetricPreference.setEnabled(enabled);
+            if (nowBarThresholdPreference != null) nowBarThresholdPreference.setEnabled(enabled);
         }
 
         private boolean ensureNotificationPermission() {
@@ -592,9 +651,16 @@ public final class SettingsActivity extends AppCompatActivity {
                 nowBarMonitorPreference.setSummary(kind + " " + state + " · ends "
                         + UsageFormat.absolute(requireContext(), NowBarManager.activeUntil(requireContext()),
                         System.currentTimeMillis()));
+            } else if (NowBarPreferences.isAutoStartEnabled(requireContext())) {
+                nowBarMonitorPreference.setSummary(
+                        "Waiting to auto-start when remaining allowance hits the threshold");
             } else {
                 nowBarMonitorPreference.setSummary(
                         "Show remaining Codex allowance until the next available usage reset");
+            }
+            if (nowBarAutoStartPreference != null) {
+                nowBarAutoStartPreference.setChecked(
+                        NowBarPreferences.isAutoStartEnabled(requireContext()));
             }
             if (nowBarPermissionPreference != null) {
                 String summary;

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -102,6 +102,22 @@
             android:key="now_bar_monitor_ui"
             android:title="Monitor until reset"
             android:summary="Show remaining Codex allowance until the next available usage reset" />
+        <SwitchPreferenceCompat
+            android:key="now_bar_auto_start_ui"
+            android:title="Auto-start when low"
+            android:summary="Start the live monitor when remaining allowance hits the threshold below" />
+        <ListPreference
+            android:entries="@array/settings_metric_entries"
+            android:entryValues="@array/settings_metric_values"
+            android:key="now_bar_metric_ui"
+            android:title="Auto-start for"
+            app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:entries="@array/settings_threshold_entries"
+            android:entryValues="@array/settings_threshold_values"
+            android:key="now_bar_threshold_ui"
+            android:title="Start when remaining reaches"
+            app:useSimpleSummaryProvider="true" />
         <Preference
             android:key="now_bar_preview"
             android:title="Start sample preview"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -42,6 +42,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubRelease.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
@@ -97,6 +98,8 @@ grep -q 'EXTRA_PROMPT_USE_RESET' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarActionReceiver.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java"
 grep -q 'Build.VERSION.SDK_INT >= 36' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'codex_live_monitor_v2' \
@@ -120,6 +123,18 @@ grep -q 'hasStoredActiveState' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'NowBarManager.onUsageUpdated' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageApi.java"
+grep -q 'maybeAutoStart' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'now_bar_auto_start_ui' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'now_bar_threshold_ui' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'NowBarPreferences.isAutoStartEnabled' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'markSuppressedUntil' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'NowBarAutoStart.shouldStart' \
+  "$ROOT/tests/ParserSelfTest.java"
 
 grep -R -q '<Chronometer' "$ROOT/app/src/main/res/layout/widget_lock_"*.xml
 grep -q 'setChronometerCountDown' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -19,6 +19,7 @@ public final class ParserSelfTest {
         testCelebrationDetection();
         testResetCreditExpiryReminders();
         testFullWindowHidesResetCountdown();
+        testNowBarAutoStart();
         testJwtMerge();
         testPkce();
         testWidgetOptions();
@@ -40,6 +41,37 @@ public final class ParserSelfTest {
         check(almostFull.showsResetCountdown(), "99% remaining still shows reset countdown");
         check(used.showsResetCountdown(), "partial usage shows reset countdown");
         System.out.println("Reset-countdown demo: hide at 100% remaining, show again at 99% or less.");
+    }
+
+    private static void testNowBarAutoStart() {
+        UsageWindow high = new UsageWindow(10, 18000L, 600L, 2000000000L); // 90% remaining
+        UsageWindow mid = new UsageWindow(80, 18000L, 600L, 2000000000L); // 20% remaining
+        UsageWindow low = new UsageWindow(95, 604800L, 600L, 2000000000L); // 5% remaining
+
+        check(!NowBarAutoStart.shouldStart(false, "both", 25, mid, null),
+                "disabled auto-start never fires");
+        check(!NowBarAutoStart.shouldStart(true, "both", 25, high, high),
+                "above threshold does not start");
+        check(NowBarAutoStart.shouldStart(true, "both", 25, mid, high),
+                "five-hour at-or-below threshold starts for both");
+        check(NowBarAutoStart.shouldStart(true, "both", 25, high, low),
+                "weekly at-or-below threshold starts for both");
+        check(NowBarAutoStart.shouldStart(true, "five_hour", 25, mid, high),
+                "five-hour metric watches five-hour only");
+        check(!NowBarAutoStart.shouldStart(true, "five_hour", 25, high, low),
+                "five-hour metric ignores weekly");
+        check(NowBarAutoStart.shouldStart(true, "weekly", 10, high, low),
+                "weekly metric watches weekly only");
+        check(!NowBarAutoStart.shouldStart(true, "weekly", 10, mid, high),
+                "weekly metric ignores five-hour");
+        check(NowBarAutoStart.shouldStart(true, "both", 100, high, high),
+                "Always threshold starts whenever a window exists");
+        check(!NowBarAutoStart.shouldStart(true, "both", 25, null, null),
+                "missing windows do not start");
+        check("both".equals(NowBarAutoStart.normalizeMetric("nope")), "invalid metric falls back");
+        check(NowBarAutoStart.normalizeThreshold(3) == 25, "invalid threshold falls back");
+        check(NowBarAutoStart.isValidThreshold(50), "50 is a valid threshold");
+        System.out.println("Now Bar auto-start threshold rules match low-usage alert semantics.");
     }
 
     private static void testStandardUsage() throws Exception {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The live usage monitor / Now Bar can now auto-start when remaining allowance hits a configurable threshold, using the same metric + remaining-percentage pattern as low-usage notifications.

### Behavior
- New Settings → Now Bar options:
  - **Auto-start when low**
  - **Auto-start for** (Both / 5-hour / Weekly)
  - **Start when remaining reaches** (Always / 10% / 25% / 50% / 75%)
- On each usage refresh (and after reboot restore), if auto-start is enabled and a watched window is at/below the threshold, the live monitor starts.
- Once started it keeps going until the next reset, the user stops/dismisses it, or sign-out clears it.
- Explicit stop/dismiss suppresses auto-restart for the remainder of that monitor window so it does not immediately pop back up.

### Implementation
- `NowBarAutoStart` — pure threshold/metric decision logic (self-tested)
- `NowBarPreferences` — persistence for auto-start settings + dismiss suppression
- `NowBarManager.maybeAutoStart()` wired from usage updates and boot restore
- Settings UI mirrors the existing notification threshold controls

### Verification
- Merged latest `origin/main` (release-notes Markdown / update-policy work from #25)
- Resolved one simple additive conflict in `run-tests.sh` javac inputs
- `./run-tests.sh` passes (Now Bar auto-start + release-notes/update-policy self-tests and source guards)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-029eaea9-259b-45d4-b7f1-aef077a5bb95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-029eaea9-259b-45d4-b7f1-aef077a5bb95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

