### PR TITLE
Fix update loading spinner clipping and button padding

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
@@ -54,7 +54,7 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
 
     private void showLoading() {
         content.removeAllViews();
-        content.addView(Ui.indeterminateLoading(this));
+        content.addView(Ui.indeterminateLoading(this, "Loading release history"));
     }
 
     private void refresh() {

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
@@ -5,7 +5,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.widget.Button;
 import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.activity.OnBackPressedCallback;
@@ -55,12 +54,7 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
 
     private void showLoading() {
         content.removeAllViews();
-        content.addView(Ui.text(this, "Loading published GitHub releases…", 16,
-                Ui.mainText(dark)));
-        ProgressBar progress = new ProgressBar(this);
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(-2, -2);
-        params.setMargins(0, Ui.dp(this, 20), 0, 0);
-        content.addView(progress, params);
+        content.addView(Ui.indeterminateLoading(this));
     }
 
     private void refresh() {

--- a/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -453,8 +453,20 @@ public final class Ui {
 
     /** One UI circular indeterminate spinner, centered below the rounded content corners. */
     public static SeslProgressBar indeterminateLoading(Context context) {
+        return indeterminateLoading(context, "Loading");
+    }
+
+    /**
+     * One UI circular indeterminate spinner with an accessibility label.
+     * Keeps the page free of clipped loading text while still announcing status to TalkBack.
+     */
+    public static SeslProgressBar indeterminateLoading(Context context, String description) {
         SeslProgressBar loading = new SeslProgressBar(context);
         loading.setIndeterminate(true);
+        if (description != null && !description.isEmpty()) {
+            loading.setContentDescription(description);
+            loading.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
+        }
         LinearLayout.LayoutParams params =
                 new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT,
                         ViewGroup.LayoutParams.WRAP_CONTENT);

--- a/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -11,6 +11,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -32,6 +33,7 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.AppCompatCheckBox;
 import androidx.appcompat.widget.AppCompatSpinner;
+import androidx.appcompat.widget.SeslProgressBar;
 import dev.oneuiproject.oneui.layout.ToolbarLayout;
 import dev.oneuiproject.oneui.ktx.ActivityKt;
 import dev.oneuiproject.oneui.popover.PopOverOptions;
@@ -447,6 +449,20 @@ public final class Ui {
         progressBar.setIndeterminate(false);
         progressBar.setLayoutParams(new LinearLayout.LayoutParams(-1, dp(context, isOneUi(context) ? 7.0f : 8.0f)));
         return progressBar;
+    }
+
+    /** One UI circular indeterminate spinner, centered below the rounded content corners. */
+    public static SeslProgressBar indeterminateLoading(Context context) {
+        SeslProgressBar loading = new SeslProgressBar(context);
+        loading.setIndeterminate(true);
+        LinearLayout.LayoutParams params =
+                new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT);
+        params.gravity = Gravity.CENTER_HORIZONTAL;
+        // Keep clear of ToolbarLayout's rounded top corners so the spinner is not clipped.
+        params.topMargin = dp(context, 48.0f);
+        loading.setLayoutParams(params);
+        return loading;
     }
 
     public static Spinner spinner(final Context context, String[] strArr, final boolean z) {

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -57,8 +57,7 @@ public final class UpdateActivity extends AppCompatActivity {
         if (status != null && !operationRunning) {
             String error = UpdatePreferences.installError(this);
             if (!error.isEmpty()) {
-                status.setText(error);
-                status.setTextColor(Ui.danger(dark));
+                setStatus(error, Ui.danger(dark));
             }
         }
     }
@@ -78,14 +77,7 @@ public final class UpdateActivity extends AppCompatActivity {
     private void checkReleases(String requestedVersion) {
         operationRunning = true;
         content.removeAllViews();
-        TextView checking = Ui.text(this, "Checking published GitHub releases…", 16,
-                Ui.mainText(dark));
-        content.addView(checking);
-        ProgressBar loading = new ProgressBar(this);
-        LinearLayout.LayoutParams loadingParams =
-                new LinearLayout.LayoutParams(-2, -2);
-        loadingParams.setMargins(0, Ui.dp(this, 20), 0, 0);
-        content.addView(loading, loadingParams);
+        content.addView(Ui.indeterminateLoading(this));
         executor.execute(() -> {
             try {
                 List<GitHubRelease> releases = ReleaseUpdateClient.check(getApplicationContext());
@@ -179,6 +171,7 @@ public final class UpdateActivity extends AppCompatActivity {
             progressParams.setMargins(0, Ui.dp(this, 18), 0, 0);
             card.addView(progress, progressParams);
             status = Ui.text(this, "", 13, Ui.secondaryText(dark));
+            status.setVisibility(View.GONE);
             LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(-1, -2);
             statusParams.setMargins(0, Ui.dp(this, 10), 0, 0);
             card.addView(status, statusParams);
@@ -270,8 +263,7 @@ public final class UpdateActivity extends AppCompatActivity {
         operationRunning = true;
         progress.setVisibility(View.VISIBLE);
         progress.setProgress(0);
-        status.setTextColor(Ui.secondaryText(dark));
-        status.setText(R.string.update_downloading);
+        setStatus(getString(R.string.update_downloading), Ui.secondaryText(dark));
         executor.execute(() -> {
             try {
                 UpdateInstaller.PreparedUpdate prepared = UpdateInstaller.prepare(
@@ -282,11 +274,13 @@ public final class UpdateActivity extends AppCompatActivity {
                                                 downloaded * 1000L / total));
                                     }
                                 }));
-                postUi(() -> status.setText(R.string.update_opening_installer));
+                postUi(() -> setStatus(getString(R.string.update_opening_installer),
+                        Ui.secondaryText(dark)));
                 UpdateInstaller.commit(getApplicationContext(), prepared);
                 postUi(() -> {
                     operationRunning = false;
-                    status.setText(R.string.update_waiting_for_installer);
+                    setStatus(getString(R.string.update_waiting_for_installer),
+                            Ui.secondaryText(dark));
                 });
             } catch (Exception exception) {
                 UpdatePreferences.setInstallError(getApplicationContext(),
@@ -294,11 +288,19 @@ public final class UpdateActivity extends AppCompatActivity {
                 postUi(() -> {
                     operationRunning = false;
                     progress.setVisibility(View.GONE);
-                    status.setTextColor(Ui.danger(dark));
-                    status.setText(safeMessage(exception));
+                    setStatus(safeMessage(exception), Ui.danger(dark));
                 });
             }
         });
+    }
+
+    private void setStatus(String message, int color) {
+        if (status == null) {
+            return;
+        }
+        status.setTextColor(color);
+        status.setText(message);
+        status.setVisibility(message == null || message.isEmpty() ? View.GONE : View.VISIBLE);
     }
 
     private void confirmOlderDownload() {

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -77,7 +77,7 @@ public final class UpdateActivity extends AppCompatActivity {
     private void checkReleases(String requestedVersion) {
         operationRunning = true;
         content.removeAllViews();
-        content.addView(Ui.indeterminateLoading(this));
+        content.addView(Ui.indeterminateLoading(this, "Checking for updates"));
         executor.execute(() -> {
             try {
                 List<GitHubRelease> releases = ReleaseUpdateClient.check(getApplicationContext());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Tightens the App update screen’s check-for-updates UX:

- Drops the clipped “Checking published GitHub releases…” text (it sat under ToolbarLayout’s rounded top corners).
- Shows the shared One UI `SeslProgressBar` indeterminate spinner instead, centered with enough top margin to clear those corners.
- Applies the same loading treatment to Release history.
- Hides the idle status line under Download/install and Verify/reinstall so the card no longer carries empty text height below the button.

## Test plan
- [x] `./run-tests.sh`
- [x] `./gradlew :app:compileDebugJavaWithJavac`
- [ ] Manually: Settings → Check for updates → confirm spinner only (no corner-clipped text)
- [ ] Manually: available/installed update card → confirm tighter padding under the primary button until download starts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69a58516-37c2-4a61-94d0-274109409522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69a58516-37c2-4a61-94d0-274109409522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

