### PR TITLE
Add Samsung Now Bar compatibility modes

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java
@@ -1,0 +1,32 @@
+package dev.bennett.codexmeter;
+
+/** Selects one mutually exclusive notification contract for the live usage monitor. */
+public final class NowBarDisplayMode {
+    public static final String AUTO = "auto";
+    public static final String ANDROID_LIVE_UPDATE = "android_live_update";
+    public static final String SAMSUNG_COMPATIBILITY = "samsung_compatibility";
+
+    private NowBarDisplayMode() {
+    }
+
+    public static String normalize(String mode) {
+        if (ANDROID_LIVE_UPDATE.equals(mode) || SAMSUNG_COMPATIBILITY.equals(mode)) {
+            return mode;
+        }
+        return AUTO;
+    }
+
+    /**
+     * Samsung currently gates Android 16 Live Updates by firmware policy. In automatic mode,
+     * use its private compatibility payload only when the platform promotion path is unavailable.
+     */
+    public static String resolve(String selectedMode, boolean samsungDevice, int sdkInt,
+            boolean canPostPromotedNotifications) {
+        String normalized = normalize(selectedMode);
+        if (!AUTO.equals(normalized)) return normalized;
+        if (samsungDevice && (sdkInt < 36 || !canPostPromotedNotifications)) {
+            return SAMSUNG_COMPATIBILITY;
+        }
+        return ANDROID_LIVE_UPDATE;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -352,6 +352,10 @@ public final class NowBarManager {
         String weeklyText = limitText("Weekly", weekly);
         int focusRemaining = fiveHour != null ? fiveHour.remainingPercent()
                 : weekly == null ? 0 : weekly.remainingPercent();
+        String availableWindows = fiveHour != null && weekly != null
+                ? "Both usage windows"
+                : fiveHour != null ? "5-hour window"
+                : weekly != null ? "Weekly window" : "Usage window unavailable";
         Icon icon = Icon.createWithResource(context, R.drawable.ic_notification);
         Bundle extras = new Bundle();
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "style", 1);
@@ -362,7 +366,7 @@ public final class NowBarManager {
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "primaryInfo",
                 fiveHourText + " · " + weeklyText);
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "secondaryInfo",
-                "Both usage windows");
+                availableWindows);
         extras.putString(SAMSUNG_ONGOING_PREFIX + "description", "Codex usage limits");
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "progress", used);
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "progressMax", 100);

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -138,10 +138,16 @@ public final class NowBarManager {
             stop(context, false);
             return false;
         }
-        if (isPreview(context)) return startPreviewWithEnd(context, until);
-        UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
-        return snapshot != null && (snapshot.fiveHour != null || snapshot.weekly != null)
-                && post(context, snapshot, until, false);
+        boolean posted;
+        if (isPreview(context)) {
+            posted = startPreviewWithEnd(context, until);
+        } else {
+            UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
+            posted = snapshot != null && (snapshot.fiveHour != null || snapshot.weekly != null)
+                    && post(context, snapshot, until, false);
+        }
+        if (!posted) stop(context, false);
+        return posted;
     }
 
     private static boolean startPreviewWithEnd(Context context, long until) {

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -34,6 +34,7 @@ public final class NowBarManager {
     private static final String CHANNEL_ID = "codex_live_monitor_v2";
     private static final String EXTRA_REQUEST_PROMOTED_ONGOING = "android.requestPromotedOngoing";
     private static final String KEY_ACTIVE = "active";
+    private static final String KEY_POSTED_MODE = "posted_mode";
     private static final String KEY_PREVIEW = "preview";
     private static final String KEY_UNTIL = "until";
     private static final int NOTIFICATION_ID = 8610;
@@ -41,6 +42,7 @@ public final class NowBarManager {
     private static final int REQUEST_REFRESH = 8612;
     private static final int REQUEST_STOP = 8613;
     private static final String PREFS = "codex_meter_now_bar_v1";
+    private static final String SAMSUNG_ONGOING_PREFIX = "android.ongoingActivityNoti.";
     private static final String TAG = "CodexNowBar";
 
     private NowBarManager() {
@@ -129,6 +131,19 @@ public final class NowBarManager {
         maybeAutoStart(context, AppPreferences.loadSnapshot(context));
     }
 
+    public static synchronized boolean repostActive(Context context) {
+        if (!hasStoredActiveState(context)) return false;
+        long until = activeUntil(context);
+        if (until <= System.currentTimeMillis()) {
+            stop(context, false);
+            return false;
+        }
+        if (isPreview(context)) return startPreviewWithEnd(context, until);
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
+        return snapshot != null && (snapshot.fiveHour != null || snapshot.weekly != null)
+                && post(context, snapshot, until, false);
+    }
+
     private static boolean startPreviewWithEnd(Context context, long until) {
         long now = System.currentTimeMillis();
         UsageSnapshot preview = new UsageSnapshot("plus", true, false, null,
@@ -181,10 +196,14 @@ public final class NowBarManager {
 
     public static boolean canPostNotifications(Context context) {
         NotificationManager manager = manager(context);
-        return manager != null && manager.areNotificationsEnabled()
-                && (Build.VERSION.SDK_INT < 33
-                || context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
-                == PackageManager.PERMISSION_GRANTED);
+        if (manager == null || !manager.areNotificationsEnabled()
+                || (Build.VERSION.SDK_INT >= 33
+                && context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+                != PackageManager.PERMISSION_GRANTED)) {
+            return false;
+        }
+        NotificationChannel channel = manager.getNotificationChannel(CHANNEL_ID);
+        return channel == null || channel.getImportance() != NotificationManager.IMPORTANCE_NONE;
     }
 
     public static boolean canPostPromotedNotifications(Context context) {
@@ -197,6 +216,22 @@ public final class NowBarManager {
         NotificationManager manager = manager(context);
         return Build.VERSION.SDK_INT >= 36 && manager != null
                 && Api36.isPostedNotificationPromoted(manager, NOTIFICATION_ID);
+    }
+
+    public static String postedDisplayMode(Context context) {
+        String posted = state(context).getString(KEY_POSTED_MODE, null);
+        return posted == null ? resolveDisplayMode(context) : NowBarDisplayMode.normalize(posted);
+    }
+
+    private static String resolveDisplayMode(Context context) {
+        return NowBarDisplayMode.resolve(NowBarPreferences.getDisplayMode(context),
+                isSamsungDevice(), Build.VERSION.SDK_INT,
+                canPostPromotedNotifications(context));
+    }
+
+    private static boolean isSamsungDevice() {
+        return "samsung".equalsIgnoreCase(Build.MANUFACTURER)
+                || "samsung".equalsIgnoreCase(Build.BRAND);
     }
 
     private static boolean post(Context context, UsageSnapshot snapshot, long until,
@@ -236,6 +271,7 @@ public final class NowBarManager {
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         Icon stopActionIcon = Icon.createWithResource(context, R.drawable.ic_notification);
         Icon refreshActionIcon = Icon.createWithResource(context, R.drawable.ic_refresh);
+        String displayMode = resolveDisplayMode(context);
 
         Notification.Builder builder = new Notification.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notification)
@@ -255,12 +291,17 @@ public final class NowBarManager {
             builder.addAction(new Notification.Action.Builder(
                     refreshActionIcon, "Refresh", refreshIntent).build());
         }
-        Bundle promotionExtras = new Bundle();
-        promotionExtras.putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true);
-        builder.addExtras(promotionExtras);
-        if (Build.VERSION.SDK_INT >= 36) {
-            Api36.applyLiveUpdateStyle(context, builder, used,
-                    (fiveHour == null ? "W " : "") + remaining + "%");
+        if (NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(displayMode)) {
+            applySamsungCompatibility(context, builder, fiveHour, weekly, used, until, now,
+                    preview);
+        } else {
+            Bundle promotionExtras = new Bundle();
+            promotionExtras.putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true);
+            builder.addExtras(promotionExtras);
+            if (Build.VERSION.SDK_INT >= 36) {
+                Api36.applyLiveUpdateStyle(context, builder, used,
+                        (fiveHour == null ? "W " : "") + remaining + "%");
+            }
         }
         final Notification notification;
         try {
@@ -271,12 +312,14 @@ public final class NowBarManager {
         }
         boolean promotable = Build.VERSION.SDK_INT >= 36
                 && Api36.hasPromotableCharacteristics(notification);
-        Log.i(TAG, "Posting live monitor: promotable=" + promotable
+        Log.i(TAG, "Posting live monitor: mode=" + displayMode + " promotable=" + promotable
                 + " allowed=" + canPostPromotedNotifications(context)
                 + " preview=" + preview + " remaining=" + remaining);
         try {
             manager.notify(NOTIFICATION_ID, notification);
-            if (Build.VERSION.SDK_INT >= 36) {
+            state(context).edit().putString(KEY_POSTED_MODE, displayMode).apply();
+            if (Build.VERSION.SDK_INT >= 36
+                    && NowBarDisplayMode.ANDROID_LIVE_UPDATE.equals(displayMode)) {
                 new Handler(Looper.getMainLooper()).postDelayed(
                         () -> Api36.logPostedPromotionState(manager, NOTIFICATION_ID), 1000L);
             }
@@ -294,6 +337,42 @@ public final class NowBarManager {
             Log.w(TAG, "Could not schedule live monitor expiry", exception);
         }
         return true;
+    }
+
+    private static void applySamsungCompatibility(Context context, Notification.Builder builder,
+            UsageWindow fiveHour, UsageWindow weekly, int used, long until, long now,
+            boolean preview) {
+        String fiveHourText = limitText("5-hour", fiveHour);
+        String weeklyText = limitText("Weekly", weekly);
+        int focusRemaining = fiveHour != null ? fiveHour.remainingPercent()
+                : weekly == null ? 0 : weekly.remainingPercent();
+        Icon icon = Icon.createWithResource(context, R.drawable.ic_notification);
+        Bundle extras = new Bundle();
+        extras.putInt(SAMSUNG_ONGOING_PREFIX + "style", 1);
+        extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "chipIcon", icon);
+        extras.putInt(SAMSUNG_ONGOING_PREFIX + "chipBgColor", Color.rgb(56, 122, 255));
+        extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "chipExpandedText",
+                "Codex · " + (fiveHour == null ? "Weekly " : "5-hour ") + focusRemaining + "%");
+        extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "primaryInfo",
+                fiveHourText + " · " + weeklyText);
+        extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "secondaryInfo",
+                "Both usage windows");
+        extras.putString(SAMSUNG_ONGOING_PREFIX + "description", "Codex usage limits");
+        extras.putInt(SAMSUNG_ONGOING_PREFIX + "progress", used);
+        extras.putInt(SAMSUNG_ONGOING_PREFIX + "progressMax", 100);
+        extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "nowbarIcon", icon);
+        extras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarPrimaryInfo", fiveHourText);
+        extras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarSecondaryInfo", weeklyText);
+        extras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarIconType", "progress");
+        builder.addExtras(extras)
+                .setSubText(preview ? "Now Bar preview" : "Until the next usage reset")
+                .setProgress(100, used, false)
+                .setCategory(Notification.CATEGORY_STATUS)
+                .setShowWhen(true)
+                .setWhen(until)
+                .setUsesChronometer(true)
+                .setChronometerCountDown(true)
+                .setTimeoutAfter(Math.max(1L, until - now));
     }
 
     private static String limitText(String label, UsageWindow window) {

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java
@@ -10,6 +10,7 @@ import android.content.SharedPreferences;
  */
 public final class NowBarPreferences {
     private static final String KEY_AUTO_ENABLED = "auto_enabled";
+    private static final String KEY_DISPLAY_MODE = "display_mode";
     private static final String KEY_METRIC = "metric";
     private static final String KEY_SUPPRESS_UNTIL = "suppress_until";
     private static final String KEY_THRESHOLD = "threshold";
@@ -24,6 +25,16 @@ public final class NowBarPreferences {
 
     public static boolean isAutoStartEnabled(Context context) {
         return prefs(context).getBoolean(KEY_AUTO_ENABLED, false);
+    }
+
+    public static String getDisplayMode(Context context) {
+        return NowBarDisplayMode.normalize(prefs(context).getString(KEY_DISPLAY_MODE,
+                NowBarDisplayMode.AUTO));
+    }
+
+    public static void setDisplayMode(Context context, String mode) {
+        prefs(context).edit().putString(KEY_DISPLAY_MODE,
+                NowBarDisplayMode.normalize(mode)).apply();
     }
 
     public static String getMetric(Context context) {

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -521,7 +521,7 @@ public final class SettingsActivity extends AppCompatActivity {
                 if (NowBarManager.isActive(requireContext())
                         && !NowBarManager.repostActive(requireContext())) {
                     Toast.makeText(requireContext(),
-                            "Could not refresh the active monitor with this display mode.",
+                            "Could not refresh this display mode, so the monitor was stopped.",
                             Toast.LENGTH_LONG).show();
                 }
                 updateNowBarSummary();
@@ -601,6 +601,12 @@ public final class SettingsActivity extends AppCompatActivity {
 
             nowBarPermissionPreference = findPreference("now_bar_permission");
             nowBarPermissionPreference.setOnPreferenceClickListener(preference -> {
+                if (!NowBarManager.canPostNotifications(requireContext())) {
+                    startActivity(new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                            .putExtra(Settings.EXTRA_APP_PACKAGE,
+                                    requireContext().getPackageName()));
+                    return true;
+                }
                 if (Build.VERSION.SDK_INT >= 36
                         && !NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
                         NowBarPreferences.getDisplayMode(requireContext()))) {

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -57,6 +57,7 @@ public final class SettingsActivity extends AppCompatActivity {
         private Preference testNotificationPreference;
         private SwitchPreferenceCompat nowBarMonitorPreference;
         private SwitchPreferenceCompat nowBarAutoStartPreference;
+        private ListPreference nowBarDisplayModePreference;
         private ListPreference nowBarMetricPreference;
         private ListPreference nowBarThresholdPreference;
         private Preference nowBarPermissionPreference;
@@ -509,6 +510,24 @@ public final class SettingsActivity extends AppCompatActivity {
         }
 
         private void bindNowBar() {
+            nowBarDisplayModePreference = findPreference("now_bar_display_mode_ui");
+            nowBarDisplayModePreference.setPersistent(false);
+            nowBarDisplayModePreference.setValue(
+                    NowBarPreferences.getDisplayMode(requireContext()));
+            nowBarDisplayModePreference.setOnPreferenceChangeListener((preference, value) -> {
+                String mode = NowBarDisplayMode.normalize(String.valueOf(value));
+                NowBarPreferences.setDisplayMode(requireContext(), mode);
+                nowBarDisplayModePreference.setValue(mode);
+                if (NowBarManager.isActive(requireContext())
+                        && !NowBarManager.repostActive(requireContext())) {
+                    Toast.makeText(requireContext(),
+                            "Could not refresh the active monitor with this display mode.",
+                            Toast.LENGTH_LONG).show();
+                }
+                updateNowBarSummary();
+                return true;
+            });
+
             nowBarMonitorPreference = findPreference("now_bar_monitor_ui");
             nowBarMonitorPreference.setPersistent(false);
             nowBarMonitorPreference.setOnPreferenceChangeListener((preference, value) -> {
@@ -582,7 +601,9 @@ public final class SettingsActivity extends AppCompatActivity {
 
             nowBarPermissionPreference = findPreference("now_bar_permission");
             nowBarPermissionPreference.setOnPreferenceClickListener(preference -> {
-                if (Build.VERSION.SDK_INT >= 36) {
+                if (Build.VERSION.SDK_INT >= 36
+                        && !NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
+                        NowBarManager.postedDisplayMode(requireContext()))) {
                     Intent promotion = new Intent(Settings.ACTION_APP_NOTIFICATION_PROMOTION_SETTINGS)
                             .putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName());
                     try {
@@ -595,8 +616,42 @@ public final class SettingsActivity extends AppCompatActivity {
                         .putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName()));
                 return true;
             });
+            findPreference("now_bar_setup_help").setOnPreferenceClickListener(preference -> {
+                showSamsungNowBarHelp();
+                return true;
+            });
             updateNowBarAutoStartEnabledState();
             updateNowBarSummary();
+        }
+
+        private void showSamsungNowBarHelp() {
+            new AlertDialog.Builder(requireContext())
+                    .setTitle("Samsung Now Bar setup")
+                    .setMessage("For Android Live Updates:\n"
+                            + "1. Open Settings > About phone/tablet > Software information.\n"
+                            + "2. Tap Build number seven times and confirm your screen lock.\n"
+                            + "3. Return to Settings > Developer options.\n"
+                            + "4. Turn on Live notifications for all apps.\n"
+                            + "5. Make sure Settings > Lock screen and AOD > Now bar is enabled.\n\n"
+                            + "If “Live notifications for all apps” is missing, select Samsung "
+                            + "compatibility above. Samsung changes third-party access by model, "
+                            + "region, and firmware build even when Android and One UI versions "
+                            + "match.\n\n"
+                            + "If both modes remain ordinary notifications, that firmware or "
+                            + "device does not expose a third-party Now Bar surface. Codex Meter "
+                            + "cannot override Samsung’s system allowlist.")
+                    .setNeutralButton("Developer options", (dialog, which) -> {
+                        try {
+                            startActivity(new Intent(
+                                    Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS));
+                        } catch (RuntimeException exception) {
+                            Toast.makeText(requireContext(),
+                                    "Developer options are not available on this firmware.",
+                                    Toast.LENGTH_LONG).show();
+                        }
+                    })
+                    .setPositiveButton("Done", null)
+                    .show();
         }
 
         private void saveNowBarAutoStart(boolean enabled, String metric, int threshold) {
@@ -643,7 +698,11 @@ public final class SettingsActivity extends AppCompatActivity {
             nowBarMonitorPreference.setChecked(active);
             if (active) {
                 String kind = NowBarManager.isPreview(requireContext()) ? "Sample preview" : "Live monitor";
-                String state = Build.VERSION.SDK_INT >= 36
+                boolean samsungCompatibility = NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
+                        NowBarManager.postedDisplayMode(requireContext()));
+                String state = samsungCompatibility
+                        ? "using Samsung compatibility"
+                        : Build.VERSION.SDK_INT >= 36
                         ? (NowBarManager.isPromoted(requireContext())
                         ? "promoted as a Live Update"
                         : "active, but not promoted by the system")
@@ -662,10 +721,17 @@ public final class SettingsActivity extends AppCompatActivity {
                 nowBarAutoStartPreference.setChecked(
                         NowBarPreferences.isAutoStartEnabled(requireContext()));
             }
+            if (nowBarDisplayModePreference != null) {
+                nowBarDisplayModePreference.setValue(
+                        NowBarPreferences.getDisplayMode(requireContext()));
+            }
             if (nowBarPermissionPreference != null) {
                 String summary;
                 if (!NowBarManager.canPostNotifications(requireContext())) {
                     summary = "App notifications disabled · tap to enable";
+                } else if (NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
+                        NowBarManager.postedDisplayMode(requireContext()))) {
+                    summary = "Samsung compatibility selected · firmware support required";
                 } else if (Build.VERSION.SDK_INT < 36) {
                     summary = "Notifications allowed · Live display depends on your device";
                 } else if (!NowBarManager.canPostPromotedNotifications(requireContext())) {

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -603,7 +603,7 @@ public final class SettingsActivity extends AppCompatActivity {
             nowBarPermissionPreference.setOnPreferenceClickListener(preference -> {
                 if (Build.VERSION.SDK_INT >= 36
                         && !NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
-                        NowBarManager.postedDisplayMode(requireContext()))) {
+                        NowBarPreferences.getDisplayMode(requireContext()))) {
                     Intent promotion = new Intent(Settings.ACTION_APP_NOTIFICATION_PROMOTION_SETTINGS)
                             .putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName());
                     try {
@@ -731,7 +731,10 @@ public final class SettingsActivity extends AppCompatActivity {
                     summary = "App notifications disabled · tap to enable";
                 } else if (NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
                         NowBarManager.postedDisplayMode(requireContext()))) {
-                    summary = "Samsung compatibility selected · firmware support required";
+                    summary = NowBarDisplayMode.AUTO.equals(
+                            NowBarPreferences.getDisplayMode(requireContext()))
+                            ? "Automatic · using Samsung fallback until Android access is allowed"
+                            : "Samsung compatibility selected · firmware support required";
                 } else if (Build.VERSION.SDK_INT < 36) {
                     summary = "Notifications allowed · Live display depends on your device";
                 } else if (!NowBarManager.canPostPromotedNotifications(requireContext())) {

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -738,7 +738,7 @@ public final class SettingsActivity extends AppCompatActivity {
             if (nowBarPermissionPreference != null) {
                 String summary;
                 if (!NowBarManager.canPostNotifications(requireContext())) {
-                    summary = "App notifications disabled · tap to enable";
+                    summary = "App or live-monitor notifications disabled · tap to enable";
                 } else if (NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
                         NowBarManager.postedDisplayMode(requireContext()))) {
                     summary = NowBarDisplayMode.AUTO.equals(

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -607,6 +607,10 @@ public final class SettingsActivity extends AppCompatActivity {
                                     requireContext().getPackageName()));
                     return true;
                 }
+                // AUTO deliberately keeps this screen reachable: a false promotion result can
+                // mean either user-disabled access or an OEM policy denial. The API cannot
+                // distinguish them, and routing by the Samsung fallback would prevent users
+                // from enabling Android Live Updates here.
                 if (Build.VERSION.SDK_INT >= 36
                         && !NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
                         NowBarPreferences.getDisplayMode(requireContext()))) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string-array name="now_bar_display_mode_entries">
+        <item>Automatic (recommended)</item>
+        <item>Android Live Update</item>
+        <item>Samsung compatibility</item>
+    </string-array>
+    <string-array name="now_bar_display_mode_values">
+        <item>auto</item>
+        <item>android_live_update</item>
+        <item>samsung_compatibility</item>
+    </string-array>
+
     <array name="widget_support_cell_sizes">
         <item>2x1</item>
         <item>2x2</item>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -98,6 +98,12 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Now Bar">
+        <ListPreference
+            android:entries="@array/now_bar_display_mode_entries"
+            android:entryValues="@array/now_bar_display_mode_values"
+            android:key="now_bar_display_mode_ui"
+            android:title="Display compatibility"
+            app:useSimpleSummaryProvider="true" />
         <SwitchPreferenceCompat
             android:key="now_bar_monitor_ui"
             android:title="Monitor until reset"
@@ -126,6 +132,11 @@
         <Preference
             android:key="now_bar_permission"
             android:title="Live notification access"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="now_bar_setup_help"
+            android:title="Samsung setup help"
+            android:summary="Developer options and firmware troubleshooting"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -43,6 +43,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
   "$ROOT/tests/ParserSelfTest.java"
@@ -116,6 +117,7 @@ test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarActionReceiver.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java"
 grep -q 'Build.VERSION.SDK_INT >= 36' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'codex_live_monitor_v2' \
@@ -124,11 +126,12 @@ grep -q 'NotificationManager.IMPORTANCE_DEFAULT' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'setSmallIcon(R.drawable.ic_notification)' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
-if grep -q 'android.ongoingActivityNoti.' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"; then
-  echo "Legacy Samsung notification extras must not be mixed with Android Live Updates" >&2
-  exit 1
-fi
+grep -q 'android.ongoingActivityNoti.' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'applySamsungCompatibility' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'NowBarDisplayMode.ANDROID_LIVE_UPDATE' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'setDeleteIntent(stopIntent)' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'FLAG_PROMOTED_ONGOING' \
@@ -151,6 +154,12 @@ grep -q 'markSuppressedUntil' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'NowBarAutoStart.shouldStart' \
   "$ROOT/tests/ParserSelfTest.java"
+grep -q 'NowBarDisplayMode.resolve' \
+  "$ROOT/tests/ParserSelfTest.java"
+grep -q 'now_bar_display_mode_ui' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'Live notifications for all apps' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 
 grep -R -q '<Chronometer' "$ROOT/app/src/main/res/layout/widget_lock_"*.xml
 grep -q 'setChronometerCountDown' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -20,6 +20,7 @@ public final class ParserSelfTest {
         testResetCreditExpiryReminders();
         testFullWindowHidesResetCountdown();
         testNowBarAutoStart();
+        testNowBarDisplayModes();
         testJwtMerge();
         testPkce();
         testWidgetOptions();
@@ -74,6 +75,29 @@ public final class ParserSelfTest {
         check(NowBarAutoStart.normalizeThreshold(3) == 25, "invalid threshold falls back");
         check(NowBarAutoStart.isValidThreshold(50), "50 is a valid threshold");
         System.out.println("Now Bar auto-start threshold rules match low-usage alert semantics.");
+    }
+
+    private static void testNowBarDisplayModes() {
+        check(NowBarDisplayMode.AUTO.equals(NowBarDisplayMode.normalize(null)),
+                "missing Now Bar mode defaults to automatic");
+        check(NowBarDisplayMode.AUTO.equals(NowBarDisplayMode.normalize("invalid")),
+                "invalid Now Bar mode defaults to automatic");
+        check(NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(NowBarDisplayMode.resolve(
+                        NowBarDisplayMode.AUTO, true, 36, false)),
+                "automatic mode falls back when Samsung blocks Android promotion");
+        check(NowBarDisplayMode.ANDROID_LIVE_UPDATE.equals(NowBarDisplayMode.resolve(
+                        NowBarDisplayMode.AUTO, true, 36, true)),
+                "automatic mode uses Android Live Update when Samsung allows promotion");
+        check(NowBarDisplayMode.ANDROID_LIVE_UPDATE.equals(NowBarDisplayMode.resolve(
+                        NowBarDisplayMode.AUTO, false, 36, false)),
+                "automatic mode does not send private Samsung extras to other devices");
+        check(NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(NowBarDisplayMode.resolve(
+                        NowBarDisplayMode.SAMSUNG_COMPATIBILITY, false, 36, true)),
+                "explicit Samsung compatibility override is preserved");
+        check(NowBarDisplayMode.ANDROID_LIVE_UPDATE.equals(NowBarDisplayMode.resolve(
+                        NowBarDisplayMode.ANDROID_LIVE_UPDATE, true, 35, false)),
+                "explicit Android Live Update override is preserved");
+        System.out.println("Now Bar display mode isolates Android and Samsung notification paths.");
     }
 
     private static void testStandardUsage() throws Exception {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Automatic, Android Live Update, and Samsung compatibility display modes
- keep Android 16 promotion and Samsung private ongoing-activity payloads mutually exclusive
- choose Samsung compatibility automatically when Samsung firmware denies platform promotion
- re-post active monitors safely when modes change and clear stale state on failure
- detect global and live-monitor-channel notification blocking and route users to app settings
- add in-app Samsung developer-options and firmware troubleshooting guidance
- test mode normalization and firmware-dependent resolution

## Root cause
PR #18 (`0346c41`) used Samsung's private `android.ongoingActivityNoti.*` contract and was verified on Canadian SM-S928W firmware. PR #21 (`002bff6`) intentionally removed that contract in favor of Android 16 Live Updates. Samsung gates the standardized path by model, region, and firmware; when `Live notifications for all apps` is missing or disabled, a valid Android Live Update can remain an ordinary notification.

Automatic mode now uses Android Live Update when `canPostPromotedNotifications()` grants access and uses the original Samsung-compatible contract on Samsung firmware when it does not. Manual overrides remain available for firmware that reports eligibility incorrectly.

## Review follow-up
- Samsung compatibility text reflects both-window, five-hour-only, weekly-only, and unavailable states.
- AUTO intentionally keeps Android promotion settings reachable because a false promotion result conflates user-disabled access with OEM denial; routing by the resolved fallback would prevent users from enabling promotion.
- blocked-notification summaries distinguish that either global app notifications or the live-monitor channel may be disabled.

## Testing
- `./run-tests.sh`
- `./build.sh`
- `./lint.sh`
- release APK builds and verifies with APK Signature Scheme v2
- GitHub build check passes
- Greptile review passes at 5/5 with no unresolved threads

## Hardware limitation
This VM has no Samsung device or Android emulator. Final rendering still requires testing the three modes on the affected Galaxy firmware; the app explains that firmware without either third-party path can only show the standard notification fallback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32bd1838-507c-4920-94bd-f990496f67f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32bd1838-507c-4920-94bd-f990496f67f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

