### PR TITLE
Add Now Bar percentage mode setting (Auto / 5-hour / Weekly)

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -350,7 +350,7 @@ public final class NowBarManager {
             promotionExtras.putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true);
             builder.addExtras(promotionExtras);
             if (Build.VERSION.SDK_INT >= 36) {
-                String criticalPrefix = weeklyFocus && fiveHour != null ? "W " : "";
+                String criticalPrefix = weeklyFocus ? "W " : "";
                 Api36.applyLiveUpdateStyle(context, builder, used,
                         criticalPrefix + remaining + "%");
             }

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -34,6 +34,7 @@ public final class NowBarManager {
     private static final String CHANNEL_ID = "codex_live_monitor_v2";
     private static final String EXTRA_REQUEST_PROMOTED_ONGOING = "android.requestPromotedOngoing";
     private static final String KEY_ACTIVE = "active";
+    private static final String KEY_AUTO_TRIGGER_FOCUS = "auto_trigger_focus";
     private static final String KEY_FOCUS_METRIC = "focus_metric";
     private static final String KEY_POSTED_MODE = "posted_mode";
     private static final String KEY_PREVIEW = "preview";
@@ -63,7 +64,14 @@ public final class NowBarManager {
         if (until <= now) return false;
         NowBarPreferences.clearSuppression(context);
         String focus = computeInitialFocus(context, snapshot, fromAutoStart, now);
-        saveState(context, false, until, focus);
+        String autoTrigger = fromAutoStart
+                ? NowBarPercentMode.triggeredFocus(
+                        NowBarPreferences.getMetric(context),
+                        NowBarPreferences.getThreshold(context),
+                        UsageSnapshot.currentWindow(snapshot.fiveHour, now),
+                        UsageSnapshot.currentWindow(snapshot.weekly, now))
+                : null;
+        saveState(context, false, until, focus, true, autoTrigger);
         if (post(context, snapshot, until, false)) return true;
         stop(context, false);
         return false;
@@ -78,7 +86,7 @@ public final class NowBarManager {
                 now);
         NowBarPreferences.clearSuppression(context);
         String focus = computeInitialFocus(context, preview, false, now);
-        saveState(context, true, until, focus);
+        saveState(context, true, until, focus, true, null);
         if (post(context, preview, until, true)) return true;
         stop(context, false);
         return false;
@@ -163,7 +171,7 @@ public final class NowBarManager {
                 new UsageWindow(18, TimeUnit.DAYS.toSeconds(7), 0L, 0L), now);
         if (!hasStoredActiveState(context) || lockedFocusMetric(context) == null) {
             String focus = computeInitialFocus(context, preview, false, now);
-            saveState(context, true, until, focus);
+            saveState(context, true, until, focus, true, null);
         }
         return post(context, preview, until, true);
     }
@@ -171,7 +179,8 @@ public final class NowBarManager {
     /**
      * Recomputes the progress focus from the current percent-mode setting and usage,
      * then reposts when a monitor is already active. Used when the user changes the
-     * percentage preference in Settings.
+     * percentage preference in Settings. AUTO restores the session auto-start trigger
+     * when one was recorded, so cycling modes does not drop that lock.
      */
     public static synchronized boolean applyPercentModeChange(Context context) {
         if (!hasStoredActiveState(context)) return false;
@@ -182,8 +191,8 @@ public final class NowBarManager {
         }
         boolean preview = isPreview(context);
         UsageSnapshot snapshot;
+        long now = System.currentTimeMillis();
         if (preview) {
-            long now = System.currentTimeMillis();
             snapshot = new UsageSnapshot("plus", true, false, null,
                     new UsageWindow(18, TimeUnit.DAYS.toSeconds(7), 0L, 0L), now);
         } else {
@@ -193,9 +202,18 @@ public final class NowBarManager {
                 return false;
             }
         }
-        String focus = computeInitialFocus(context, snapshot, false, System.currentTimeMillis());
-        saveState(context, preview, until, focus);
-        return post(context, snapshot, until, preview);
+        UsageWindow fiveHour = UsageSnapshot.currentWindow(
+                snapshot == null ? null : snapshot.fiveHour, now);
+        UsageWindow weekly = UsageSnapshot.currentWindow(
+                snapshot == null ? null : snapshot.weekly, now);
+        String focus = NowBarPercentMode.focusForSettingsChange(
+                NowBarPreferences.getPercentMode(context), fiveHour, weekly,
+                sessionAutoTriggerFocus(context));
+        // Preserve KEY_AUTO_TRIGGER_FOCUS across mode switches.
+        saveState(context, preview, until, focus, false, null);
+        if (post(context, snapshot, until, preview)) return true;
+        stop(context, false);
+        return false;
     }
 
     public static synchronized void stop(Context context) {
@@ -299,9 +317,13 @@ public final class NowBarManager {
             fiveHour = UsageSnapshot.currentWindow(fiveHour, now);
             weekly = UsageSnapshot.currentWindow(weekly, now);
         }
-        String focus = NowBarPercentMode.resolveFocus(
-                NowBarPreferences.getPercentMode(context), fiveHour, weekly,
-                lockedFocusMetric(context));
+        String percentMode = NowBarPreferences.getPercentMode(context);
+        String lockedForAuto = null;
+        if (NowBarPercentMode.AUTO.equals(NowBarPercentMode.normalize(percentMode))) {
+            lockedForAuto = sessionAutoTriggerFocus(context);
+            if (lockedForAuto == null) lockedForAuto = lockedFocusMetric(context);
+        }
+        String focus = NowBarPercentMode.resolveFocus(percentMode, fiveHour, weekly, lockedForAuto);
         UsageWindow progressWindow = NowBarPercentMode.selectWindow(focus, fiveHour, weekly);
         int remaining = progressWindow == null ? 0 : progressWindow.remainingPercent();
         int used = progressWindow == null ? 0 : progressWindow.usedPercent;
@@ -471,6 +493,11 @@ public final class NowBarManager {
                 state(context).getString(KEY_FOCUS_METRIC, null));
     }
 
+    private static String sessionAutoTriggerFocus(Context context) {
+        return NowBarPercentMode.normalizeFocusMetric(
+                state(context).getString(KEY_AUTO_TRIGGER_FOCUS, null));
+    }
+
     private static String computeInitialFocus(Context context, UsageSnapshot snapshot,
             boolean fromAutoStart, long now) {
         UsageWindow fiveHour = snapshot == null ? null
@@ -491,7 +518,12 @@ public final class NowBarManager {
         return NowBarPercentMode.lowerRemainingFocus(fiveHour, weekly);
     }
 
-    private static void saveState(Context context, boolean preview, long until, String focus) {
+    /**
+     * @param updateAutoTrigger when true, writes or clears {@link #KEY_AUTO_TRIGGER_FOCUS};
+     *        when false, leaves any existing session auto-start trigger untouched
+     */
+    private static void saveState(Context context, boolean preview, long until, String focus,
+            boolean updateAutoTrigger, String autoTriggerFocus) {
         SharedPreferences.Editor editor = state(context).edit()
                 .putBoolean(KEY_ACTIVE, true)
                 .putBoolean(KEY_PREVIEW, preview)
@@ -501,6 +533,14 @@ public final class NowBarManager {
             editor.remove(KEY_FOCUS_METRIC);
         } else {
             editor.putString(KEY_FOCUS_METRIC, normalizedFocus);
+        }
+        if (updateAutoTrigger) {
+            String normalizedTrigger = NowBarPercentMode.normalizeFocusMetric(autoTriggerFocus);
+            if (normalizedTrigger == null) {
+                editor.remove(KEY_AUTO_TRIGGER_FOCUS);
+            } else {
+                editor.putString(KEY_AUTO_TRIGGER_FOCUS, normalizedTrigger);
+            }
         }
         editor.apply();
     }

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -34,6 +34,7 @@ public final class NowBarManager {
     private static final String CHANNEL_ID = "codex_live_monitor_v2";
     private static final String EXTRA_REQUEST_PROMOTED_ONGOING = "android.requestPromotedOngoing";
     private static final String KEY_ACTIVE = "active";
+    private static final String KEY_FOCUS_METRIC = "focus_metric";
     private static final String KEY_POSTED_MODE = "posted_mode";
     private static final String KEY_PREVIEW = "preview";
     private static final String KEY_UNTIL = "until";
@@ -49,6 +50,10 @@ public final class NowBarManager {
     }
 
     public static synchronized boolean start(Context context) {
+        return startInternal(context, false);
+    }
+
+    private static boolean startInternal(Context context, boolean fromAutoStart) {
         UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
         if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
             return false;
@@ -57,7 +62,8 @@ public final class NowBarManager {
         long until = snapshot.nextResetMillis(now);
         if (until <= now) return false;
         NowBarPreferences.clearSuppression(context);
-        saveState(context, false, until);
+        String focus = computeInitialFocus(context, snapshot, fromAutoStart, now);
+        saveState(context, false, until, focus);
         if (post(context, snapshot, until, false)) return true;
         stop(context, false);
         return false;
@@ -71,7 +77,8 @@ public final class NowBarManager {
                         TimeUnit.DAYS.toSeconds(4), (now + TimeUnit.DAYS.toMillis(4)) / 1000L),
                 now);
         NowBarPreferences.clearSuppression(context);
-        saveState(context, true, until);
+        String focus = computeInitialFocus(context, preview, false, now);
+        saveState(context, true, until, focus);
         if (post(context, preview, until, true)) return true;
         stop(context, false);
         return false;
@@ -106,7 +113,7 @@ public final class NowBarManager {
         if (NowBarPreferences.isSuppressed(context)) return false;
         if (!canPostNotifications(context)) return false;
         if (!NowBarPreferences.meetsThreshold(context, snapshot)) return false;
-        return start(context);
+        return startInternal(context, true);
     }
 
     public static synchronized void restore(Context context) {
@@ -154,7 +161,41 @@ public final class NowBarManager {
         long now = System.currentTimeMillis();
         UsageSnapshot preview = new UsageSnapshot("plus", true, false, null,
                 new UsageWindow(18, TimeUnit.DAYS.toSeconds(7), 0L, 0L), now);
+        if (!hasStoredActiveState(context) || lockedFocusMetric(context) == null) {
+            String focus = computeInitialFocus(context, preview, false, now);
+            saveState(context, true, until, focus);
+        }
         return post(context, preview, until, true);
+    }
+
+    /**
+     * Recomputes the progress focus from the current percent-mode setting and usage,
+     * then reposts when a monitor is already active. Used when the user changes the
+     * percentage preference in Settings.
+     */
+    public static synchronized boolean applyPercentModeChange(Context context) {
+        if (!hasStoredActiveState(context)) return false;
+        long until = activeUntil(context);
+        if (until <= System.currentTimeMillis()) {
+            stop(context, false);
+            return false;
+        }
+        boolean preview = isPreview(context);
+        UsageSnapshot snapshot;
+        if (preview) {
+            long now = System.currentTimeMillis();
+            snapshot = new UsageSnapshot("plus", true, false, null,
+                    new UsageWindow(18, TimeUnit.DAYS.toSeconds(7), 0L, 0L), now);
+        } else {
+            snapshot = AppPreferences.loadSnapshot(context);
+            if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
+                stop(context, false);
+                return false;
+            }
+        }
+        String focus = computeInitialFocus(context, snapshot, false, System.currentTimeMillis());
+        saveState(context, preview, until, focus);
+        return post(context, snapshot, until, preview);
     }
 
     public static synchronized void stop(Context context) {
@@ -258,9 +299,13 @@ public final class NowBarManager {
             fiveHour = UsageSnapshot.currentWindow(fiveHour, now);
             weekly = UsageSnapshot.currentWindow(weekly, now);
         }
-        UsageWindow progressWindow = fiveHour != null ? fiveHour : weekly;
+        String focus = NowBarPercentMode.resolveFocus(
+                NowBarPreferences.getPercentMode(context), fiveHour, weekly,
+                lockedFocusMetric(context));
+        UsageWindow progressWindow = NowBarPercentMode.selectWindow(focus, fiveHour, weekly);
         int remaining = progressWindow == null ? 0 : progressWindow.remainingPercent();
         int used = progressWindow == null ? 0 : progressWindow.usedPercent;
+        boolean weeklyFocus = NowBarPercentMode.isWeeklyFocus(focus);
         String fiveHourText = limitText("5-hour", fiveHour);
         String weeklyText = limitText("Weekly", weekly);
         String title = "Codex usage";
@@ -298,15 +343,16 @@ public final class NowBarManager {
                     refreshActionIcon, "Refresh", refreshIntent).build());
         }
         if (NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(displayMode)) {
-            applySamsungCompatibility(context, builder, fiveHour, weekly, used, until, now,
-                    preview);
+            applySamsungCompatibility(context, builder, fiveHour, weekly, used, remaining,
+                    weeklyFocus, until, now, preview);
         } else {
             Bundle promotionExtras = new Bundle();
             promotionExtras.putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true);
             builder.addExtras(promotionExtras);
             if (Build.VERSION.SDK_INT >= 36) {
+                String criticalPrefix = weeklyFocus && fiveHour != null ? "W " : "";
                 Api36.applyLiveUpdateStyle(context, builder, used,
-                        (fiveHour == null ? "W " : "") + remaining + "%");
+                        criticalPrefix + remaining + "%");
             }
         }
         final Notification notification;
@@ -346,12 +392,11 @@ public final class NowBarManager {
     }
 
     private static void applySamsungCompatibility(Context context, Notification.Builder builder,
-            UsageWindow fiveHour, UsageWindow weekly, int used, long until, long now,
-            boolean preview) {
+            UsageWindow fiveHour, UsageWindow weekly, int used, int focusRemaining,
+            boolean weeklyFocus, long until, long now, boolean preview) {
         String fiveHourText = limitText("5-hour", fiveHour);
         String weeklyText = limitText("Weekly", weekly);
-        int focusRemaining = fiveHour != null ? fiveHour.remainingPercent()
-                : weekly == null ? 0 : weekly.remainingPercent();
+        String focusLabel = weeklyFocus ? "Weekly " : "5-hour ";
         String availableWindows = fiveHour != null && weekly != null
                 ? "Both usage windows"
                 : fiveHour != null ? "5-hour window"
@@ -362,7 +407,7 @@ public final class NowBarManager {
         extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "chipIcon", icon);
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "chipBgColor", Color.rgb(56, 122, 255));
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "chipExpandedText",
-                "Codex · " + (fiveHour == null ? "Weekly " : "5-hour ") + focusRemaining + "%");
+                "Codex · " + focusLabel + focusRemaining + "%");
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "primaryInfo",
                 fiveHourText + " · " + weeklyText);
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "secondaryInfo",
@@ -421,9 +466,43 @@ public final class NowBarManager {
         return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
     }
 
-    private static void saveState(Context context, boolean preview, long until) {
-        state(context).edit().putBoolean(KEY_ACTIVE, true).putBoolean(KEY_PREVIEW, preview)
-                .putLong(KEY_UNTIL, until).apply();
+    private static String lockedFocusMetric(Context context) {
+        return NowBarPercentMode.normalizeFocusMetric(
+                state(context).getString(KEY_FOCUS_METRIC, null));
+    }
+
+    private static String computeInitialFocus(Context context, UsageSnapshot snapshot,
+            boolean fromAutoStart, long now) {
+        UsageWindow fiveHour = snapshot == null ? null
+                : UsageSnapshot.currentWindow(snapshot.fiveHour, now);
+        UsageWindow weekly = snapshot == null ? null
+                : UsageSnapshot.currentWindow(snapshot.weekly, now);
+        String mode = NowBarPreferences.getPercentMode(context);
+        if (!NowBarPercentMode.AUTO.equals(NowBarPercentMode.normalize(mode))) {
+            return NowBarPercentMode.resolveFocus(mode, fiveHour, weekly, null);
+        }
+        if (fromAutoStart) {
+            String triggered = NowBarPercentMode.triggeredFocus(
+                    NowBarPreferences.getMetric(context),
+                    NowBarPreferences.getThreshold(context),
+                    fiveHour, weekly);
+            if (triggered != null) return triggered;
+        }
+        return NowBarPercentMode.lowerRemainingFocus(fiveHour, weekly);
+    }
+
+    private static void saveState(Context context, boolean preview, long until, String focus) {
+        SharedPreferences.Editor editor = state(context).edit()
+                .putBoolean(KEY_ACTIVE, true)
+                .putBoolean(KEY_PREVIEW, preview)
+                .putLong(KEY_UNTIL, until);
+        String normalizedFocus = NowBarPercentMode.normalizeFocusMetric(focus);
+        if (normalizedFocus == null) {
+            editor.remove(KEY_FOCUS_METRIC);
+        } else {
+            editor.putString(KEY_FOCUS_METRIC, normalizedFocus);
+        }
+        editor.apply();
     }
 
     private static boolean hasStoredActiveState(Context context) {

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java
@@ -1,0 +1,103 @@
+package dev.bennett.codexmeter;
+
+/**
+ * Chooses which remaining-percentage value drives the Now Bar / Live Update
+ * progress pill. Explicit modes lock to one window; automatic mode locks to the
+ * window that triggered auto-start (lower remaining when both triggered), or to
+ * the lower remaining value for a manual start.
+ */
+public final class NowBarPercentMode {
+    public static final String AUTO = "auto";
+    public static final String FIVE_HOUR = "five_hour";
+    public static final String WEEKLY = "weekly";
+
+    private NowBarPercentMode() {
+    }
+
+    public static String normalize(String mode) {
+        if (FIVE_HOUR.equals(mode) || WEEKLY.equals(mode)) {
+            return mode;
+        }
+        return AUTO;
+    }
+
+    public static String normalizeFocusMetric(String focus) {
+        if (FIVE_HOUR.equals(focus) || WEEKLY.equals(focus)) {
+            return focus;
+        }
+        return null;
+    }
+
+    /**
+     * Among watched windows that are at or below the auto-start threshold, returns
+     * the focus metric with the lower remaining percentage. Ties prefer five-hour.
+     */
+    public static String triggeredFocus(String autoStartMetric, int threshold,
+            UsageWindow fiveHour, UsageWindow weekly) {
+        String watched = NowBarAutoStart.normalizeMetric(autoStartMetric);
+        boolean fiveTriggered = fiveHour != null
+                && !NowBarAutoStart.METRIC_WEEKLY.equals(watched)
+                && fiveHour.remainingPercent() <= threshold;
+        boolean weeklyTriggered = weekly != null
+                && !NowBarAutoStart.METRIC_FIVE_HOUR.equals(watched)
+                && weekly.remainingPercent() <= threshold;
+        if (fiveTriggered && weeklyTriggered) {
+            return fiveHour.remainingPercent() <= weekly.remainingPercent()
+                    ? FIVE_HOUR : WEEKLY;
+        }
+        if (fiveTriggered) return FIVE_HOUR;
+        if (weeklyTriggered) return WEEKLY;
+        return null;
+    }
+
+    /** Picks the window with the lower remaining percentage among those present. */
+    public static String lowerRemainingFocus(UsageWindow fiveHour, UsageWindow weekly) {
+        if (fiveHour != null && weekly != null) {
+            return fiveHour.remainingPercent() <= weekly.remainingPercent()
+                    ? FIVE_HOUR : WEEKLY;
+        }
+        if (fiveHour != null) return FIVE_HOUR;
+        if (weekly != null) return WEEKLY;
+        return null;
+    }
+
+    /**
+     * Resolves which metric's remaining % should drive the Now Bar progress/pill.
+     *
+     * @param lockedFocusMetric focus captured when the monitor started (AUTO only);
+     *        ignored for explicit five-hour / weekly modes
+     */
+    public static String resolveFocus(String mode, UsageWindow fiveHour, UsageWindow weekly,
+            String lockedFocusMetric) {
+        String normalized = normalize(mode);
+        if (FIVE_HOUR.equals(normalized)) {
+            if (fiveHour != null) return FIVE_HOUR;
+            if (weekly != null) return WEEKLY;
+            return null;
+        }
+        if (WEEKLY.equals(normalized)) {
+            if (weekly != null) return WEEKLY;
+            if (fiveHour != null) return FIVE_HOUR;
+            return null;
+        }
+        String locked = normalizeFocusMetric(lockedFocusMetric);
+        if (FIVE_HOUR.equals(locked) && fiveHour != null) return FIVE_HOUR;
+        if (WEEKLY.equals(locked) && weekly != null) return WEEKLY;
+        return lowerRemainingFocus(fiveHour, weekly);
+    }
+
+    public static UsageWindow selectWindow(String focus, UsageWindow fiveHour,
+            UsageWindow weekly) {
+        if (WEEKLY.equals(focus)) {
+            return weekly != null ? weekly : fiveHour;
+        }
+        if (FIVE_HOUR.equals(focus)) {
+            return fiveHour != null ? fiveHour : weekly;
+        }
+        return fiveHour != null ? fiveHour : weekly;
+    }
+
+    public static boolean isWeeklyFocus(String focus) {
+        return WEEKLY.equals(normalizeFocusMetric(focus));
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java
@@ -100,4 +100,18 @@ public final class NowBarPercentMode {
     public static boolean isWeeklyFocus(String focus) {
         return WEEKLY.equals(normalizeFocusMetric(focus));
     }
+
+    /**
+     * Resolves focus when the user changes the percentage preference mid-session.
+     * Explicit modes ignore the session auto-start trigger; AUTO restores it so
+     * cycling AUTO → weekly → AUTO keeps the original trigger lock.
+     */
+    public static String focusForSettingsChange(String mode, UsageWindow fiveHour,
+            UsageWindow weekly, String sessionAutoTriggerFocus) {
+        String normalized = normalize(mode);
+        if (!AUTO.equals(normalized)) {
+            return resolveFocus(normalized, fiveHour, weekly, null);
+        }
+        return resolveFocus(AUTO, fiveHour, weekly, sessionAutoTriggerFocus);
+    }
 }

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java
@@ -12,6 +12,7 @@ public final class NowBarPreferences {
     private static final String KEY_AUTO_ENABLED = "auto_enabled";
     private static final String KEY_DISPLAY_MODE = "display_mode";
     private static final String KEY_METRIC = "metric";
+    private static final String KEY_PERCENT_MODE = "percent_mode";
     private static final String KEY_SUPPRESS_UNTIL = "suppress_until";
     private static final String KEY_THRESHOLD = "threshold";
     private static final String PREFS = "codex_meter_now_bar_prefs_v1";
@@ -35,6 +36,16 @@ public final class NowBarPreferences {
     public static void setDisplayMode(Context context, String mode) {
         prefs(context).edit().putString(KEY_DISPLAY_MODE,
                 NowBarDisplayMode.normalize(mode)).apply();
+    }
+
+    public static String getPercentMode(Context context) {
+        return NowBarPercentMode.normalize(prefs(context).getString(KEY_PERCENT_MODE,
+                NowBarPercentMode.AUTO));
+    }
+
+    public static void setPercentMode(Context context, String mode) {
+        prefs(context).edit().putString(KEY_PERCENT_MODE,
+                NowBarPercentMode.normalize(mode)).apply();
     }
 
     public static String getMetric(Context context) {

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -58,6 +58,7 @@ public final class SettingsActivity extends AppCompatActivity {
         private SwitchPreferenceCompat nowBarMonitorPreference;
         private SwitchPreferenceCompat nowBarAutoStartPreference;
         private ListPreference nowBarDisplayModePreference;
+        private ListPreference nowBarPercentModePreference;
         private ListPreference nowBarMetricPreference;
         private ListPreference nowBarThresholdPreference;
         private Preference nowBarPermissionPreference;
@@ -528,6 +529,24 @@ public final class SettingsActivity extends AppCompatActivity {
                 return true;
             });
 
+            nowBarPercentModePreference = findPreference("now_bar_percent_mode_ui");
+            nowBarPercentModePreference.setPersistent(false);
+            nowBarPercentModePreference.setValue(
+                    NowBarPreferences.getPercentMode(requireContext()));
+            nowBarPercentModePreference.setOnPreferenceChangeListener((preference, value) -> {
+                String mode = NowBarPercentMode.normalize(String.valueOf(value));
+                NowBarPreferences.setPercentMode(requireContext(), mode);
+                nowBarPercentModePreference.setValue(mode);
+                if (NowBarManager.isActive(requireContext())
+                        && !NowBarManager.applyPercentModeChange(requireContext())) {
+                    Toast.makeText(requireContext(),
+                            "Could not refresh the percentage mode, so the monitor was stopped.",
+                            Toast.LENGTH_LONG).show();
+                }
+                updateNowBarSummary();
+                return true;
+            });
+
             nowBarMonitorPreference = findPreference("now_bar_monitor_ui");
             nowBarMonitorPreference.setPersistent(false);
             nowBarMonitorPreference.setOnPreferenceChangeListener((preference, value) -> {
@@ -734,6 +753,10 @@ public final class SettingsActivity extends AppCompatActivity {
             if (nowBarDisplayModePreference != null) {
                 nowBarDisplayModePreference.setValue(
                         NowBarPreferences.getDisplayMode(requireContext()));
+            }
+            if (nowBarPercentModePreference != null) {
+                nowBarPercentModePreference.setValue(
+                        NowBarPreferences.getPercentMode(requireContext()));
             }
             if (nowBarPermissionPreference != null) {
                 String summary;

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -11,6 +11,17 @@
         <item>samsung_compatibility</item>
     </string-array>
 
+    <string-array name="now_bar_percent_mode_entries">
+        <item>Auto</item>
+        <item>5-hour usage</item>
+        <item>Weekly usage</item>
+    </string-array>
+    <string-array name="now_bar_percent_mode_values">
+        <item>auto</item>
+        <item>five_hour</item>
+        <item>weekly</item>
+    </string-array>
+
     <array name="widget_support_cell_sizes">
         <item>2x1</item>
         <item>2x2</item>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -104,6 +104,12 @@
             android:key="now_bar_display_mode_ui"
             android:title="Display compatibility"
             app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:entries="@array/now_bar_percent_mode_entries"
+            android:entryValues="@array/now_bar_percent_mode_values"
+            android:key="now_bar_percent_mode_ui"
+            android:title="Percentage left"
+            app:useSimpleSummaryProvider="true" />
         <SwitchPreferenceCompat
             android:key="now_bar_monitor_ui"
             android:title="Monitor until reset"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -162,6 +162,26 @@ grep -q 'NowBarPercentMode.resolveFocus' \
   "$ROOT/tests/ParserSelfTest.java"
 grep -q 'NowBarPercentMode.triggeredFocus' \
   "$ROOT/tests/ParserSelfTest.java"
+grep -q 'NowBarPercentMode.focusForSettingsChange' \
+  "$ROOT/tests/ParserSelfTest.java"
+grep -q 'KEY_AUTO_TRIGGER_FOCUS' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'sessionAutoTriggerFocus' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'focusForSettingsChange' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+# applyPercentModeChange must stop the monitor when post() fails (no zombie active state).
+python3 - <<'PY'
+from pathlib import Path
+text = Path("app/src/main/java/dev/bennett/codexmeter/NowBarManager.java").read_text()
+start = text.index("public static synchronized boolean applyPercentModeChange")
+end = text.index("public static synchronized void stop(Context context)", start)
+block = text[start:end]
+assert "if (post(context, snapshot, until, preview)) return true;" in block
+assert "stop(context, false);" in block
+assert "return false;" in block
+print("applyPercentModeChange stops on post failure.")
+PY
 grep -q 'now_bar_display_mode_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings.xml"
 grep -q 'now_bar_percent_mode_ui' \

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -44,6 +44,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
   "$ROOT/tests/ParserSelfTest.java"
@@ -118,6 +119,7 @@ test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarActionReceiver.jav
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java"
 grep -q 'Build.VERSION.SDK_INT >= 36' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'codex_live_monitor_v2' \
@@ -156,8 +158,20 @@ grep -q 'NowBarAutoStart.shouldStart' \
   "$ROOT/tests/ParserSelfTest.java"
 grep -q 'NowBarDisplayMode.resolve' \
   "$ROOT/tests/ParserSelfTest.java"
+grep -q 'NowBarPercentMode.resolveFocus' \
+  "$ROOT/tests/ParserSelfTest.java"
+grep -q 'NowBarPercentMode.triggeredFocus' \
+  "$ROOT/tests/ParserSelfTest.java"
 grep -q 'now_bar_display_mode_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'now_bar_percent_mode_ui' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'NowBarPreferences.getPercentMode' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'applyPercentModeChange' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'KEY_FOCUS_METRIC' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'Live notifications for all apps' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -160,6 +160,15 @@ public final class ParserSelfTest {
                 "selectWindow returns the focused window");
         check(NowBarPercentMode.selectWindow("weekly", mid, low).remainingPercent() == 5,
                 "focused weekly remaining is used for the pill");
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.focusForSettingsChange("auto", mid, low, "weekly")),
+                "settings change back to AUTO restores session auto-start trigger");
+        check(NowBarPercentMode.FIVE_HOUR.equals(
+                        NowBarPercentMode.focusForSettingsChange("five_hour", mid, low, "weekly")),
+                "settings change to five-hour ignores session auto-start trigger");
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.focusForSettingsChange("auto", mid, low, null)),
+                "settings change to AUTO without trigger picks lower remaining");
         System.out.println("Now Bar percent mode selects auto-trigger, weekly, or five-hour focus.");
     }
 

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -21,6 +21,7 @@ public final class ParserSelfTest {
         testFullWindowHidesResetCountdown();
         testNowBarAutoStart();
         testNowBarDisplayModes();
+        testNowBarPercentModes();
         testJwtMerge();
         testPkce();
         testWidgetOptions();
@@ -98,6 +99,68 @@ public final class ParserSelfTest {
                         NowBarDisplayMode.ANDROID_LIVE_UPDATE, true, 35, false)),
                 "explicit Android Live Update override is preserved");
         System.out.println("Now Bar display mode isolates Android and Samsung notification paths.");
+    }
+
+    private static void testNowBarPercentModes() {
+        UsageWindow high = new UsageWindow(10, 18000L, 600L, 2000000000L); // 90% remaining
+        UsageWindow mid = new UsageWindow(80, 18000L, 600L, 2000000000L); // 20% remaining
+        UsageWindow low = new UsageWindow(95, 604800L, 600L, 2000000000L); // 5% remaining
+
+        check(NowBarPercentMode.AUTO.equals(NowBarPercentMode.normalize(null)),
+                "missing percent mode defaults to auto");
+        check(NowBarPercentMode.AUTO.equals(NowBarPercentMode.normalize("nope")),
+                "invalid percent mode defaults to auto");
+        check(NowBarPercentMode.FIVE_HOUR.equals(NowBarPercentMode.normalize("five_hour")),
+                "five-hour percent mode preserved");
+        check(NowBarPercentMode.WEEKLY.equals(NowBarPercentMode.normalize("weekly")),
+                "weekly percent mode preserved");
+
+        check(NowBarPercentMode.FIVE_HOUR.equals(
+                        NowBarPercentMode.resolveFocus("five_hour", mid, low, null)),
+                "explicit five-hour mode uses five-hour");
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.resolveFocus("weekly", mid, low, null)),
+                "explicit weekly mode uses weekly");
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.resolveFocus("five_hour", null, low, null)),
+                "explicit five-hour falls back to weekly when missing");
+        check(NowBarPercentMode.FIVE_HOUR.equals(
+                        NowBarPercentMode.resolveFocus("weekly", mid, null, null)),
+                "explicit weekly falls back to five-hour when missing");
+
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.triggeredFocus("both", 25, high, low)),
+                "auto trigger picks weekly when only weekly crossed threshold");
+        check(NowBarPercentMode.FIVE_HOUR.equals(
+                        NowBarPercentMode.triggeredFocus("both", 25, mid, high)),
+                "auto trigger picks five-hour when only five-hour crossed threshold");
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.triggeredFocus("both", 25, mid, low)),
+                "auto trigger picks lower remaining when both crossed threshold");
+        check(NowBarPercentMode.FIVE_HOUR.equals(
+                        NowBarPercentMode.triggeredFocus("five_hour", 25, mid, low)),
+                "auto trigger respects five-hour-only watch metric");
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.triggeredFocus("weekly", 25, mid, low)),
+                "auto trigger respects weekly-only watch metric");
+
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.resolveFocus("auto", mid, low, "weekly")),
+                "auto mode keeps locked weekly focus from trigger");
+        check(NowBarPercentMode.FIVE_HOUR.equals(
+                        NowBarPercentMode.resolveFocus("auto", mid, low, "five_hour")),
+                "auto mode keeps locked five-hour focus from trigger");
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.resolveFocus("auto", mid, low, null)),
+                "auto mode without lock picks lower remaining");
+        check(NowBarPercentMode.WEEKLY.equals(
+                        NowBarPercentMode.lowerRemainingFocus(high, low)),
+                "lower remaining prefers weekly when it is lower");
+        check(NowBarPercentMode.selectWindow("weekly", mid, low) == low,
+                "selectWindow returns the focused window");
+        check(NowBarPercentMode.selectWindow("weekly", mid, low).remainingPercent() == 5,
+                "focused weekly remaining is used for the pill");
+        System.out.println("Now Bar percent mode selects auto-trigger, weekly, or five-hour focus.");
     }
 
     private static void testStandardUsage() throws Exception {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a **Percentage left** setting under Now Bar so the compact progress pill / Live Update critical percentage can follow:

- **Auto** — locks to the usage window that triggered auto-start; when both windows crossed the threshold, picks the lower remaining %
- **5-hour usage** — always drives the pill from the 5-hour window (falls back to weekly if missing)
- **Weekly usage** — always drives the pill from the weekly window (falls back to 5-hour if missing)

The expanded notification text still shows both windows (`5-hour: X% left · Weekly: Y% left`); only the progress/pill focus changes.

Changing the setting while a monitor is active recomputes focus and reposts immediately. AUTO restores the session auto-start trigger across mode cycles. If a mid-session repost fails, the monitor is stopped (no zombie active state).

## Test plan
- [x] `./run-tests.sh` (includes new `NowBarPercentMode` self-tests + source checks)
- [x] Greptile P1: `applyPercentModeChange` stops on `post()` failure
- [x] Greptile P2: AUTO re-lock preserves `KEY_AUTO_TRIGGER_FOCUS` across settings changes
- [ ] On device: Settings → Now Bar → Percentage left → Auto / 5-hour / Weekly and confirm the compact pill updates
- [ ] Auto-start with only weekly below threshold → pill shows weekly remaining
- [ ] Auto-start with both below threshold → pill shows the lower remaining value
- [ ] Explicit Weekly with both windows available → pill ignores 5-hour even when it is lower
- [ ] Cycle AUTO → Weekly → AUTO after auto-start and confirm the original trigger focus returns
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e8d8d1c-5200-4ad9-b5cf-e4c82819c25b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e8d8d1c-5200-4ad9-b5cf-e4c82819c25b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

