### PR TITLE
Prepare Codex Meter 2.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.3.3 — 2026-07-17
+
+### Added
+
+- Now Bar percentage-mode setting (Auto / 5-hour / Weekly) so users choose which remaining percentage drives the live-monitor progress pill, with Auto locking to the auto-start trigger window (#33).
+- A `W` prefix on weekly-focused Live Update critical percentage text so compact Now Bar labels stay unambiguous (#33).
+
+### Changed
+
+- Normalized app, widget, and OAuth action buttons to a full-pill corner radius with consistent 18sp bold labels (#32).
+- Changing the percentage mode safely re-posts an active monitor, stops the session if posting fails, and restores Auto to the original auto-start lock instead of recomputing lower-remaining (#33).
+
+### Development
+
+- Expanded regression coverage for Now Bar percent-mode selection, settings-change focus resolution, and failed applyPercentModeChange cleanup (#33).
+
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.3.2...v2.3.3 <!-- pragma: allowlist secret -->
+
 ## 2.3.2 — 2026-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Codex Meter is an unofficial native Android application and widget for viewing the Codex allowance attached to a signed-in ChatGPT account. It displays the rolling five-hour and weekly limits, reset times, reset credits, home-screen widgets, Samsung One UI lock-screen widgets, and optional reset notifications.
 
-## Version 2.3.2
+## Version 2.3.3
 
-Version 2.3.2 adds firmware-aware Android Live Update and Samsung compatibility modes, safe live-monitor mode switching, and in-app notification and Now Bar troubleshooting.
+Version 2.3.3 adds a Now Bar percentage-mode setting (Auto / 5-hour / Weekly), clearer weekly Live Update labels, and consistent full-pill action buttons.
 
 ### Live countdowns
 
@@ -68,7 +68,7 @@ Requirements:
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.3.2`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
+Creating a `v*` tag that matches the Gradle `versionName` (for example `v2.3.3`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases.
 
 ## Platform stability
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "2.3.2"
+        versionCode = 16
+        versionName = "2.3.3"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 15;
-    public static final String VERSION_NAME = "2.3.2";
+    public static final int VERSION_CODE = 16;
+    public static final String VERSION_NAME = "2.3.3";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.3.2 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.3.3 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.3.2"
+VERSION_NAME="2.3.3"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -52,12 +52,12 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.3.2"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 15' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.3.2"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 15' "$ROOT/app/build.gradle.kts"
-grep -q 'codex-meter-android/2.3.2' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.3.2"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.3.3"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 16' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.3.3"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 16' "$ROOT/app/build.gradle.kts"
+grep -q 'codex-meter-android/2.3.3' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.3.3"' "$ROOT/build.sh"
 grep -q 'BenItBuhner/Codex-Meter/releases?per_page=30' "$ROOT/app/build.gradle.kts" # pragma: allowlist secret
 ! grep -R -q 'thatjoshguy67/Codex-Meter' \
   "$ROOT/app/src" "$ROOT/app/build.gradle.kts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump Codex Meter to **2.3.3** (versionCode **16**) and document everything merged since `v2.3.2`.

## Release contents

### Added
- Now Bar percentage-mode setting (Auto / 5-hour / Weekly) so users choose which remaining percentage drives the live-monitor progress pill, with Auto locking to the auto-start trigger window (#33)
- A `W` prefix on weekly-focused Live Update critical percentage text so compact Now Bar labels stay unambiguous (#33)

### Changed
- Normalized app, widget, and OAuth action buttons to a full-pill corner radius with consistent 18sp bold labels (#32)
- Changing the percentage mode safely re-posts an active monitor, stops the session if posting fails, and restores Auto to the original auto-start lock instead of recomputing lower-remaining (#33)

### Development
- Expanded regression coverage for Now Bar percent-mode selection, settings-change focus resolution, and failed `applyPercentModeChange` cleanup (#33)

## Release boundary

`v2.3.2...HEAD` is PRs **#32** and **#33**. This PR only bumps version metadata and release docs — it does **not** create the `v2.3.3` tag or GitHub Release. After merge, tagging `v2.3.3` on the merge commit triggers CI to build the signed APK and publish it as **Latest**.

## Testing

- `./run-tests.sh` passed (parser/updater/OAuth/onboarding/widget checks + version guards for 2.3.3 / code 16)
- `./lint.sh` passed
- `./build.sh` produced `dist/CodexMeter-2.3.3.apk` (`versionCode=16`, `versionName=2.3.3`, APK Signature Scheme v2)
- PR CI `build` job succeeded; `release` correctly skipped (tag-only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6a560e7-c438-40a2-ba10-3203236b6e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6a560e7-c438-40a2-ba10-3203236b6e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

