### PR TITLE
Add local Codex reset announcement watch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,11 @@ android {
             ?: "https://api.github.com/repos/BenItBuhner/Codex-Meter/releases?per_page=30" // pragma: allowlist secret
         buildConfigField("String", "UPDATE_API_URL",
             "\"${updateApiUrl.replace("\\", "\\\\").replace("\"", "\\\"")}\"")
+        val xClientId = providers.gradleProperty("xClientId").orNull
+            ?: System.getenv("X_CLIENT_ID")
+            ?: ""
+        buildConfigField("String", "X_CLIENT_ID",
+            "\"${xClientId.replace("\\", "\\\\").replace("\"", "\\\"")}\"")
     }
 
     buildFeatures {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,15 @@
                     android:host="auth"
                     android:pathPrefix="/complete"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="codexmeter"
+                    android:host="x-auth"
+                    android:path="/complete"/>
+            </intent-filter>
         </activity>
         <activity
             android:name="dev.bennett.codexmeter.OnboardingActivity"
@@ -276,6 +285,10 @@
             android:exported="false"/>
         <service
             android:name="dev.bennett.codexmeter.ReleaseUpdateJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"/>
+        <service
+            android:name="dev.bennett.codexmeter.ResetWatchJobService"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false"/>
         <service

--- a/app/src/main/java/dev/bennett/codexmeter/AnnouncementPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AnnouncementPreferences.java
@@ -1,0 +1,211 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/** Durable local state and user controls for the @thsottiaux reset watch. */
+public final class AnnouncementPreferences {
+    private static final String PREFS = "codex_meter_reset_watch_v1";
+    private static final String KEY_MONITORING = "monitoring";
+    private static final String KEY_INTERVAL = "interval_minutes";
+    private static final String KEY_NOTIFICATIONS = "notifications";
+    private static final String KEY_BANNER = "banner";
+    private static final String KEY_USER_ID = "x_user_id";
+    private static final String KEY_LAST_SEEN_ID = "last_seen_id";
+    private static final String KEY_POSTS = "posts";
+    private static final String KEY_LAST_CHECK = "last_check";
+    private static final String KEY_LAST_ERROR = "last_error";
+    private static final String KEY_DISMISSED = "dismissed";
+    private static final int MAX_POSTS = 20;
+    private static final long BANNER_MAX_AGE_MS = TimeUnit.HOURS.toMillis(72);
+
+    private AnnouncementPreferences() {
+    }
+
+    public static boolean monitoringEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_MONITORING, false);
+    }
+
+    public static void setMonitoringEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_MONITORING, enabled).apply();
+        if (!enabled) ResetWatchScheduler.cancel(context);
+    }
+
+    public static int intervalMinutes(Context context) {
+        return normalizeInterval(prefs(context).getInt(KEY_INTERVAL, 30));
+    }
+
+    public static void setIntervalMinutes(Context context, int minutes) {
+        prefs(context).edit().putInt(KEY_INTERVAL, normalizeInterval(minutes)).apply();
+    }
+
+    static int normalizeInterval(int minutes) {
+        return minutes == 60 ? 60 : 30;
+    }
+
+    public static boolean notificationsEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_NOTIFICATIONS, true);
+    }
+
+    public static void setNotificationsEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_NOTIFICATIONS, enabled).apply();
+        if (!enabled) ResetWatchNotificationManager.clearState(context);
+    }
+
+    public static boolean bannerEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_BANNER, true);
+    }
+
+    public static void setBannerEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_BANNER, enabled).apply();
+        broadcast(context);
+    }
+
+    public static String userId(Context context) {
+        return prefs(context).getString(KEY_USER_ID, "");
+    }
+
+    public static void setUserId(Context context, String id) {
+        if (!XTimelineParser.isValidPostId(id)) {
+            throw new IllegalArgumentException("X returned an invalid account ID.");
+        }
+        prefs(context).edit().putString(KEY_USER_ID, id).apply();
+    }
+
+    public static String lastSeenId(Context context) {
+        return prefs(context).getString(KEY_LAST_SEEN_ID, "");
+    }
+
+    public static boolean hasBaseline(Context context) {
+        return XTimelineParser.isValidPostId(lastSeenId(context));
+    }
+
+    public static long lastCheckMillis(Context context) {
+        return prefs(context).getLong(KEY_LAST_CHECK, 0L);
+    }
+
+    public static String lastError(Context context) {
+        return prefs(context).getString(KEY_LAST_ERROR, "");
+    }
+
+    public static void saveSuccess(Context context, List<XPost> incoming, String newestId)
+            throws Exception {
+        Map<String, XPost> merged = new LinkedHashMap<>();
+        if (incoming != null) {
+            for (XPost post : incoming) {
+                if (post != null) merged.put(post.id, post);
+            }
+        }
+        for (XPost post : posts(context)) {
+            if (!merged.containsKey(post.id)) merged.put(post.id, post);
+        }
+        ArrayList<XPost> sorted = new ArrayList<>(merged.values());
+        sorted.sort((left, right) -> -XTimelineParser.compareIds(left.id, right.id));
+        if (sorted.size() > MAX_POSTS) {
+            sorted = new ArrayList<>(sorted.subList(0, MAX_POSTS));
+        }
+        JSONArray stored = new JSONArray();
+        for (XPost post : sorted) stored.put(post.toJson());
+
+        String currentId = lastSeenId(context);
+        String nextId = XTimelineParser.compareIds(newestId, currentId) > 0
+                ? newestId : currentId;
+        SharedPreferences.Editor editor = prefs(context).edit()
+                .putString(KEY_POSTS, stored.toString())
+                .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
+                .remove(KEY_LAST_ERROR);
+        if (XTimelineParser.isValidPostId(nextId)) {
+            editor.putString(KEY_LAST_SEEN_ID, nextId);
+        }
+        editor.apply();
+        broadcast(context);
+    }
+
+    public static void saveError(Context context, String error) {
+        String message = error == null ? "" : error.trim();
+        if (message.isEmpty()) message = "Could not check X for Codex reset updates.";
+        if (message.length() > 240) message = message.substring(0, 240);
+        prefs(context).edit()
+                .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
+                .putString(KEY_LAST_ERROR, message)
+                .apply();
+        broadcast(context);
+    }
+
+    public static List<XPost> posts(Context context) {
+        String json = prefs(context).getString(KEY_POSTS, "[]");
+        try {
+            JSONArray array = new JSONArray(json == null ? "[]" : json);
+            ArrayList<XPost> parsed = new ArrayList<>();
+            for (int index = 0; index < array.length() && parsed.size() < MAX_POSTS; index++) {
+                JSONObject object = array.optJSONObject(index);
+                XPost post = XPost.fromJson(object);
+                if (post != null) parsed.add(post);
+            }
+            parsed.sort((left, right) -> -XTimelineParser.compareIds(left.id, right.id));
+            return Collections.unmodifiableList(parsed);
+        } catch (Exception exception) {
+            return Collections.emptyList();
+        }
+    }
+
+    public static XPost latestBanner(Context context) {
+        if (!bannerEnabled(context)) return null;
+        Set<String> dismissed = prefs(context).getStringSet(KEY_DISMISSED, new HashSet<>());
+        long now = System.currentTimeMillis();
+        for (XPost post : posts(context)) {
+            if (post.signal.isRelevant() && !dismissed.contains(post.id)
+                    && post.createdAtMillis > 0L
+                    && now - post.createdAtMillis <= BANNER_MAX_AGE_MS) {
+                return post;
+            }
+        }
+        return null;
+    }
+
+    public static void dismiss(Context context, String postId) {
+        if (!XTimelineParser.isValidPostId(postId)) return;
+        Set<String> dismissed = new HashSet<>(prefs(context)
+                .getStringSet(KEY_DISMISSED, new HashSet<>()));
+        dismissed.add(postId);
+        while (dismissed.size() > 50) {
+            dismissed.remove(dismissed.iterator().next());
+        }
+        prefs(context).edit().putStringSet(KEY_DISMISSED, dismissed).apply();
+        broadcast(context);
+    }
+
+    public static void clearRemoteState(Context context) {
+        prefs(context).edit()
+                .remove(KEY_USER_ID)
+                .remove(KEY_LAST_SEEN_ID)
+                .remove(KEY_POSTS)
+                .remove(KEY_LAST_CHECK)
+                .remove(KEY_LAST_ERROR)
+                .remove(KEY_DISMISSED)
+                .apply();
+        broadcast(context);
+    }
+
+    private static SharedPreferences prefs(Context context) {
+        Context app = context.getApplicationContext();
+        return (app == null ? context : app).getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    private static void broadcast(Context context) {
+        context.sendBroadcast(new android.content.Intent(AppConstants.ACTION_ANNOUNCEMENTS_UPDATED)
+                        .setPackage(context.getPackageName())
+                        .addFlags(android.content.Intent.FLAG_RECEIVER_REGISTERED_ONLY),
+                AppConstants.INTERNAL_PERMISSION);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -7,6 +7,8 @@ public final class AppConstants {
     public static final String ACTION_OAUTH_READY = "dev.bennett.codexmeter.action.OAUTH_READY";
     public static final String ACTION_OAUTH_RESULT = "dev.bennett.codexmeter.action.OAUTH_RESULT";
     public static final String ACTION_INSTALL_STATUS = "dev.bennett.codexmeter.action.INSTALL_STATUS";
+    public static final String ACTION_ANNOUNCEMENTS_UPDATED =
+            "dev.bennett.codexmeter.action.ANNOUNCEMENTS_UPDATED";
     public static final String ACTION_RELEASES_UPDATED = "dev.bennett.codexmeter.action.RELEASES_UPDATED";
     public static final String ACTION_REFRESH_WIDGET = "dev.bennett.codexmeter.action.REFRESH_WIDGET";
     public static final String ACTION_RESET_ALERT = "dev.bennett.codexmeter.action.RESET_ALERT";
@@ -46,5 +48,9 @@ public final class AppConstants {
 
     public static String updaterUserAgent() {
         return "codex-meter-android/" + VERSION_NAME + " updater";
+    }
+
+    public static String resetWatchUserAgent() {
+        return "codex-meter-android/" + VERSION_NAME + " reset-watch";
     }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
@@ -12,6 +12,7 @@ public final class BootReceiver extends BroadcastReceiver {
         if ("android.intent.action.BOOT_COMPLETED".equals(action) || "android.intent.action.MY_PACKAGE_REPLACED".equals(action)) {
             RefreshScheduler.schedulePeriodic(context);
             ReleaseUpdateScheduler.ensureScheduled(context);
+            ResetWatchScheduler.ensureScheduled(context);
             ResetAlertScheduler.scheduleFromSnapshot(context, AppPreferences.loadSnapshot(context));
             ResetCreditExpiryScheduler.scheduleFromSnapshot(context,
                     AppPreferences.loadResetCredits(context));

--- a/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -67,7 +67,8 @@ public final class MainActivity extends AppCompatActivity {
                 MainActivity.this.rebuild();
                 return;
             }
-            if (AppConstants.ACTION_RELEASES_UPDATED.equals(action)) {
+            if (AppConstants.ACTION_RELEASES_UPDATED.equals(action)
+                    || AppConstants.ACTION_ANNOUNCEMENTS_UPDATED.equals(action)) {
                 MainActivity.this.rebuild();
             }
         }
@@ -95,6 +96,7 @@ public final class MainActivity extends AppCompatActivity {
         rebuild();
         RefreshScheduler.schedulePeriodic(this);
         ReleaseUpdateScheduler.ensureScheduled(this);
+        ResetWatchScheduler.ensureScheduled(this);
     }
 
     @Override
@@ -148,6 +150,7 @@ public final class MainActivity extends AppCompatActivity {
         intentFilter.addAction(AppConstants.ACTION_USAGE_UPDATED);
         intentFilter.addAction(AppConstants.ACTION_RESET_CREDITS_UPDATED);
         intentFilter.addAction(AppConstants.ACTION_RELEASES_UPDATED);
+        intentFilter.addAction(AppConstants.ACTION_ANNOUNCEMENTS_UPDATED);
         try {
             if (Build.VERSION.SDK_INT >= 33) {
                 registerReceiver(this.authReceiver, intentFilter, "dev.bennett.codexmeter.permission.INTERNAL", null, 4);
@@ -198,6 +201,13 @@ public final class MainActivity extends AppCompatActivity {
             intent.removeExtra("start_sign_in");
         }
         Uri data = intent == null ? null : intent.getData();
+        if (data != null && "codexmeter".equals(data.getScheme())
+                && "x-auth".equals(data.getHost())
+                && "/complete".equals(data.getPath())) {
+            intent.setData(null);
+            completeXAuthentication(data);
+            return;
+        }
         if (data != null && "codexmeter".equals(data.getScheme()) && "auth".equals(data.getHost())) {
             if (SecureTokenStore.isSignedIn(this)) {
                 AppPreferences.setOAuthPending(this, false, "");
@@ -246,6 +256,11 @@ public final class MainActivity extends AppCompatActivity {
     public void rebuild() {
         if (this.content != null) {
             this.content.removeAllViews();
+            XPost announcement = AnnouncementPreferences.latestBanner(this);
+            if (announcement != null) {
+                this.content.addView(buildAnnouncementCard(announcement));
+                Ui.addSpacer(this.content, 20);
+            }
             GitHubRelease update = UpdatePreferences.availableUpdate(this);
             if (update != null) {
                 this.content.addView(buildUpdateCard(update));
@@ -262,6 +277,40 @@ public final class MainActivity extends AppCompatActivity {
             }
             this.content.addView(buildResetCreditsCard());
         }
+    }
+
+    private LinearLayout buildAnnouncementCard(XPost post) {
+        LinearLayout card = Ui.card(this, this.dark);
+        TextView title = Ui.text(this, post.signal.title(), 18, Ui.mainText(this.dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+
+        String detail = post.signal.likelihoodLabel() + " · local signal score "
+                + post.signal.likelihood + "/100 · @" + ResetWatchSource.HANDLE
+                + "\n" + post.text;
+        TextView summary = Ui.text(this, detail, 13, Ui.secondaryText(this.dark));
+        LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
+        summaryParams.setMargins(0, Ui.dp(this, 7), 0, Ui.dp(this, 14));
+        card.addView(summary, summaryParams);
+
+        LinearLayout actions = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
+        Button open = Ui.button(this, "Open on X", true, this.dark);
+        open.setOnClickListener(view -> {
+            try {
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(post.url)));
+            } catch (RuntimeException exception) {
+                Toast.makeText(this, "No browser is available.", Toast.LENGTH_SHORT).show();
+            }
+        });
+        actions.addView(open, new LinearLayout.LayoutParams(0, Ui.dp(this, 54), 1.0f));
+        Button dismiss = Ui.button(this, "Dismiss", false, this.dark);
+        LinearLayout.LayoutParams dismissParams =
+                new LinearLayout.LayoutParams(0, Ui.dp(this, 54), 1.0f);
+        dismissParams.setMargins(Ui.dp(this, 10), 0, 0, 0);
+        actions.addView(dismiss, dismissParams);
+        dismiss.setOnClickListener(view -> AnnouncementPreferences.dismiss(this, post.id));
+        card.addView(actions);
+        return card;
     }
 
     private LinearLayout buildUpdateCard(GitHubRelease release) {
@@ -499,6 +548,23 @@ public final class MainActivity extends AppCompatActivity {
             linearLayoutCard.addView(textViewText3, layoutParams2);
         }
         return linearLayoutCard;
+    }
+
+    private void completeXAuthentication(Uri callback) {
+        final Context applicationContext = getApplicationContext();
+        new Thread(() -> {
+            try {
+                XAuthentication.complete(applicationContext, callback);
+                runOnUiThread(() -> {
+                    Toast.makeText(this, "X connected. Reset watch is checking now.",
+                            Toast.LENGTH_LONG).show();
+                    rebuild();
+                });
+            } catch (Exception exception) {
+                runOnUiThread(() -> Toast.makeText(this,
+                        safeMessage(exception), Toast.LENGTH_LONG).show());
+            }
+        }, "x-oauth-exchange").start();
     }
 
     public void startOrContinueSignIn() {

--- a/app/src/main/java/dev/bennett/codexmeter/ResetAnnouncementClassifier.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetAnnouncementClassifier.java
@@ -1,0 +1,83 @@
+package dev.bennett.codexmeter;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Tiny, deterministic linear intent scorer for @thsottiaux posts.
+ *
+ * <p>The available public examples are too sparse for defensible statistical training. These
+ * explicit features make every result reviewable and can later be replaced with coefficients
+ * fitted from an authorized, hand-labeled X timeline export.</p>
+ */
+public final class ResetAnnouncementClassifier {
+    public static final int MODEL_VERSION = 1;
+
+    private static final Pattern TIME_WINDOW = Pattern.compile(
+            "\\b(next|within|over)\\s+(the\\s+)?\\d+\\s*(minute|minutes|min|hour|hours|hr|hrs|day|days)\\b");
+    private static final Pattern RESET_NEGATION = Pattern.compile(
+            "\\b(no|not|never|without|won't|will not|isn't|is not|aren't|are not)\\b[^.!?]{0,28}\\breset");
+    private static final Pattern COMPLETED = Pattern.compile(
+            "\\b(has|have|is|are|just|now|already)\\b[^.!?]{0,24}\\b(reset|resetting|restored|refilled)\\b"
+                    + "|\\breset\\b[^.!?]{0,20}\\b(complete|completed|done|landed|live)\\b");
+
+    private ResetAnnouncementClassifier() {
+    }
+
+    public static ResetSignal classify(String text) {
+        String value = normalize(text);
+        if (value.isEmpty()) return new ResetSignal(ResetSignal.NONE, 0);
+
+        boolean product = containsAny(value, "codex", "chatgpt work", "chatgpt team",
+                "chatgpt enterprise");
+        boolean usage = containsAny(value, "usage limit", "usage limits", "rate limit",
+                "rate limits", "allowance", "quota");
+        boolean reset = containsAny(value, "reset", "resetting", "refill", "refilling");
+        boolean bank = containsAny(value, "reset bank", "reset-bank", "banked reset",
+                "bankable reset", "credit", "credits", "into your bank");
+        boolean future = containsAny(value, "will reset", "will be reset", "going to reset",
+                "resetting soon", "coming soon", "later today", "rolling out",
+                "should land", "will land", "over the next", "in the next",
+                "another usage limit reset", "another rate limit reset");
+        boolean timed = TIME_WINDOW.matcher(value).find();
+        boolean completed = COMPLETED.matcher(value).find();
+        boolean negated = RESET_NEGATION.matcher(value).find();
+
+        if (negated || !reset || (!product && !usage && !bank)) {
+            return new ResetSignal(ResetSignal.NONE, negated ? 5 : 0);
+        }
+
+        int score = 20;
+        if (product) score += 25;
+        if (usage) score += 20;
+        if (bank) score += 20;
+        if (future) score += 15;
+        if (timed) score += 15;
+        if (completed) score += 10;
+
+        if (bank) {
+            return new ResetSignal(ResetSignal.RESET_CREDIT, score);
+        }
+        if (future || timed) {
+            return new ResetSignal(ResetSignal.RESET_IMMINENT, score);
+        }
+        if (completed) {
+            return new ResetSignal(ResetSignal.RESET_CONFIRMED, score);
+        }
+        return new ResetSignal(ResetSignal.GENERAL_UPDATE, Math.min(score, 65));
+    }
+
+    private static boolean containsAny(String value, String... needles) {
+        for (String needle : needles) {
+            if (value.contains(needle)) return true;
+        }
+        return false;
+    }
+
+    private static String normalize(String text) {
+        return text == null ? "" : text.toLowerCase(Locale.ROOT)
+                .replace('\u2019', '\'')
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetSignal.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetSignal.java
@@ -1,0 +1,52 @@
+package dev.bennett.codexmeter;
+
+/** Auditable reset-announcement classification returned by the local intent scorer. */
+public final class ResetSignal {
+    public static final String NONE = "none";
+    public static final String RESET_IMMINENT = "reset_imminent";
+    public static final String RESET_CREDIT = "reset_credit";
+    public static final String RESET_CONFIRMED = "reset_confirmed";
+    public static final String GENERAL_UPDATE = "general_update";
+
+    public final String category;
+    public final int likelihood;
+
+    ResetSignal(String category, int likelihood) {
+        this.category = normalize(category);
+        this.likelihood = Math.max(0, Math.min(100, likelihood));
+    }
+
+    public boolean isRelevant() {
+        return !NONE.equals(category);
+    }
+
+    public boolean isActionable() {
+        return likelihood >= 70
+                && (RESET_IMMINENT.equals(category)
+                || RESET_CREDIT.equals(category)
+                || RESET_CONFIRMED.equals(category));
+    }
+
+    public String title() {
+        if (RESET_CREDIT.equals(category)) return "Reset-bank credit may be coming";
+        if (RESET_IMMINENT.equals(category)) return "Codex reset looks imminent";
+        if (RESET_CONFIRMED.equals(category)) return "Codex reset announced";
+        if (GENERAL_UPDATE.equals(category)) return "Codex usage update";
+        return "No reset signal";
+    }
+
+    public String likelihoodLabel() {
+        if (likelihood >= 90) return "Very likely";
+        if (likelihood >= 70) return "Likely";
+        if (likelihood >= 50) return "Possible";
+        return "Low confidence";
+    }
+
+    static String normalize(String value) {
+        if (RESET_IMMINENT.equals(value) || RESET_CREDIT.equals(value)
+                || RESET_CONFIRMED.equals(value) || GENERAL_UPDATE.equals(value)) {
+            return value;
+        }
+        return NONE;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetWatchClient.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetWatchClient.java
@@ -1,0 +1,221 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/** Authenticated X API v2 client for the fixed @thsottiaux public timeline. */
+public final class ResetWatchClient {
+    private static final int MAX_RESPONSE_BYTES = 512 * 1024;
+    private static final Object LOCK = new Object();
+
+    private ResetWatchClient() {
+    }
+
+    public static List<XPost> check(Context context) throws Exception {
+        Context app = context.getApplicationContext();
+        if (app == null) app = context;
+        synchronized (LOCK) {
+            try {
+                XOAuthTokens tokens = usableTokens(app);
+                String userId = AnnouncementPreferences.userId(app);
+                if (!XTimelineParser.isValidPostId(userId)) {
+                    userId = resolveUserId(app, tokens);
+                    AnnouncementPreferences.setUserId(app, userId);
+                }
+                String sinceId = AnnouncementPreferences.lastSeenId(app);
+                ArrayList<XPost> posts = new ArrayList<>();
+                String newestId = "";
+                String paginationToken = "";
+                for (int page = 0; page < 32; page++) {
+                    // A 401 on the previous request may have rotated the refresh token.
+                    tokens = usableTokens(app);
+                    String endpoint = timelineEndpoint(userId, sinceId, paginationToken);
+                    Response response = getWithRefresh(app, endpoint, tokens);
+                    List<XPost> pagePosts = XTimelineParser.parse(response.body);
+                    posts.addAll(pagePosts);
+                    if (newestId.isEmpty()) {
+                        newestId = XTimelineParser.newestId(response.body, pagePosts);
+                    }
+                    JSONObject meta = new JSONObject(response.body).optJSONObject("meta");
+                    paginationToken = meta == null ? "" : meta.optString("next_token", "");
+                    if (paginationToken.isEmpty()) break;
+                    if (page == 31) {
+                        throw new IllegalStateException(
+                                "X returned more timeline pages than the reset watch can process.");
+                    }
+                }
+                boolean hadBaseline = AnnouncementPreferences.hasBaseline(app);
+                AnnouncementPreferences.saveSuccess(app, posts, newestId);
+                ResetWatchNotificationManager.notifyNew(app, posts, hadBaseline);
+                return posts;
+            } catch (Exception exception) {
+                if (exception instanceof XAuthorizationException) {
+                    SecureXTokenStore.clear(app);
+                    AnnouncementPreferences.setMonitoringEnabled(app, false);
+                    ResetWatchScheduler.cancel(app);
+                }
+                AnnouncementPreferences.saveError(app, safeMessage(exception));
+                throw exception;
+            }
+        }
+    }
+
+    private static XOAuthTokens usableTokens(Context context) throws Exception {
+        XOAuthTokens tokens = SecureXTokenStore.load(context);
+        if (tokens == null) throw new IllegalStateException("Connect X to check Codex reset posts.");
+        if (tokens.shouldRefresh(System.currentTimeMillis())) {
+            tokens = XOAuthClient.refresh(tokens);
+            SecureXTokenStore.save(context, tokens);
+        }
+        return tokens;
+    }
+
+    private static String resolveUserId(Context context, XOAuthTokens tokens) throws Exception {
+        Response response = getWithRefresh(context,
+                "https://api.x.com/2/users/by/username/" + ResetWatchSource.HANDLE, tokens);
+        JSONObject data = new JSONObject(response.body).optJSONObject("data");
+        String id = data == null ? "" : data.optString("id", "");
+        String username = data == null ? "" : data.optString("username", "");
+        if (!XTimelineParser.isValidPostId(id)
+                || (!username.isEmpty()
+                && !ResetWatchSource.HANDLE.equalsIgnoreCase(username))) {
+            throw new IllegalStateException("X did not return the expected @"
+                    + ResetWatchSource.HANDLE + " account.");
+        }
+        return id;
+    }
+
+    private static Response getWithRefresh(Context context, String endpoint, XOAuthTokens tokens)
+            throws Exception {
+        Response response = get(endpoint, tokens.accessToken);
+        if (response.status != HttpURLConnection.HTTP_UNAUTHORIZED) {
+            ensureSuccess(response);
+            return response;
+        }
+        XOAuthTokens refreshed = XOAuthClient.refresh(tokens);
+        SecureXTokenStore.save(context, refreshed);
+        response = get(endpoint, refreshed.accessToken);
+        ensureSuccess(response);
+        return response;
+    }
+
+    private static Response get(String endpoint, String accessToken) throws Exception {
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) new URL(endpoint).openConnection();
+            connection.setConnectTimeout(15_000);
+            connection.setReadTimeout(25_000);
+            connection.setUseCaches(false);
+            connection.setInstanceFollowRedirects(false);
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("Accept-Encoding", "identity");
+            connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+            connection.setRequestProperty("User-Agent", AppConstants.resetWatchUserAgent());
+            int status = connection.getResponseCode();
+            URL finalUrl = connection.getURL();
+            if (!"https".equalsIgnoreCase(finalUrl.getProtocol())
+                    || !"api.x.com".equalsIgnoreCase(finalUrl.getHost())) {
+                throw new SecurityException("X redirected the reset check to an untrusted host.");
+            }
+            String body = read(status >= 200 && status < 400
+                    ? connection.getInputStream() : connection.getErrorStream());
+            return new Response(status, body);
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    private static void ensureSuccess(Response response) throws XAuthorizationException {
+        if (response.status == HttpURLConnection.HTTP_OK) return;
+        if (response.status == HttpURLConnection.HTTP_UNAUTHORIZED
+                || response.status == HttpURLConnection.HTTP_FORBIDDEN) {
+            throw new XAuthorizationException("X access expired or lacks public-post read access. "
+                    + "Reconnect X from Settings.");
+        }
+        if (response.status == 429) {
+            throw new IllegalStateException("X temporarily limited reset checks. "
+                    + "The next scheduled check will try again.");
+        }
+        String detail = "";
+        try {
+            JSONObject object = new JSONObject(response.body);
+            detail = object.optString("detail", object.optString("title", ""));
+            if (detail.isEmpty()) {
+                JSONArray errors = object.optJSONArray("errors");
+                JSONObject first = errors == null ? null : errors.optJSONObject(0);
+                if (first != null) detail = first.optString("message", "");
+            }
+        } catch (Exception ignored) {
+        }
+        if (!detail.isEmpty()) {
+            throw new IllegalStateException("X reset check failed (" + response.status + "): "
+                    + safe(detail, 180));
+        }
+        throw new IllegalStateException(
+                "X reset check failed with HTTP " + response.status + ".");
+    }
+
+    private static String timelineEndpoint(String userId, String sinceId, String paginationToken)
+            throws Exception {
+        StringBuilder endpoint = new StringBuilder("https://api.x.com/2/users/")
+                .append(userId)
+                .append("/tweets?max_results=100&exclude=retweets&tweet.fields=created_at");
+        if (XTimelineParser.isValidPostId(sinceId)) {
+            endpoint.append("&since_id=").append(sinceId);
+        }
+        if (paginationToken != null && !paginationToken.isEmpty()) {
+            endpoint.append("&pagination_token=")
+                    .append(URLEncoder.encode(paginationToken, "UTF-8"));
+        }
+        return endpoint.toString();
+    }
+
+    private static String read(InputStream input) throws Exception {
+        if (input == null) return "";
+        try (InputStream stream = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int total = 0;
+            int count;
+            while ((count = stream.read(buffer)) != -1) {
+                total += count;
+                if (total > MAX_RESPONSE_BYTES) {
+                    throw new IllegalStateException("X returned too much timeline data.");
+                }
+                output.write(buffer, 0, count);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static String safeMessage(Exception exception) {
+        String message = exception == null ? "" : exception.getMessage();
+        if (message == null || message.trim().isEmpty()) {
+            message = "Could not check X for Codex reset updates.";
+        }
+        return safe(message, 240);
+    }
+
+    private static String safe(String value, int limit) {
+        String cleaned = value == null ? "" : value.trim();
+        return cleaned.length() <= limit ? cleaned : cleaned.substring(0, limit);
+    }
+
+    private static final class Response {
+        final int status;
+        final String body;
+
+        Response(int status, String body) {
+            this.status = status;
+            this.body = body == null ? "" : body;
+        }
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetWatchClient.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetWatchClient.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -32,10 +33,12 @@ public final class ResetWatchClient {
                     AnnouncementPreferences.setUserId(app, userId);
                 }
                 String sinceId = AnnouncementPreferences.lastSeenId(app);
+                boolean hadBaseline = AnnouncementPreferences.hasBaseline(app);
                 ArrayList<XPost> posts = new ArrayList<>();
                 String newestId = "";
                 String paginationToken = "";
-                for (int page = 0; page < 32; page++) {
+                int maxPages = hadBaseline ? 3 : 1;
+                for (int page = 0; page < maxPages; page++) {
                     // A 401 on the previous request may have rotated the refresh token.
                     tokens = usableTokens(app);
                     String endpoint = timelineEndpoint(userId, sinceId, paginationToken);
@@ -48,12 +51,11 @@ public final class ResetWatchClient {
                     JSONObject meta = new JSONObject(response.body).optJSONObject("meta");
                     paginationToken = meta == null ? "" : meta.optString("next_token", "");
                     if (paginationToken.isEmpty()) break;
-                    if (page == 31) {
-                        throw new IllegalStateException(
-                                "X returned more timeline pages than the reset watch can process.");
-                    }
                 }
-                boolean hadBaseline = AnnouncementPreferences.hasBaseline(app);
+                if (!SecureXTokenStore.isConnected(app)
+                        || !AnnouncementPreferences.monitoringEnabled(app)) {
+                    return Collections.emptyList();
+                }
                 AnnouncementPreferences.saveSuccess(app, posts, newestId);
                 ResetWatchNotificationManager.notifyNew(app, posts, hadBaseline);
                 return posts;

--- a/app/src/main/java/dev/bennett/codexmeter/ResetWatchJobService.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetWatchJobService.java
@@ -1,0 +1,63 @@
+package dev.bennett.codexmeter;
+
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+
+/** Executes reset-watch polling without keeping an Activity alive. */
+public final class ResetWatchJobService extends JobService {
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final Map<JobParameters, Future<?>> active = new HashMap<>();
+
+    @Override
+    public boolean onStartJob(JobParameters params) {
+        if (!AnnouncementPreferences.monitoringEnabled(this)
+                || !SecureXTokenStore.isConnected(this)) {
+            return false;
+        }
+        FutureTask<Void> task = new FutureTask<>(() -> {
+            try {
+                ResetWatchClient.check(getApplicationContext());
+            } catch (Exception ignored) {
+                // The persisted status explains the failure; the next cadence retries.
+            } finally {
+                boolean shouldFinish;
+                synchronized (active) {
+                    shouldFinish = active.remove(params) != null;
+                }
+                if (shouldFinish) jobFinished(params, false);
+            }
+        }, null);
+        synchronized (active) {
+            active.put(params, task);
+        }
+        executor.execute(task);
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters params) {
+        Future<?> task;
+        synchronized (active) {
+            task = active.remove(params);
+        }
+        if (task != null) task.cancel(true);
+        return AnnouncementPreferences.monitoringEnabled(this)
+                && SecureXTokenStore.isConnected(this);
+    }
+
+    @Override
+    public void onDestroy() {
+        synchronized (active) {
+            for (Future<?> task : active.values()) task.cancel(true);
+            active.clear();
+        }
+        executor.shutdownNow();
+        super.onDestroy();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetWatchNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetWatchNotificationManager.java
@@ -1,0 +1,116 @@
+package dev.bennett.codexmeter;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Posts at most one high-confidence, deduplicated reset-watch notification per poll. */
+public final class ResetWatchNotificationManager {
+    private static final String CHANNEL_ID = "codex_reset_watch_v1";
+    private static final String PREFS = "codex_meter_reset_watch_notifications_v1";
+    private static final String KEY_NOTIFIED = "notified_post_ids";
+    private static final int NOTIFICATION_BASE = 74700;
+
+    private ResetWatchNotificationManager() {
+    }
+
+    public static void notifyNew(Context context, List<XPost> posts, boolean hadBaseline) {
+        if (context == null || posts == null || posts.isEmpty() || !hadBaseline
+                || !AnnouncementPreferences.notificationsEnabled(context)) {
+            return;
+        }
+        Set<String> notified = new HashSet<>(state(context)
+                .getStringSet(KEY_NOTIFIED, new HashSet<>()));
+        XPost best = null;
+        for (XPost post : posts) {
+            if (post == null || notified.contains(post.id) || !post.signal.isActionable()) {
+                continue;
+            }
+            if (best == null || post.signal.likelihood > best.signal.likelihood
+                    || (post.signal.likelihood == best.signal.likelihood
+                    && XTimelineParser.compareIds(post.id, best.id) > 0)) {
+                best = post;
+            }
+        }
+        if (best == null || !post(context, best)) return;
+        for (XPost post : posts) {
+            if (post != null && post.signal.isActionable()) notified.add(post.id);
+        }
+        while (notified.size() > 50) notified.remove(notified.iterator().next());
+        state(context).edit().putStringSet(KEY_NOTIFIED, notified).apply();
+    }
+
+    public static void ensureChannel(Context context) {
+        NotificationManager manager = manager(context);
+        if (manager == null) return;
+        NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                "Codex reset watch", NotificationManager.IMPORTANCE_DEFAULT);
+        channel.setDescription("High-confidence reset and reset-bank posts from @thsottiaux");
+        manager.createNotificationChannel(channel);
+    }
+
+    public static void clearState(Context context) {
+        if (context != null) state(context).edit().clear().apply();
+    }
+
+    private static boolean post(Context context, XPost post) {
+        NotificationManager manager = manager(context);
+        if (manager == null) return false;
+        ensureChannel(context);
+        if (!manager.areNotificationsEnabled()
+                || (Build.VERSION.SDK_INT >= 33
+                && context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+                != PackageManager.PERMISSION_GRANTED)) {
+            return false;
+        }
+        NotificationChannel channel = manager.getNotificationChannel(CHANNEL_ID);
+        if (channel == null || channel.getImportance() == NotificationManager.IMPORTANCE_NONE) {
+            return false;
+        }
+        int id = NOTIFICATION_BASE + Math.floorMod(post.id.hashCode(), 100_000);
+        PendingIntent content = PendingIntent.getActivity(context, id,
+                new Intent(context, MainActivity.class)
+                        .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
+                                | Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent openX = PendingIntent.getActivity(context, id + 10_000,
+                new Intent(Intent.ACTION_VIEW, Uri.parse(post.url))
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        String text = post.signal.likelihoodLabel() + " · "
+                + (post.text.length() <= 240 ? post.text : post.text.substring(0, 240));
+        Notification notification = new Notification.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_reset_notification)
+                .setContentTitle(post.signal.title())
+                .setContentText(text)
+                .setStyle(new Notification.BigTextStyle().bigText(text))
+                .setContentIntent(content)
+                .addAction(new Notification.Action.Builder(
+                        android.R.drawable.ic_menu_view, "Open on X", openX).build())
+                .setAutoCancel(true)
+                .setCategory(Notification.CATEGORY_SOCIAL)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
+                .setShowWhen(true)
+                .build();
+        manager.notify(id, notification);
+        return true;
+    }
+
+    private static NotificationManager manager(Context context) {
+        return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    private static SharedPreferences state(Context context) {
+        return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetWatchScheduler.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetWatchScheduler.java
@@ -1,0 +1,105 @@
+package dev.bennett.codexmeter;
+
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
+import android.content.Context;
+import java.util.concurrent.TimeUnit;
+
+/** Schedules best-effort 30- or 60-minute checks under Android battery policy. */
+public final class ResetWatchScheduler {
+    private static final int PERIODIC_JOB_ID = 73500;
+    private static final int INITIAL_JOB_ID = 73501;
+    private static final int MANUAL_JOB_ID = 73502;
+
+    private ResetWatchScheduler() {
+    }
+
+    public static boolean ensureScheduled(Context context) {
+        Context app = application(context);
+        if (!AnnouncementPreferences.monitoringEnabled(app)
+                || !SecureXTokenStore.isConnected(app)) {
+            cancel(app);
+            return true;
+        }
+        try {
+            JobScheduler scheduler = scheduler(app);
+            if (scheduler == null) return false;
+            long period = TimeUnit.MINUTES.toMillis(
+                    AnnouncementPreferences.intervalMinutes(app));
+            long flex = Math.min(TimeUnit.MINUTES.toMillis(15), period / 3);
+            JobInfo existing = scheduler.getPendingJob(PERIODIC_JOB_ID);
+            boolean scheduled = true;
+            if (existing == null || differs(existing.getIntervalMillis(), period)
+                    || differs(existing.getFlexMillis(), flex)
+                    || existing.getNetworkType() != JobInfo.NETWORK_TYPE_ANY
+                    || !existing.isPersisted()) {
+                JobInfo periodic = base(app, PERIODIC_JOB_ID)
+                        .setPeriodic(period, flex)
+                        .setPersisted(true)
+                        .build();
+                scheduled = scheduler.schedule(periodic) == JobScheduler.RESULT_SUCCESS;
+            }
+            if (AnnouncementPreferences.lastCheckMillis(app) == 0L
+                    && scheduler.getPendingJob(INITIAL_JOB_ID) == null) {
+                scheduled = scheduler.schedule(base(app, INITIAL_JOB_ID)
+                        .setMinimumLatency(0L)
+                        .setOverrideDeadline(TimeUnit.MINUTES.toMillis(2))
+                        .build()) == JobScheduler.RESULT_SUCCESS && scheduled;
+            }
+            return scheduled;
+        } catch (RuntimeException exception) {
+            return false;
+        }
+    }
+
+    public static boolean requestImmediate(Context context) {
+        Context app = application(context);
+        if (!AnnouncementPreferences.monitoringEnabled(app)
+                || !SecureXTokenStore.isConnected(app)) {
+            return false;
+        }
+        try {
+            JobScheduler scheduler = scheduler(app);
+            if (scheduler == null) return false;
+            scheduler.cancel(MANUAL_JOB_ID);
+            return scheduler.schedule(base(app, MANUAL_JOB_ID)
+                    .setMinimumLatency(0L)
+                    .setOverrideDeadline(TimeUnit.MINUTES.toMillis(1))
+                    .build()) == JobScheduler.RESULT_SUCCESS;
+        } catch (RuntimeException exception) {
+            return false;
+        }
+    }
+
+    public static void cancel(Context context) {
+        try {
+            JobScheduler scheduler = scheduler(application(context));
+            if (scheduler != null) {
+                scheduler.cancel(PERIODIC_JOB_ID);
+                scheduler.cancel(INITIAL_JOB_ID);
+                scheduler.cancel(MANUAL_JOB_ID);
+            }
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    private static JobInfo.Builder base(Context context, int id) {
+        return new JobInfo.Builder(id,
+                new ComponentName(context, ResetWatchJobService.class))
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY);
+    }
+
+    private static JobScheduler scheduler(Context context) {
+        return (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+    }
+
+    private static boolean differs(long actual, long expected) {
+        return Math.abs(actual - expected) > TimeUnit.MINUTES.toMillis(1);
+    }
+
+    private static Context application(Context context) {
+        Context app = context.getApplicationContext();
+        return app == null ? context : app;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/ResetWatchSource.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ResetWatchSource.java
@@ -1,0 +1,14 @@
+package dev.bennett.codexmeter;
+
+/** Fixed public source monitored by this feature. */
+public final class ResetWatchSource {
+    public static final String HANDLE = "thsottiaux";
+    public static final String PROFILE_URL = "https://x.com/" + HANDLE;
+
+    private ResetWatchSource() {
+    }
+
+    public static String postUrl(String id) {
+        return PROFILE_URL + "/status/" + id;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/SecureXTokenStore.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SecureXTokenStore.java
@@ -96,8 +96,8 @@ public final class SecureXTokenStore {
         KeyGenerator generator = KeyGenerator.getInstance("AES", "AndroidKeyStore");
         generator.init(new KeyGenParameterSpec.Builder(KEY_ALIAS,
                 KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
-                .setBlockModes("GCM")
-                .setEncryptionPaddings("NoPadding")
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                 .setRandomizedEncryptionRequired(true)
                 .build());
         return generator.generateKey();

--- a/app/src/main/java/dev/bennett/codexmeter/SecureXTokenStore.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SecureXTokenStore.java
@@ -1,0 +1,104 @@
+package dev.bennett.codexmeter;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.security.keystore.KeyGenParameterSpec;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.security.KeyStore;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import org.json.JSONObject;
+
+/** Android Keystore-backed storage isolated from the user's ChatGPT credentials. */
+@SuppressLint("ApplySharedPref")
+public final class SecureXTokenStore {
+    private static final String KEY_ALIAS = "codex_meter_x_auth_key_v1";
+    private static final String KEY_BLOB = "blob";
+    private static final String PREFS = "secure_x_auth_v1";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final Object LOCK = new Object();
+
+    private SecureXTokenStore() {
+    }
+
+    public static void save(Context context, XOAuthTokens tokens) throws Exception {
+        if (tokens == null || !tokens.isUsable()) {
+            throw new IllegalArgumentException("X returned incomplete credentials.");
+        }
+        synchronized (LOCK) {
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey());
+            byte[] ciphertext = cipher.doFinal(
+                    tokens.toJson().toString().getBytes(StandardCharsets.UTF_8));
+            JSONObject blob = new JSONObject()
+                    .put("iv", Base64.getEncoder().encodeToString(cipher.getIV()))
+                    .put("ct", Base64.getEncoder().encodeToString(ciphertext));
+            if (!prefs(context).edit().putString(KEY_BLOB, blob.toString()).commit()) {
+                throw new Exception("Could not persist encrypted X credentials.");
+            }
+        }
+    }
+
+    public static XOAuthTokens load(Context context) {
+        synchronized (LOCK) {
+            SharedPreferences preferences = prefs(context);
+            String stored = preferences.getString(KEY_BLOB, "");
+            if (stored == null || stored.isEmpty()) return null;
+            try {
+                JSONObject blob = new JSONObject(stored);
+                Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+                cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(),
+                        new GCMParameterSpec(128,
+                                Base64.getDecoder().decode(blob.getString("iv"))));
+                XOAuthTokens tokens = XOAuthTokens.fromJson(new JSONObject(new String(
+                        cipher.doFinal(Base64.getDecoder().decode(blob.getString("ct"))),
+                        StandardCharsets.UTF_8)));
+                return tokens.isUsable() ? tokens : null;
+            } catch (Exception exception) {
+                preferences.edit().remove(KEY_BLOB).commit();
+                return null;
+            }
+        }
+    }
+
+    public static boolean isConnected(Context context) {
+        return load(context) != null;
+    }
+
+    public static void clear(Context context) {
+        synchronized (LOCK) {
+            prefs(context).edit().clear().commit();
+            try {
+                KeyStore store = KeyStore.getInstance("AndroidKeyStore");
+                store.load(null);
+                if (store.containsAlias(KEY_ALIAS)) store.deleteEntry(KEY_ALIAS);
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static SharedPreferences prefs(Context context) {
+        Context app = context.getApplicationContext();
+        return (app == null ? context : app).getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    private static SecretKey getOrCreateKey() throws Exception {
+        KeyStore store = KeyStore.getInstance("AndroidKeyStore");
+        store.load(null);
+        Key key = store.getKey(KEY_ALIAS, null);
+        if (key instanceof SecretKey) return (SecretKey) key;
+        KeyGenerator generator = KeyGenerator.getInstance("AES", "AndroidKeyStore");
+        generator.init(new KeyGenParameterSpec.Builder(KEY_ALIAS,
+                KeyGenParameterSpec.PURPOSE_ENCRYPT | KeyGenParameterSpec.PURPOSE_DECRYPT)
+                .setBlockModes("GCM")
+                .setEncryptionPaddings("NoPadding")
+                .setRandomizedEncryptionRequired(true)
+                .build());
+        return generator.generateKey();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/SecureXTokenStore.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SecureXTokenStore.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyStore;
@@ -94,7 +95,7 @@ public final class SecureXTokenStore {
         if (key instanceof SecretKey) return (SecretKey) key;
         KeyGenerator generator = KeyGenerator.getInstance("AES", "AndroidKeyStore");
         generator.init(new KeyGenParameterSpec.Builder(KEY_ALIAS,
-                KeyGenParameterSpec.PURPOSE_ENCRYPT | KeyGenParameterSpec.PURPOSE_DECRYPT)
+                KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
                 .setBlockModes("GCM")
                 .setEncryptionPaddings("NoPadding")
                 .setRandomizedEncryptionRequired(true)

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -62,6 +62,9 @@ public final class SettingsActivity extends AppCompatActivity {
         private ListPreference nowBarThresholdPreference;
         private Preference nowBarPermissionPreference;
         private Preference updateStatusPreference;
+        private Preference resetWatchAccountPreference;
+        private Preference resetWatchStatusPreference;
+        private SwitchPreferenceCompat resetWatchMonitorPreference;
 
         @Override
         public void onCreatePreferences(Bundle bundle, String rootKey) {
@@ -70,6 +73,7 @@ public final class SettingsActivity extends AppCompatActivity {
             bindAccount();
             bindAppearance();
             bindRefresh();
+            bindResetWatch();
             bindUpdates();
             bindNotifications();
             bindNowBar();
@@ -90,6 +94,7 @@ public final class SettingsActivity extends AppCompatActivity {
             super.onResume();
             updatePermissionSummary();
             updateNowBarSummary();
+            updateResetWatchSummary();
             updateUpdateSummary();
         }
 
@@ -214,6 +219,151 @@ public final class SettingsActivity extends AppCompatActivity {
                 RefreshScheduler.schedulePeriodic(requireContext());
                 return true;
             });
+        }
+
+        private void bindResetWatch() {
+            resetWatchAccountPreference = findPreference("reset_watch_account");
+            resetWatchAccountPreference.setOnPreferenceClickListener(preference -> {
+                if (SecureXTokenStore.isConnected(requireContext())) {
+                    new AlertDialog.Builder(requireContext())
+                            .setTitle("Disconnect X?")
+                            .setMessage("This removes encrypted X tokens and cached reset-watch "
+                                    + "posts from this device.")
+                            .setNegativeButton("Cancel", null)
+                            .setPositiveButton("Disconnect", (dialog, which) -> {
+                                XAuthentication.disconnect(requireContext());
+                                Toast.makeText(requireContext(), "X disconnected.",
+                                        Toast.LENGTH_SHORT).show();
+                                updateResetWatchSummary();
+                            })
+                            .show();
+                } else {
+                    startXConnection();
+                }
+                return true;
+            });
+
+            resetWatchMonitorPreference = findPreference("reset_watch_monitor_ui");
+            resetWatchMonitorPreference.setPersistent(false);
+            resetWatchMonitorPreference.setChecked(
+                    AnnouncementPreferences.monitoringEnabled(requireContext()));
+            resetWatchMonitorPreference.setOnPreferenceChangeListener((preference, value) -> {
+                boolean enabled = (Boolean) value;
+                if (enabled && !SecureXTokenStore.isConnected(requireContext())) {
+                    startXConnection();
+                    return false;
+                }
+                AnnouncementPreferences.setMonitoringEnabled(requireContext(), enabled);
+                if (enabled) {
+                    ResetWatchScheduler.ensureScheduled(requireContext());
+                    ResetWatchScheduler.requestImmediate(requireContext());
+                }
+                updateResetWatchSummary();
+                return true;
+            });
+
+            ListPreference interval = findPreference("reset_watch_interval_ui");
+            interval.setPersistent(false);
+            interval.setValue(String.valueOf(
+                    AnnouncementPreferences.intervalMinutes(requireContext())));
+            interval.setOnPreferenceChangeListener((preference, value) -> {
+                AnnouncementPreferences.setIntervalMinutes(requireContext(),
+                        Integer.parseInt(String.valueOf(value)));
+                ResetWatchScheduler.ensureScheduled(requireContext());
+                updateResetWatchSummary();
+                return true;
+            });
+
+            SwitchPreferenceCompat notifications =
+                    findPreference("reset_watch_notifications_ui");
+            notifications.setPersistent(false);
+            notifications.setChecked(
+                    AnnouncementPreferences.notificationsEnabled(requireContext()));
+            notifications.setOnPreferenceChangeListener((preference, value) -> {
+                boolean enabled = (Boolean) value;
+                AnnouncementPreferences.setNotificationsEnabled(requireContext(), enabled);
+                if (enabled) {
+                    ResetWatchNotificationManager.ensureChannel(requireContext());
+                    if (Build.VERSION.SDK_INT >= 33
+                            && requireContext().checkSelfPermission(
+                            "android.permission.POST_NOTIFICATIONS")
+                            != PackageManager.PERMISSION_GRANTED) {
+                        requestPermissions(
+                                new String[]{"android.permission.POST_NOTIFICATIONS"}, 8603);
+                    }
+                }
+                return true;
+            });
+
+            SwitchPreferenceCompat banner = findPreference("reset_watch_banner_ui");
+            banner.setPersistent(false);
+            banner.setChecked(AnnouncementPreferences.bannerEnabled(requireContext()));
+            banner.setOnPreferenceChangeListener((preference, value) -> {
+                AnnouncementPreferences.setBannerEnabled(requireContext(), (Boolean) value);
+                return true;
+            });
+
+            findPreference("reset_watch_check_now").setOnPreferenceClickListener(preference -> {
+                if (!SecureXTokenStore.isConnected(requireContext())) {
+                    startXConnection();
+                    return true;
+                }
+                boolean scheduled = ResetWatchScheduler.requestImmediate(requireContext());
+                Toast.makeText(requireContext(), scheduled
+                                ? "Reset-watch check scheduled."
+                                : "Could not schedule the reset-watch check.",
+                        scheduled ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG).show();
+                return true;
+            });
+            resetWatchStatusPreference = findPreference("reset_watch_status");
+            updateResetWatchSummary();
+        }
+
+        private void startXConnection() {
+            try {
+                XAuthentication.begin(requireActivity());
+            } catch (Exception exception) {
+                Toast.makeText(requireContext(), MainActivity.safeMessage(exception),
+                        Toast.LENGTH_LONG).show();
+            }
+        }
+
+        private void updateResetWatchSummary() {
+            if (resetWatchStatusPreference == null || getContext() == null) return;
+            boolean configured = XAuthentication.isConfigured();
+            boolean connected = SecureXTokenStore.isConnected(requireContext());
+            if (resetWatchAccountPreference != null) {
+                resetWatchAccountPreference.setTitle(connected ? "Disconnect X" : "Connect X");
+                resetWatchAccountPreference.setSummary(configured
+                        ? (connected ? "Connected with read-only OAuth access"
+                        : "Read @thsottiaux through the official X API")
+                        : "Unavailable: this build has no X Native App client ID");
+            }
+            if (resetWatchMonitorPreference != null) {
+                resetWatchMonitorPreference.setChecked(
+                        AnnouncementPreferences.monitoringEnabled(requireContext()));
+            }
+            StringBuilder summary = new StringBuilder();
+            if (!configured) {
+                summary.append("X OAuth is not configured for this build");
+            } else if (!connected) {
+                summary.append("Not connected");
+            } else if (AnnouncementPreferences.monitoringEnabled(requireContext())) {
+                summary.append("Monitoring every ")
+                        .append(AnnouncementPreferences.intervalMinutes(requireContext()))
+                        .append(" minutes (best effort)");
+            } else {
+                summary.append("Connected · automatic checks off");
+            }
+            long checkedAt = AnnouncementPreferences.lastCheckMillis(requireContext());
+            if (checkedAt > 0L) {
+                summary.append(" · Checked ").append(DateUtils.getRelativeTimeSpanString(
+                        checkedAt, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS,
+                        DateUtils.FORMAT_ABBREV_RELATIVE));
+            }
+            String error = AnnouncementPreferences.lastError(requireContext());
+            if (!error.isEmpty()) summary.append(" · ").append(error);
+            resetWatchStatusPreference.setSummary(summary.toString());
         }
 
         private void bindUpdates() {

--- a/app/src/main/java/dev/bennett/codexmeter/XAuthentication.java
+++ b/app/src/main/java/dev/bennett/codexmeter/XAuthentication.java
@@ -1,5 +1,6 @@
 package dev.bennett.codexmeter;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -9,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 /** Starts and completes X OAuth without embedding an app secret in the APK. */
+@SuppressLint("ApplySharedPref")
 public final class XAuthentication {
     private static final String PREFS = "codex_meter_x_oauth_pending_v1";
     private static final String KEY_STATE = "state";

--- a/app/src/main/java/dev/bennett/codexmeter/XAuthentication.java
+++ b/app/src/main/java/dev/bennett/codexmeter/XAuthentication.java
@@ -1,0 +1,102 @@
+package dev.bennett.codexmeter;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/** Starts and completes X OAuth without embedding an app secret in the APK. */
+public final class XAuthentication {
+    private static final String PREFS = "codex_meter_x_oauth_pending_v1";
+    private static final String KEY_STATE = "state";
+    private static final String KEY_VERIFIER = "verifier";
+    private static final String KEY_STARTED_AT = "started_at";
+    private static final long MAX_PENDING_AGE_MS = 10 * 60 * 1000L;
+
+    private XAuthentication() {
+    }
+
+    public static boolean isConfigured() {
+        return BuildConfig.X_CLIENT_ID != null && !BuildConfig.X_CLIENT_ID.trim().isEmpty();
+    }
+
+    public static void begin(Activity activity) throws Exception {
+        if (!isConfigured()) {
+            throw new IllegalStateException(
+                    "This build needs an X Native App client ID before reset watch can connect.");
+        }
+        Pkce pkce = Pkce.generate();
+        if (!prefs(activity).edit()
+                .putString(KEY_STATE, pkce.state)
+                .putString(KEY_VERIFIER, pkce.verifier)
+                .putLong(KEY_STARTED_AT, System.currentTimeMillis())
+                .commit()) {
+            throw new Exception("Could not prepare secure X sign-in.");
+        }
+        activity.startActivity(new Intent(Intent.ACTION_VIEW,
+                Uri.parse(XOAuthFlow.authorizeUrl(BuildConfig.X_CLIENT_ID, pkce))));
+    }
+
+    public static void complete(Context context, Uri callback) throws Exception {
+        if (callback == null || !"codexmeter".equals(callback.getScheme())
+                || !"x-auth".equals(callback.getHost())
+                || !"/complete".equals(callback.getPath())) {
+            throw new SecurityException("Invalid X sign-in callback.");
+        }
+        SharedPreferences pending = prefs(context);
+        String expectedState = pending.getString(KEY_STATE, "");
+        String verifier = pending.getString(KEY_VERIFIER, "");
+        long startedAt = pending.getLong(KEY_STARTED_AT, 0L);
+        String actualState = callback.getQueryParameter("state");
+        String error = callback.getQueryParameter("error");
+        String description = callback.getQueryParameter("error_description");
+        if (!secureEquals(expectedState, actualState)
+                || verifier.isEmpty()
+                || startedAt <= 0L
+                || System.currentTimeMillis() - startedAt > MAX_PENDING_AGE_MS) {
+            clearPending(context);
+            throw new SecurityException("X sign-in expired or its security state did not match.");
+        }
+        if (error != null && !error.isEmpty()) {
+            clearPending(context);
+            throw new Exception(description == null || description.isEmpty() ? error : description);
+        }
+        String code = callback.getQueryParameter("code");
+        clearPending(context);
+        if (code == null || code.isEmpty()) {
+            throw new Exception("X did not return an authorization code.");
+        }
+        XOAuthTokens tokens = XOAuthClient.exchangeCode(code, verifier);
+        SecureXTokenStore.save(context, tokens);
+        AnnouncementPreferences.setMonitoringEnabled(context, true);
+        ResetWatchScheduler.ensureScheduled(context);
+        ResetWatchScheduler.requestImmediate(context);
+    }
+
+    public static void disconnect(Context context) {
+        SecureXTokenStore.clear(context);
+        clearPending(context);
+        AnnouncementPreferences.setMonitoringEnabled(context, false);
+        AnnouncementPreferences.clearRemoteState(context);
+        ResetWatchNotificationManager.clearState(context);
+        ResetWatchScheduler.cancel(context);
+    }
+
+    private static void clearPending(Context context) {
+        prefs(context).edit().clear().commit();
+    }
+
+    private static SharedPreferences prefs(Context context) {
+        Context app = context.getApplicationContext();
+        return (app == null ? context : app).getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    private static boolean secureEquals(String expected, String actual) {
+        if (expected == null || actual == null || expected.isEmpty()) return false;
+        return MessageDigest.isEqual(expected.getBytes(StandardCharsets.UTF_8),
+                actual.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/XAuthorizationException.java
+++ b/app/src/main/java/dev/bennett/codexmeter/XAuthorizationException.java
@@ -1,0 +1,8 @@
+package dev.bennett.codexmeter;
+
+/** Signals credentials that cannot recover without a new X authorization grant. */
+final class XAuthorizationException extends Exception {
+    XAuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/XOAuthClient.java
+++ b/app/src/main/java/dev/bennett/codexmeter/XOAuthClient.java
@@ -1,0 +1,156 @@
+package dev.bennett.codexmeter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.net.ssl.HttpsURLConnection;
+import org.json.JSONObject;
+
+/** Minimal public-client OAuth implementation for X native apps. */
+public final class XOAuthClient {
+    private static final String TOKEN_URL = "https://api.x.com/2/oauth2/token";
+    private static final int MAX_RESPONSE_BYTES = 256 * 1024;
+
+    private XOAuthClient() {
+    }
+
+    public static XOAuthTokens exchangeCode(String code, String verifier) throws Exception {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("code", code);
+        form.put("grant_type", "authorization_code");
+        form.put("client_id", BuildConfig.X_CLIENT_ID);
+        form.put("redirect_uri", XOAuthFlow.REDIRECT_URI);
+        form.put("code_verifier", verifier);
+        return parse(postForm(form), null, true);
+    }
+
+    public static XOAuthTokens refresh(XOAuthTokens current) throws Exception {
+        if (current == null || current.refreshToken.isEmpty()) {
+            throw new XAuthorizationException("Reconnect X to continue reset checks.");
+        }
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("refresh_token", current.refreshToken);
+        form.put("grant_type", "refresh_token");
+        form.put("client_id", BuildConfig.X_CLIENT_ID);
+        return current.mergeRefresh(parse(postForm(form), current, true));
+    }
+
+    static XOAuthTokens parse(String json, XOAuthTokens current, boolean requireRefresh)
+            throws Exception {
+        JSONObject object = new JSONObject(json);
+        String access = object.optString("access_token", "");
+        String refresh = object.optString("refresh_token", "");
+        long expiresIn = object.optLong("expires_in", 0L);
+        if (access.isEmpty() || (requireRefresh && refresh.isEmpty()) || expiresIn <= 0L) {
+            throw new XAuthorizationException("X returned incomplete credentials. Reconnect X.");
+        }
+        XOAuthTokens tokens = new XOAuthTokens(access, refresh,
+                System.currentTimeMillis() + expiresIn * 1000L);
+        return tokens;
+    }
+
+    private static String postForm(Map<String, String> values) throws Exception {
+        byte[] body = formEncode(values).getBytes(StandardCharsets.UTF_8);
+        HttpsURLConnection connection =
+                (HttpsURLConnection) URI.create(TOKEN_URL).toURL().openConnection();
+        try {
+            connection.setRequestMethod("POST");
+            connection.setConnectTimeout(15_000);
+            connection.setReadTimeout(25_000);
+            connection.setDoOutput(true);
+            connection.setUseCaches(false);
+            connection.setInstanceFollowRedirects(false);
+            connection.setRequestProperty("Content-Type",
+                    "application/x-www-form-urlencoded;charset=UTF-8");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("Accept-Encoding", "identity");
+            connection.setRequestProperty("User-Agent", AppConstants.resetWatchUserAgent());
+            connection.setFixedLengthStreamingMode(body.length);
+            try (OutputStream output = connection.getOutputStream()) {
+                output.write(body);
+            }
+            int status = connection.getResponseCode();
+            if (!"https".equalsIgnoreCase(connection.getURL().getProtocol())
+                    || !"api.x.com".equalsIgnoreCase(connection.getURL().getHost())) {
+                throw new SecurityException("X authentication redirected to an untrusted host.");
+            }
+            String response = read(status >= 200 && status < 400
+                    ? connection.getInputStream() : connection.getErrorStream());
+            if (status < 200 || status >= 300) {
+                String message = error(response,
+                        "X authentication failed with HTTP " + status + ".");
+                if (isPermanentAuthError(status, response)) {
+                    throw new XAuthorizationException(message);
+                }
+                throw new Exception(message);
+            }
+            return response;
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static String formEncode(Map<String, String> values) throws Exception {
+        StringBuilder result = new StringBuilder();
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            if (result.length() > 0) result.append('&');
+            result.append(URLEncoder.encode(entry.getKey(), "UTF-8"))
+                    .append('=')
+                    .append(URLEncoder.encode(entry.getValue(), "UTF-8"));
+        }
+        return result.toString();
+    }
+
+    private static String read(InputStream input) throws Exception {
+        if (input == null) return "";
+        try (InputStream stream = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int total = 0;
+            int count;
+            while ((count = stream.read(buffer)) != -1) {
+                total += count;
+                if (total > MAX_RESPONSE_BYTES) {
+                    throw new Exception("X authentication returned too much data.");
+                }
+                output.write(buffer, 0, count);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static String error(String body, String fallback) {
+        try {
+            JSONObject object = new JSONObject(body == null ? "" : body);
+            String description = object.optString("error_description", "");
+            if (!description.isEmpty()) return description;
+            String error = object.optString("error", "");
+            if (!error.isEmpty()) return error;
+            String title = object.optString("title", "");
+            if (!title.isEmpty()) return title;
+        } catch (Exception ignored) {
+        }
+        return fallback;
+    }
+
+    private static boolean isPermanentAuthError(int status, String body) {
+        if (status != HttpURLConnection.HTTP_BAD_REQUEST
+                && status != HttpURLConnection.HTTP_UNAUTHORIZED
+                && status != HttpURLConnection.HTTP_FORBIDDEN) {
+            return false;
+        }
+        try {
+            String code = new JSONObject(body == null ? "" : body)
+                    .optString("error", "");
+            return "invalid_grant".equals(code) || "invalid_client".equals(code)
+                    || "unauthorized_client".equals(code);
+        } catch (Exception ignored) {
+            return status == HttpURLConnection.HTTP_UNAUTHORIZED;
+        }
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/XOAuthFlow.java
+++ b/app/src/main/java/dev/bennett/codexmeter/XOAuthFlow.java
@@ -1,0 +1,36 @@
+package dev.bennett.codexmeter;
+
+import java.net.URLEncoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Pure OAuth URL construction for X's native-app Authorization Code + PKCE flow. */
+public final class XOAuthFlow {
+    public static final String REDIRECT_URI = "codexmeter://x-auth/complete";
+    public static final String SCOPE = "tweet.read users.read offline.access";
+
+    private XOAuthFlow() {
+    }
+
+    public static String authorizeUrl(String clientId, Pkce pkce) throws Exception {
+        if (clientId == null || clientId.trim().isEmpty() || pkce == null) {
+            throw new IllegalArgumentException("X OAuth is not configured.");
+        }
+        Map<String, String> parameters = new LinkedHashMap<>();
+        parameters.put("response_type", "code");
+        parameters.put("client_id", clientId.trim());
+        parameters.put("redirect_uri", REDIRECT_URI);
+        parameters.put("scope", SCOPE);
+        parameters.put("state", pkce.state);
+        parameters.put("code_challenge", pkce.challenge);
+        parameters.put("code_challenge_method", "S256");
+        StringBuilder url = new StringBuilder("https://x.com/i/oauth2/authorize?");
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            if (url.charAt(url.length() - 1) != '?') url.append('&');
+            url.append(URLEncoder.encode(entry.getKey(), "UTF-8"))
+                    .append('=')
+                    .append(URLEncoder.encode(entry.getValue(), "UTF-8"));
+        }
+        return url.toString();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/XOAuthTokens.java
+++ b/app/src/main/java/dev/bennett/codexmeter/XOAuthTokens.java
@@ -1,0 +1,49 @@
+package dev.bennett.codexmeter;
+
+import org.json.JSONObject;
+
+/** OAuth 2.0 user tokens for read-only X API access. */
+public final class XOAuthTokens {
+    public final String accessToken;
+    public final String refreshToken;
+    public final long expiresAtMillis;
+
+    XOAuthTokens(String accessToken, String refreshToken, long expiresAtMillis) {
+        this.accessToken = safe(accessToken);
+        this.refreshToken = safe(refreshToken);
+        this.expiresAtMillis = Math.max(0L, expiresAtMillis);
+    }
+
+    boolean isUsable() {
+        return !accessToken.isEmpty();
+    }
+
+    boolean shouldRefresh(long now) {
+        return !refreshToken.isEmpty() && expiresAtMillis <= now + 5 * 60 * 1000L;
+    }
+
+    JSONObject toJson() throws Exception {
+        return new JSONObject()
+                .put("access_token", accessToken)
+                .put("refresh_token", refreshToken)
+                .put("expires_at", expiresAtMillis);
+    }
+
+    static XOAuthTokens fromJson(JSONObject object) {
+        return new XOAuthTokens(object.optString("access_token", ""),
+                object.optString("refresh_token", ""),
+                object.optLong("expires_at", 0L));
+    }
+
+    XOAuthTokens mergeRefresh(XOAuthTokens updated) {
+        if (updated == null) return this;
+        return new XOAuthTokens(
+                updated.accessToken.isEmpty() ? accessToken : updated.accessToken,
+                updated.refreshToken.isEmpty() ? refreshToken : updated.refreshToken,
+                updated.expiresAtMillis > 0L ? updated.expiresAtMillis : expiresAtMillis);
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/XPost.java
+++ b/app/src/main/java/dev/bennett/codexmeter/XPost.java
@@ -1,0 +1,44 @@
+package dev.bennett.codexmeter;
+
+import org.json.JSONObject;
+
+/** Sanitized post metadata and its local reset signal. */
+public final class XPost {
+    public final String id;
+    public final String text;
+    public final long createdAtMillis;
+    public final String url;
+    public final ResetSignal signal;
+
+    XPost(String id, String text, long createdAtMillis, ResetSignal signal) {
+        this.id = safe(id, 32);
+        this.text = safe(text, 2000);
+        this.createdAtMillis = Math.max(0L, createdAtMillis);
+        this.url = ResetWatchSource.postUrl(this.id);
+        this.signal = signal == null ? new ResetSignal(ResetSignal.NONE, 0) : signal;
+    }
+
+    JSONObject toJson() throws Exception {
+        return new JSONObject()
+                .put("id", id)
+                .put("text", text)
+                .put("created_at_millis", createdAtMillis)
+                .put("category", signal.category)
+                .put("likelihood", signal.likelihood);
+    }
+
+    static XPost fromJson(JSONObject object) {
+        if (object == null) return null;
+        String id = object.optString("id", "");
+        if (!XTimelineParser.isValidPostId(id)) return null;
+        return new XPost(id, object.optString("text", ""),
+                object.optLong("created_at_millis", 0L),
+                new ResetSignal(object.optString("category", ResetSignal.NONE),
+                        object.optInt("likelihood", 0)));
+    }
+
+    private static String safe(String value, int max) {
+        String cleaned = value == null ? "" : value.trim();
+        return cleaned.length() <= max ? cleaned : cleaned.substring(0, max);
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/XTimelineParser.java
+++ b/app/src/main/java/dev/bennett/codexmeter/XTimelineParser.java
@@ -1,0 +1,91 @@
+package dev.bennett.codexmeter;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/** Parses the bounded X API v2 user-posts response used by the reset watch. */
+public final class XTimelineParser {
+    private XTimelineParser() {
+    }
+
+    public static List<XPost> parse(String json) throws Exception {
+        JSONObject root = new JSONObject(json == null || json.trim().isEmpty() ? "{}" : json);
+        JSONArray data = root.optJSONArray("data");
+        if (data == null) return Collections.emptyList();
+
+        ArrayList<XPost> posts = new ArrayList<>();
+        for (int index = 0; index < data.length() && posts.size() < 100; index++) {
+            JSONObject item = data.optJSONObject(index);
+            if (item == null) continue;
+            String id = item.optString("id", "");
+            String text = clean(item.optString("text", ""), 2000);
+            if (!isValidPostId(id) || text.isEmpty()) continue;
+            long createdAt = parseInstant(item.optString("created_at", ""));
+            posts.add(new XPost(id, text, createdAt,
+                    ResetAnnouncementClassifier.classify(text)));
+        }
+        posts.sort(new Comparator<XPost>() {
+            @Override
+            public int compare(XPost left, XPost right) {
+                int time = Long.compare(right.createdAtMillis, left.createdAtMillis);
+                return time != 0 ? time : -compareIds(left.id, right.id);
+            }
+        });
+        return Collections.unmodifiableList(posts);
+    }
+
+    static String newestId(String json, List<XPost> posts) {
+        try {
+            JSONObject meta = new JSONObject(json == null ? "{}" : json).optJSONObject("meta");
+            String newest = meta == null ? "" : meta.optString("newest_id", "");
+            if (isValidPostId(newest)) return newest;
+        } catch (Exception ignored) {
+        }
+        String newest = "";
+        if (posts != null) {
+            for (XPost post : posts) {
+                if (post != null && compareIds(post.id, newest) > 0) newest = post.id;
+            }
+        }
+        return newest;
+    }
+
+    static int compareIds(String left, String right) {
+        String a = isValidPostId(left) ? stripLeadingZeroes(left) : "";
+        String b = isValidPostId(right) ? stripLeadingZeroes(right) : "";
+        if (a.length() != b.length()) return Integer.compare(a.length(), b.length());
+        return a.compareTo(b);
+    }
+
+    static boolean isValidPostId(String value) {
+        if (value == null || value.isEmpty() || value.length() > 32) return false;
+        for (int index = 0; index < value.length(); index++) {
+            if (value.charAt(index) < '0' || value.charAt(index) > '9') return false;
+        }
+        return true;
+    }
+
+    private static String stripLeadingZeroes(String value) {
+        int index = 0;
+        while (index + 1 < value.length() && value.charAt(index) == '0') index++;
+        return value.substring(index);
+    }
+
+    private static long parseInstant(String value) {
+        try {
+            return Instant.parse(value).toEpochMilli();
+        } catch (Exception ignored) {
+            return 0L;
+        }
+    }
+
+    private static String clean(String value, int max) {
+        String cleaned = value == null ? "" : value.trim();
+        return cleaned.length() <= max ? cleaned : cleaned.substring(0, max);
+    }
+}

--- a/app/src/main/res/values/settings_arrays.xml
+++ b/app/src/main/res/values/settings_arrays.xml
@@ -20,6 +20,12 @@
     <string-array name="settings_refresh_values">
         <item>5</item><item>10</item><item>15</item><item>30</item><item>60</item><item>120</item>
     </string-array>
+    <string-array name="reset_watch_interval_entries">
+        <item>30 minutes</item><item>60 minutes</item>
+    </string-array>
+    <string-array name="reset_watch_interval_values">
+        <item>30</item><item>60</item>
+    </string-array>
     <string-array name="settings_metric_entries">
         <item>Both</item><item>5-hour</item><item>Weekly</item>
     </string-array>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -32,6 +32,42 @@
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="Codex reset watch">
+        <Preference
+            android:key="reset_watch_account"
+            android:title="Connect X"
+            android:summary="Read @thsottiaux through the official X API"
+            app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
+            android:key="reset_watch_monitor_ui"
+            android:title="Check for reset announcements"
+            android:summary="Best-effort background checks under Android battery policy" />
+        <ListPreference
+            android:entries="@array/reset_watch_interval_entries"
+            android:entryValues="@array/reset_watch_interval_values"
+            android:key="reset_watch_interval_ui"
+            android:title="Check interval"
+            app:useSimpleSummaryProvider="true" />
+        <SwitchPreferenceCompat
+            android:key="reset_watch_notifications_ui"
+            android:title="Reset-watch notifications"
+            android:summary="Notify only for high-confidence reset or reset-bank posts" />
+        <SwitchPreferenceCompat
+            android:key="reset_watch_banner_ui"
+            android:title="Dashboard banner"
+            android:summary="Show recent reset-related posts and local likelihood" />
+        <Preference
+            android:key="reset_watch_check_now"
+            android:title="Check now"
+            android:summary="Request an immediate X API check"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="reset_watch_status"
+            android:title="Reset-watch status"
+            app:iconSpaceReserved="false"
+            app:selectable="false" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="App updates">
         <SwitchPreferenceCompat
             android:key="automatic_update_checks_ui"
@@ -143,7 +179,7 @@
     <PreferenceCategory android:title="Privacy">
         <Preference
             android:icon="@drawable/ic_oui_privacy"
-            android:summary="OAuth tokens are encrypted with Android Keystore. Requests go only to OpenAI for authentication and ChatGPT &amp; Codex endpoints."
+            android:summary="OAuth tokens are encrypted with Android Keystore. Requests go only to OpenAI and, when reset watch is connected, the official X API."
             android:title="Local data and privacy"
             app:iconSpaceReserved="false"
             app:selectable="false" />

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -30,6 +30,13 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageParser.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetSignal.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAnnouncementClassifier.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetWatchSource.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/XPost.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/XTimelineParser.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/XOAuthTokens.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/XOAuthFlow.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/RateLimitResetCredit.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReminder.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/Pkce.java" \
@@ -72,6 +79,8 @@ grep -q 'NowBarActionReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'MY_PACKAGE_REPLACED' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'android.permission.REQUEST_INSTALL_PACKAGES' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ReleaseUpdateJobService' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'ResetWatchJobService' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'android:host="x-auth"' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'WidgetRepairJobService' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'UpdateInstallReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ReleaseHistoryActivity' "$ROOT/app/src/main/AndroidManifest.xml"
@@ -160,6 +169,14 @@ grep -q 'now_bar_display_mode_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings.xml"
 grep -q 'Live notifications for all apps' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'ResetWatchScheduler.ensureScheduled' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java"
+grep -q 'ACTION_ANNOUNCEMENTS_UPDATED' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'reset_watch_interval_ui' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'ResetAnnouncementClassifier.classify' \
+  "$ROOT/tests/ParserSelfTest.java"
 
 grep -R -q '<Chronometer' "$ROOT/app/src/main/res/layout/widget_lock_"*.xml
 grep -q 'setChronometerCountDown' "$ROOT/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -17,6 +17,9 @@ public final class ParserSelfTest {
         testZeroDurationWindowIgnored();
         testNextResetSelection();
         testCelebrationDetection();
+        testResetAnnouncementClassifier();
+        testXTimelineParser();
+        testXOAuthFlow();
         testResetCreditExpiryReminders();
         testFullWindowHidesResetCountdown();
         testNowBarAutoStart();
@@ -31,7 +34,93 @@ public final class ParserSelfTest {
         testReleaseChecksums();
         testReleaseNotesMarkdown();
         testReleaseUpdatePolicy();
-        System.out.println("All parser, updater, OAuth, onboarding, and widget-option self-tests passed.");
+        System.out.println("All parser, reset-watch, updater, OAuth, onboarding, and widget-option self-tests passed.");
+    }
+
+    private static void testResetAnnouncementClassifier() {
+        ResetSignal bank = ResetAnnouncementClassifier.classify(
+                "Codex usage limits will be fully reset again in the next hour and we will "
+                        + "credit one additional reset into your bank.");
+        check(ResetSignal.RESET_CREDIT.equals(bank.category), "reset-bank classification");
+        check(bank.likelihood >= 90 && bank.isActionable(),
+                "reset-bank post is high confidence");
+
+        ResetSignal imminent = ResetAnnouncementClassifier.classify(
+                "Introducing another usage limit reset for all our ChatGPT Work and Codex "
+                        + "users. Should land over the next 30 minutes.");
+        check(ResetSignal.RESET_IMMINENT.equals(imminent.category),
+                "timed full-reset classification");
+        check(imminent.likelihood >= 90, "timed full reset is very likely");
+
+        ResetSignal complete = ResetAnnouncementClassifier.classify(
+                "Codex usage limits are now reset. Enjoy.");
+        check(ResetSignal.RESET_CONFIRMED.equals(complete.category),
+                "completed reset classification");
+        check(complete.isActionable(), "completed reset is actionable");
+
+        check(ResetSignal.NONE.equals(ResetAnnouncementClassifier.classify(
+                        "We will not reset Codex usage limits today.").category),
+                "negated reset is rejected");
+        check(ResetSignal.NONE.equals(ResetAnnouncementClassifier.classify(
+                        "Reset your password to continue.").category),
+                "unrelated reset is rejected");
+        check(ResetSignal.NONE.equals(ResetAnnouncementClassifier.classify(
+                        "Codex shipped a faster terminal today.").category),
+                "unrelated Codex update is rejected");
+        System.out.println("Reset-watch demo: bank credit, imminent reset, completion, "
+                + "negation, and unrelated-post intents classified locally.");
+    }
+
+    private static void testXTimelineParser() throws Exception {
+        String json = "{\"data\":["
+                + "{\"id\":\"2075820987833274448\",\"created_at\":"
+                + "\"2026-07-11T12:00:00Z\",\"text\":\"Codex usage limits will reset "
+                + "in the next 30 minutes.\"},"
+                + "{\"id\":\"2075820987833274447\",\"created_at\":"
+                + "\"2026-07-11T11:00:00Z\",\"text\":\"A product update.\"},"
+                + "{\"id\":\"bad/id\",\"text\":\"Codex reset soon.\"}],"
+                + "\"meta\":{\"newest_id\":\"2075820987833274448\"}}";
+        List<XPost> posts = XTimelineParser.parse(json);
+        check(posts.size() == 2, "invalid X post IDs are rejected");
+        check("2075820987833274448".equals(posts.get(0).id),
+                "X timeline remains newest first");
+        check(posts.get(0).signal.isActionable(), "X timeline post is classified");
+        check("https://x.com/thsottiaux/status/2075820987833274448"
+                        .equals(posts.get(0).url),
+                "X status URL is canonical");
+        check("2075820987833274448".equals(XTimelineParser.newestId(json, posts)),
+                "X newest ID comes from response metadata");
+        check(XTimelineParser.parse("{\"meta\":{\"result_count\":0}}").isEmpty(),
+                "empty X timeline response is accepted");
+    }
+
+    private static void testXOAuthFlow() throws Exception {
+        Pkce pkce = Pkce.generate();
+        check(pkce.verifier.length() >= 43 && pkce.verifier.length() <= 128,
+                "X PKCE verifier length is RFC compliant");
+        String url = XOAuthFlow.authorizeUrl("native client", pkce);
+        check(url.startsWith("https://x.com/i/oauth2/authorize?"),
+                "X authorization uses the trusted HTTPS host");
+        check(url.contains("client_id=native+client"), "X client ID is encoded");
+        check(url.contains("redirect_uri=codexmeter%3A%2F%2Fx-auth%2Fcomplete"),
+                "X callback URI is exact");
+        check(url.contains("scope=tweet.read+users.read+offline.access"),
+                "X OAuth requests read-only and offline scopes");
+        check(url.contains("code_challenge_method=S256"), "X OAuth requires PKCE S256");
+        check(url.contains("state=" + pkce.state), "X OAuth carries CSRF state");
+
+        long expiry = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2);
+        XOAuthTokens tokens = new XOAuthTokens("access", "refresh", expiry);
+        XOAuthTokens restored = XOAuthTokens.fromJson(tokens.toJson());
+        check("access".equals(restored.accessToken)
+                        && "refresh".equals(restored.refreshToken)
+                        && restored.expiresAtMillis == expiry,
+                "X OAuth tokens round-trip through encrypted-store JSON");
+        check(!restored.shouldRefresh(System.currentTimeMillis()),
+                "fresh X access token stays active");
+        check(new XOAuthTokens("a", "r", System.currentTimeMillis())
+                        .shouldRefresh(System.currentTimeMillis()),
+                "expiring X access token requests refresh");
     }
 
     private static void testFullWindowHidesResetCountdown() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add read-only X OAuth 2.0 PKCE using a build-supplied Native App client ID
- poll @thsottiaux every 30 or 60 minutes through the official X API with bounded pagination and disconnect-race protection
- classify reset, reset-bank, confirmation, and general usage signals locally
- surface high-confidence notifications and dismissible dashboard banners
- add parser, classifier, OAuth, and source integration checks

## Configuration
Build with `X_CLIENT_ID` or `-PxClientId=...` from an X Native App whose exact callback URI is `codexmeter://x-auth/complete`.

## Testing
- `./run-tests.sh`
- `./lint.sh`
- `./build.sh`
- `git diff --check main...HEAD`

All checks pass. The release build produces a v2-signed `dist/CodexMeter-2.3.2.apk`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bdc7aff-4b6a-4656-bd61-0082be0bbb70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bdc7aff-4b6a-4656-bd61-0082be0bbb70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

