### PR TITLE
Restore Samsung Now Bar compatibility

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -33,6 +33,7 @@ public final class NowBarManager {
 
     private static final String CHANNEL_ID = "codex_live_monitor_v2";
     private static final String EXTRA_REQUEST_PROMOTED_ONGOING = "android.requestPromotedOngoing";
+    private static final String SAMSUNG_ONGOING_PREFIX = "android.ongoingActivityNoti.";
     private static final String KEY_ACTIVE = "active";
     private static final String KEY_PREVIEW = "preview";
     private static final String KEY_UNTIL = "until";
@@ -262,6 +263,7 @@ public final class NowBarManager {
             Api36.applyLiveUpdateStyle(context, builder, used,
                     (fiveHour == null ? "W " : "") + remaining + "%");
         }
+        addSamsungOngoingActivityExtras(context, builder, fiveHour, weekly, used);
         final Notification notification;
         try {
             notification = builder.build();
@@ -294,6 +296,50 @@ public final class NowBarManager {
             Log.w(TAG, "Could not schedule live monitor expiry", exception);
         }
         return true;
+    }
+
+    /**
+     * Supplies One UI's expanded and collapsed Now Bar fields while retaining the public
+     * Android Live Update style above. Samsung devices that do not consume these extras simply
+     * ignore them and continue to render the standard ongoing notification.
+     */
+    private static void addSamsungOngoingActivityExtras(Context context,
+            Notification.Builder builder, UsageWindow fiveHour, UsageWindow weekly, int used) {
+        if (fiveHour == null && weekly == null) return;
+        Icon icon = Icon.createWithResource(context, R.drawable.ic_notification);
+        String fiveHourText = limitText("5-hour", fiveHour);
+        String weeklyText = limitText("Weekly", weekly);
+        boolean hasBothWindows = fiveHour != null && weekly != null;
+        String focusLabel = fiveHour != null ? "5-hour" : "Weekly";
+        String primaryText = fiveHour != null ? fiveHourText : weeklyText;
+        String secondaryText = hasBothWindows ? weeklyText : null;
+        String combinedText = hasBothWindows ? fiveHourText + " · " + weeklyText : primaryText;
+        int focusRemaining = fiveHour != null
+                ? fiveHour.remainingPercent() : weekly.remainingPercent();
+
+        Bundle samsungExtras = new Bundle();
+        samsungExtras.putInt(SAMSUNG_ONGOING_PREFIX + "style", 1);
+        samsungExtras.putParcelable(SAMSUNG_ONGOING_PREFIX + "chipIcon", icon);
+        samsungExtras.putInt(SAMSUNG_ONGOING_PREFIX + "chipBgColor",
+                Color.rgb(56, 122, 255));
+        samsungExtras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "chipExpandedText",
+                "Codex · " + focusLabel + " " + focusRemaining + "%");
+        samsungExtras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "primaryInfo",
+                combinedText);
+        samsungExtras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "secondaryInfo",
+                hasBothWindows ? "Both usage windows" : focusLabel + " usage window");
+        samsungExtras.putString(SAMSUNG_ONGOING_PREFIX + "description",
+                "Codex usage limits");
+        samsungExtras.putInt(SAMSUNG_ONGOING_PREFIX + "progress", used);
+        samsungExtras.putInt(SAMSUNG_ONGOING_PREFIX + "progressMax", 100);
+        samsungExtras.putParcelable(SAMSUNG_ONGOING_PREFIX + "nowbarIcon", icon);
+        samsungExtras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarPrimaryInfo", primaryText);
+        if (secondaryText != null) {
+            samsungExtras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarSecondaryInfo",
+                    secondaryText);
+        }
+        samsungExtras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarIconType", "progress");
+        builder.addExtras(samsungExtras);
     }
 
     private static String limitText(String label, UsageWindow window) {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -124,11 +124,22 @@ grep -q 'NotificationManager.IMPORTANCE_DEFAULT' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'setSmallIcon(R.drawable.ic_notification)' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
-if grep -q 'android.ongoingActivityNoti.' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"; then
-  echo "Legacy Samsung notification extras must not be mixed with Android Live Updates" >&2
-  exit 1
-fi
+grep -q 'android.ongoingActivityNoti.' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'addSamsungOngoingActivityExtras' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'nowbarPrimaryInfo' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'nowbarSecondaryInfo' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'fiveHour == null && weekly == null' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'String primaryText = fiveHour != null ? fiveHourText : weeklyText' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'if (secondaryText != null)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'builder.addExtras(samsungExtras)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'setDeleteIntent(stopIntent)' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'FLAG_PROMOTED_ONGOING' \


### PR DESCRIPTION
## Summary

- restore Samsung's `android.ongoingActivityNoti.*` payload alongside Android 16's public `ProgressStyle`
- supply separate collapsed and expanded Now Bar values for the 5-hour and weekly usage windows
- make weekly-only and 5-hour-only responses show only the window that actually exists instead of an unavailable placeholder
- update the source regression checks so the Samsung compatibility payload cannot be removed accidentally again

## Regression

The v2.3.1 notification still posts as a standard ongoing Android Live Update, but One UI no longer adds Codex Meter to its Now Bar list. The regression lines up with #21 removing the Samsung extras and adding a test that prohibited combining them with the public API.

This keeps the public Android 16 implementation intact. Samsung devices consume the additional OEM fields; other Android devices ignore them.

## Validation

- `./run-tests.sh`
- `./gradlew :app:assembleDebug :app:lintRelease --no-daemon --console=plain`
- side-by-side `2.3.1-debug` installed successfully on a Samsung SM-S928W without replacing the Play Store app
- `POST_NOTIFICATION` and `POST_PROMOTED_NOTIFICATIONS` are allowed for the debug package
- with the device's current values, notification extras contain `5-hour: 100% left` as `nowbarPrimaryInfo` and `Weekly: 93% left` as `nowbarSecondaryInfo`
- Samsung SystemUI reports `isNowBarVisible = true`, `hasNowBarPrimary = true`, and `hasNowBarSecondary = true`
- tapping the card changes Samsung SystemUI to `isNowBarExpanded = true`
- a weekly-only device snapshot keeps the Now Bar visible with `Weekly: 93% left` as the sole primary value and no `nowbarSecondaryInfo` placeholder

The Play Store app remains installed and unchanged throughout this verification.
