### PR TITLE
Prepare Codex Meter 2.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2.3.2 — 2026-07-15
+
+### Added
+
+- Automatic, Android Live Update, and Samsung compatibility display modes for the live usage monitor, including manual overrides for firmware that reports promotion support incorrectly (#29).
+- In-app diagnostics for blocked app or live-monitor notifications, plus Samsung developer-option and firmware troubleshooting guidance (#29).
+
+### Changed
+
+- Automatic mode now keeps Android 16 Live Update promotion and Samsung's private ongoing-activity payload mutually exclusive, selecting the Samsung-compatible path when Galaxy firmware denies platform promotion (#29).
+- Changing display modes safely re-posts an active monitor, while failed updates clear stale active state instead of leaving the monitor stuck (#29).
+
+### Fixed
+
+- Restored Now Bar presentation on compatible Samsung firmware where third-party Android Live Updates remain ordinary notifications, while retaining the standard notification fallback on unsupported firmware (#29).
+
+### Development
+
+- Added regression coverage for display-mode normalization and firmware-dependent mode resolution (#29).
+
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.3.1...v2.3.2 <!-- pragma: allowlist secret -->
+
 ## 2.3.1 — 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Codex Meter is an unofficial native Android application and widget for viewing the Codex allowance attached to a signed-in ChatGPT account. It displays the rolling five-hour and weekly limits, reset times, reset credits, home-screen widgets, Samsung One UI lock-screen widgets, and optional reset notifications.
 
-## Version 2.3.1
+## Version 2.3.2
 
-Version 2.3.1 adds configurable Now Bar auto-start on low usage thresholds, renders GitHub release notes as readable Markdown in-app, and blocks irreversible pre-2.3.0 installs through the updater.
+Version 2.3.2 adds firmware-aware Android Live Update and Samsung compatibility modes, safe live-monitor mode switching, and in-app notification and Now Bar troubleshooting.
 
 ### Live countdowns
 
@@ -68,7 +68,7 @@ Requirements:
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.3.1`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
+Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.3.2`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
 
 ## Platform stability
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 14
-        versionName = "2.3.1"
+        versionCode = 15
+        versionName = "2.3.2"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 14;
-    public static final String VERSION_NAME = "2.3.1";
+    public static final int VERSION_CODE = 15;
+    public static final String VERSION_NAME = "2.3.2";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.3.1 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.3.2 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.3.1"
+VERSION_NAME="2.3.2"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,12 +51,12 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.3.1"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 14' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.3.1"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 14' "$ROOT/app/build.gradle.kts"
-grep -q 'codex-meter-android/2.3.1' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.3.1"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.3.2"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 15' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.3.2"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 15' "$ROOT/app/build.gradle.kts"
+grep -q 'codex-meter-android/2.3.2' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.3.2"' "$ROOT/build.sh"
 grep -q 'BenItBuhner/Codex-Meter/releases?per_page=30' "$ROOT/app/build.gradle.kts" # pragma: allowlist secret
 ! grep -R -q 'thatjoshguy67/Codex-Meter' \
   "$ROOT/app/src" "$ROOT/app/build.gradle.kts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump the app, build output, user agent, and release guards to version code 15 / version 2.3.2
- document every merged change since v2.3.1 from PR #29
- update the README release summary and tag example for v2.3.2

## Release contents
- add Automatic, Android Live Update, and Samsung compatibility display modes
- select the firmware-appropriate promotion path while keeping Android and Samsung payloads mutually exclusive
- safely re-post active monitors after mode changes and clear stale state after failures
- diagnose blocked app/channel notifications and add Samsung firmware troubleshooting guidance
- restore Now Bar presentation on compatible Galaxy firmware where third-party Live Updates are not promoted
- expand regression coverage for mode normalization and firmware-dependent resolution

## Release boundary
`v2.3.1...HEAD` contains PR #29 only. No new first-time human contributor was identified for this interval.

The `v2.3.2` tag and GitHub release are intentionally not created by this PR.

## Testing
- `./run-tests.sh`
- `./lint.sh`
- `./build.sh`
- release metadata and CI changelog-extraction consistency check
- local release APK verifies with APK Signature Scheme v2 and is emitted as `CodexMeter-2.3.2.apk`
- GitHub Actions `Build Codex Meter APK / build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f767a77-e245-47ee-a751-9a8050d262f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f767a77-e245-47ee-a751-9a8050d262f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

