### PR TITLE
Fix Now Bar progress dot and theme-adaptive Codex logo

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.drawable.Icon;
 import android.os.Build;
@@ -425,9 +426,10 @@ public final class NowBarManager {
                 : fiveHour != null ? "5-hour window"
                 : weekly != null ? "Weekly window" : "Usage window unavailable";
         // Chip sits on the accent fill → always-light Codex mark.
-        // Expanded Now Bar follows system night mode → theme-adaptive Codex mark (no white square).
+        // Expanded Now Bar: pick an explicit light/dark resource at post time. Night-qualified
+        // drawables can resolve wrong inside Samsung SystemUI (separate process / config).
         Icon chipIcon = Icon.createWithResource(context, R.drawable.ic_codex_logo_on_accent);
-        Icon nowBarIcon = Icon.createWithResource(context, R.drawable.ic_codex_logo);
+        Icon nowBarIcon = themeAdaptiveCodexLogo(context);
         Icon progressDot = Icon.createWithResource(context, R.drawable.ic_now_bar_progress_dot);
         Bundle extras = new Bundle();
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "style", 1);
@@ -461,6 +463,23 @@ public final class NowBarManager {
     private static String limitText(String label, UsageWindow window) {
         return label + ": " + (window == null ? "unavailable"
                 : window.remainingPercent() + "% left");
+    }
+
+    /**
+     * Picks a fixed (non night-qualified) Codex logo resource from the posting process's
+     * current UI mode so SystemUI loads the intended contrast without re-resolving
+     * {@code drawable-night}.
+     */
+    private static Icon themeAdaptiveCodexLogo(Context context) {
+        return Icon.createWithResource(context, themeAdaptiveCodexLogoRes(context));
+    }
+
+    static int themeAdaptiveCodexLogoRes(Context context) {
+        int night = context.getResources().getConfiguration().uiMode
+                & Configuration.UI_MODE_NIGHT_MASK;
+        return night == Configuration.UI_MODE_NIGHT_YES
+                ? R.drawable.ic_codex_logo_dark
+                : R.drawable.ic_codex_logo;
     }
 
     private static void createChannel(NotificationManager manager) {

--- a/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -347,6 +347,7 @@ public final class NowBarManager {
         String displayMode = resolveDisplayMode(context);
 
         Notification.Builder builder = new Notification.Builder(context, CHANNEL_ID)
+                // Official Codex mark (white, no opaque square) — system tints status-bar icons.
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(title)
                 .setContentText(text)
@@ -423,10 +424,14 @@ public final class NowBarManager {
                 ? "Both usage windows"
                 : fiveHour != null ? "5-hour window"
                 : weekly != null ? "Weekly window" : "Usage window unavailable";
-        Icon icon = Icon.createWithResource(context, R.drawable.ic_notification);
+        // Chip sits on the accent fill → always-light Codex mark.
+        // Expanded Now Bar follows system night mode → theme-adaptive Codex mark (no white square).
+        Icon chipIcon = Icon.createWithResource(context, R.drawable.ic_codex_logo_on_accent);
+        Icon nowBarIcon = Icon.createWithResource(context, R.drawable.ic_codex_logo);
+        Icon progressDot = Icon.createWithResource(context, R.drawable.ic_now_bar_progress_dot);
         Bundle extras = new Bundle();
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "style", 1);
-        extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "chipIcon", icon);
+        extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "chipIcon", chipIcon);
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "chipBgColor", Color.rgb(56, 122, 255));
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "chipExpandedText",
                 "Codex · " + focusLabel + focusRemaining + "%");
@@ -437,7 +442,8 @@ public final class NowBarManager {
         extras.putString(SAMSUNG_ONGOING_PREFIX + "description", "Codex usage limits");
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "progress", used);
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "progressMax", 100);
-        extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "nowbarIcon", icon);
+        extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "progressSegments.icon", progressDot);
+        extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "nowbarIcon", nowBarIcon);
         extras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarPrimaryInfo", fiveHourText);
         extras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarSecondaryInfo", weeklyText);
         extras.putString(SAMSUNG_ONGOING_PREFIX + "nowbarIconType", "progress");
@@ -557,8 +563,9 @@ public final class NowBarManager {
             Notification.ProgressStyle style = new Notification.ProgressStyle()
                     .setProgress(used)
                     .setStyledByProgress(true)
+                    // Plain circle tracker — not the brand glyph (that belongs in setSmallIcon).
                     .setProgressTrackerIcon(
-                            Icon.createWithResource(context, R.drawable.ic_notification))
+                            Icon.createWithResource(context, R.drawable.ic_now_bar_progress_dot))
                     .setProgressSegments(Collections.singletonList(
                             new Notification.ProgressStyle.Segment(100)
                                     .setColor(Color.rgb(56, 122, 255))));

--- a/app/src/main/res/drawable-night/ic_codex_logo.xml
+++ b/app/src/main/res/drawable-night/ic_codex_logo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Official Codex mark for status-bar / notification small icons. Always white so the system can tint it; no opaque background square. -->
+<!-- Official Codex mark for Now Bar / Live Update surfaces on dark themes. Transparent background (no white square) so contrast follows the host UI. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/drawable/ic_codex_logo.xml
+++ b/app/src/main/res/drawable/ic_codex_logo.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Official Codex mark for status-bar / notification small icons. Always white so the system can tint it; no opaque background square. -->
+<!-- Official Codex mark for Now Bar / Live Update surfaces on light themes. Transparent background (no white square) so contrast follows the host UI. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FFFFFFFF"
+        android:fillColor="#FF111111"
         android:fillType="evenOdd"
         android:pathData="M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_codex_logo.xml
+++ b/app/src/main/res/drawable/ic_codex_logo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Official Codex mark for Now Bar / Live Update surfaces on light themes. Transparent background (no white square) so contrast follows the host UI. -->
+<!-- Official Codex mark with a dark fill for light Now Bar / Live Update surfaces. Pair with ic_codex_logo_dark; select at post time so SystemUI gets a fixed resource. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/drawable/ic_codex_logo_dark.xml
+++ b/app/src/main/res/drawable/ic_codex_logo_dark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Official Codex mark for Now Bar / Live Update surfaces on dark themes. Transparent background (no white square) so contrast follows the host UI. -->
+<!-- Official Codex mark with a light fill for dark Now Bar / Live Update surfaces. Explicit (non night-qualified) so SystemUI cannot resolve the wrong theme variant. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/drawable/ic_codex_logo_on_accent.xml
+++ b/app/src/main/res/drawable/ic_codex_logo_on_accent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Official Codex mark for status-bar / notification small icons. Always white so the system can tint it; no opaque background square. -->
+<!-- Official Codex mark for accent-colored chip backgrounds (e.g. blue Now Bar chip). Always light for contrast on the accent fill. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/drawable/ic_now_bar_progress_dot.xml
+++ b/app/src/main/res/drawable/ic_now_bar_progress_dot.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Simple filled circle used as the Live Update / Now Bar progress tracker. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,2c5.523,0 10,4.477 10,10s-4.477,10 -10,10S2,17.523 2,12 6.477,2 12,2z"/>
+</vector>

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -132,24 +132,29 @@ grep -q 'ic_now_bar_progress_dot' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'ic_codex_logo_on_accent' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
-grep -q 'R.drawable.ic_codex_logo)' \
+grep -q 'themeAdaptiveCodexLogo' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'ic_codex_logo_dark' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 test -f "$ROOT/app/src/main/res/drawable/ic_now_bar_progress_dot.xml"
 test -f "$ROOT/app/src/main/res/drawable/ic_codex_logo.xml"
-test -f "$ROOT/app/src/main/res/drawable-night/ic_codex_logo.xml"
+test -f "$ROOT/app/src/main/res/drawable/ic_codex_logo_dark.xml"
 test -f "$ROOT/app/src/main/res/drawable/ic_codex_logo_on_accent.xml"
+# Do not rely on night-qualified logos for Samsung extras (SystemUI may mismatch).
+! test -f "$ROOT/app/src/main/res/drawable-night/ic_codex_logo.xml"
 # Progress tracker must be a plain circle, not the brand glyph.
 grep -q 'M12,2c5.523,0 10,4.477 10,10' \
   "$ROOT/app/src/main/res/drawable/ic_now_bar_progress_dot.xml"
 # Codex logo vectors must stay transparent (no baked white square background).
 ! grep -q 'android:pathData="M19.503 0H4.496' \
   "$ROOT/app/src/main/res/drawable/ic_codex_logo.xml" \
+  "$ROOT/app/src/main/res/drawable/ic_codex_logo_dark.xml" \
   "$ROOT/app/src/main/res/drawable/ic_notification.xml" \
   "$ROOT/app/src/main/res/drawable/ic_codex_logo_on_accent.xml"
 grep -q 'fillType="evenOdd"' \
   "$ROOT/app/src/main/res/drawable/ic_notification.xml"
 grep -q '#FF111111' "$ROOT/app/src/main/res/drawable/ic_codex_logo.xml"
-grep -q '#FFFFFFFF' "$ROOT/app/src/main/res/drawable-night/ic_codex_logo.xml"
+grep -q '#FFFFFFFF' "$ROOT/app/src/main/res/drawable/ic_codex_logo_dark.xml"
 grep -q 'android.ongoingActivityNoti.' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'applySamsungCompatibility' \

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -128,6 +128,28 @@ grep -q 'NotificationManager.IMPORTANCE_DEFAULT' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'setSmallIcon(R.drawable.ic_notification)' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'ic_now_bar_progress_dot' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'ic_codex_logo_on_accent' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'R.drawable.ic_codex_logo)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+test -f "$ROOT/app/src/main/res/drawable/ic_now_bar_progress_dot.xml"
+test -f "$ROOT/app/src/main/res/drawable/ic_codex_logo.xml"
+test -f "$ROOT/app/src/main/res/drawable-night/ic_codex_logo.xml"
+test -f "$ROOT/app/src/main/res/drawable/ic_codex_logo_on_accent.xml"
+# Progress tracker must be a plain circle, not the brand glyph.
+grep -q 'M12,2c5.523,0 10,4.477 10,10' \
+  "$ROOT/app/src/main/res/drawable/ic_now_bar_progress_dot.xml"
+# Codex logo vectors must stay transparent (no baked white square background).
+! grep -q 'android:pathData="M19.503 0H4.496' \
+  "$ROOT/app/src/main/res/drawable/ic_codex_logo.xml" \
+  "$ROOT/app/src/main/res/drawable/ic_notification.xml" \
+  "$ROOT/app/src/main/res/drawable/ic_codex_logo_on_accent.xml"
+grep -q 'fillType="evenOdd"' \
+  "$ROOT/app/src/main/res/drawable/ic_notification.xml"
+grep -q '#FF111111' "$ROOT/app/src/main/res/drawable/ic_codex_logo.xml"
+grep -q '#FFFFFFFF' "$ROOT/app/src/main/res/drawable-night/ic_codex_logo.xml"
 grep -q 'android.ongoingActivityNoti.' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'applySamsungCompatibility' \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces the janky brand-glyph progress tracker with a plain circle (`ic_now_bar_progress_dot`) for Android Live Update `ProgressStyle` and Samsung progress segment icons.
- Switches Now Bar / notification icons to the official Codex mark (transparent background — no baked white square).
- Theme-adaptive logo fills without night-qualified SystemUI resolution: light surfaces use `ic_codex_logo`, dark surfaces use explicit `ic_codex_logo_dark`, accent chips use `ic_codex_logo_on_accent`. Status-bar `ic_notification` stays white for system tinting.

## Verification
- `./run-tests.sh` passed
- `./build.sh` produced `dist/CodexMeter-2.3.3.apk` with the new drawables
- Greptile P2 (Samsung night-qualified logo mismatch) addressed by selecting fixed light/dark resources at post time

[After fix](https://cursor.com/agents/bc-8d23fffc-c8a3-4130-b636-3add2ee207f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnowbar_icons_after.png)
[Before broken](https://cursor.com/agents/bc-8d23fffc-c8a3-4130-b636-3add2ee207f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnowbar_icons_before.png)
[nowbar-icon-fix-demo.mp4](https://cursor.com/agents/bc-8d23fffc-c8a3-4130-b636-3add2ee207f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnowbar-icon-fix-demo.mp4)

## Test plan
- [x] `./run-tests.sh`
- [x] Release APK build + resource dump confirms new drawables
- [x] Light/dark/accent/circle scenario boards + demo recording
- [ ] On-device: Now Bar preview in Settings under light and dark system themes


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d23fffc-c8a3-4130-b636-3add2ee207f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d23fffc-c8a3-4130-b636-3add2ee207f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

