### PR TITLE
Add update-check frequency and update-available notifications

### DIFF
--- a/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
+++ b/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
@@ -17,6 +17,8 @@ public final class BootReceiver extends BroadcastReceiver {
                     AppPreferences.loadResetCredits(context));
             NowBarManager.restore(context);
             if ("android.intent.action.MY_PACKAGE_REPLACED".equals(action)) {
+                UpdateNotificationManager.dismiss(context);
+                UpdatePreferences.clearNotifiedVersion(context);
                 WidgetUpgradeRepair.afterPackageReplaced(context);
             } else {
                 WidgetUpgradeRepair.runIfNeeded(context);

--- a/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateScheduler.java
+++ b/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateScheduler.java
@@ -10,8 +10,6 @@ import java.util.concurrent.TimeUnit;
 public final class ReleaseUpdateScheduler {
     private static final int PERIODIC_JOB_ID = 73400;
     private static final int INITIAL_JOB_ID = 73401;
-    private static final long PERIOD = TimeUnit.DAYS.toMillis(1);
-    private static final long FLEX = TimeUnit.HOURS.toMillis(6);
 
     private ReleaseUpdateScheduler() {
     }
@@ -27,14 +25,17 @@ public final class ReleaseUpdateScheduler {
             if (scheduler == null) {
                 return false;
             }
+            int hours = UpdatePreferences.checkIntervalHours(app);
+            long period = UpdateCheckFrequency.periodMillis(hours);
+            long flex = UpdateCheckFrequency.flexMillis(hours);
             boolean scheduled = true;
             JobInfo existing = scheduler.getPendingJob(PERIODIC_JOB_ID);
-            if (existing == null || existing.getIntervalMillis() != PERIOD
-                    || existing.getFlexMillis() != FLEX
+            if (existing == null || existing.getIntervalMillis() != period
+                    || existing.getFlexMillis() != flex
                     || existing.getNetworkType() != JobInfo.NETWORK_TYPE_ANY
                     || !existing.isPersisted()) {
                 JobInfo periodic = base(app, PERIODIC_JOB_ID)
-                        .setPeriodic(PERIOD, FLEX)
+                        .setPeriodic(period, flex)
                         .setPersisted(true)
                         .build();
                 scheduled = scheduler.schedule(periodic) == JobScheduler.RESULT_SUCCESS;

--- a/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -63,6 +63,9 @@ public final class SettingsActivity extends AppCompatActivity {
         private ListPreference nowBarThresholdPreference;
         private Preference nowBarPermissionPreference;
         private Preference updateStatusPreference;
+        private SwitchPreferenceCompat automaticUpdatePreference;
+        private ListPreference updateIntervalPreference;
+        private SwitchPreferenceCompat notifyUpdatePreference;
 
         @Override
         public void onCreatePreferences(Bundle bundle, String rootKey) {
@@ -218,19 +221,55 @@ public final class SettingsActivity extends AppCompatActivity {
         }
 
         private void bindUpdates() {
-            SwitchPreferenceCompat automatic = findPreference("automatic_update_checks_ui");
-            automatic.setPersistent(false);
-            automatic.setChecked(UpdatePreferences.automaticChecks(requireContext()));
-            automatic.setOnPreferenceChangeListener((preference, value) -> {
+            automaticUpdatePreference = findPreference("automatic_update_checks_ui");
+            automaticUpdatePreference.setPersistent(false);
+            automaticUpdatePreference.setChecked(UpdatePreferences.automaticChecks(requireContext()));
+            automaticUpdatePreference.setOnPreferenceChangeListener((preference, value) -> {
                 boolean enabled = (Boolean) value;
                 UpdatePreferences.setAutomaticChecks(requireContext(), enabled);
                 if (enabled) {
                     ReleaseUpdateScheduler.ensureScheduled(requireContext());
                 } else {
                     ReleaseUpdateScheduler.cancel(requireContext());
+                    if (notifyUpdatePreference != null) {
+                        notifyUpdatePreference.setChecked(false);
+                    }
+                }
+                updateAutomaticUpdateEnabledState();
+                updateAutomaticUpdateSummary();
+                return true;
+            });
+
+            updateIntervalPreference = findPreference("update_check_interval_ui");
+            updateIntervalPreference.setPersistent(false);
+            updateIntervalPreference.setValue(
+                    String.valueOf(UpdatePreferences.checkIntervalHours(requireContext())));
+            updateIntervalPreference.setOnPreferenceChangeListener((preference, value) -> {
+                int hours = UpdateCheckFrequency.normalize(Integer.parseInt(String.valueOf(value)));
+                UpdatePreferences.setCheckIntervalHours(requireContext(), hours);
+                updateIntervalPreference.setValue(String.valueOf(hours));
+                ReleaseUpdateScheduler.ensureScheduled(requireContext());
+                updateAutomaticUpdateSummary();
+                return true;
+            });
+
+            notifyUpdatePreference = findPreference("notify_update_available_ui");
+            notifyUpdatePreference.setPersistent(false);
+            notifyUpdatePreference.setChecked(
+                    UpdatePreferences.notifyUpdatesEnabled(requireContext()));
+            notifyUpdatePreference.setOnPreferenceChangeListener((preference, value) -> {
+                boolean enabled = (Boolean) value;
+                if (enabled && !ensureUpdateNotificationPermission()) {
+                    return false;
+                }
+                UpdatePreferences.setNotifyUpdatesEnabled(requireContext(), enabled);
+                if (enabled) {
+                    UpdateNotificationManager.ensureChannel(requireContext());
+                    UpdateNotificationManager.onReleasesUpdated(requireContext());
                 }
                 return true;
             });
+
             updateStatusPreference = findPreference("update_status");
             findPreference("check_for_updates").setOnPreferenceClickListener(preference -> {
                 startActivity(new Intent(requireContext(), UpdateActivity.class)
@@ -241,13 +280,75 @@ public final class SettingsActivity extends AppCompatActivity {
                 Ui.startSecondaryActivity(requireActivity(), ReleaseHistoryActivity.class);
                 return true;
             });
+            updateAutomaticUpdateEnabledState();
+            updateAutomaticUpdateSummary();
             updateUpdateSummary();
+        }
+
+        private void updateAutomaticUpdateEnabledState() {
+            boolean enabled = UpdatePreferences.automaticChecks(requireContext());
+            if (updateIntervalPreference != null) {
+                updateIntervalPreference.setEnabled(enabled);
+            }
+            if (notifyUpdatePreference != null) {
+                notifyUpdatePreference.setEnabled(enabled);
+                if (!enabled) {
+                    notifyUpdatePreference.setChecked(false);
+                }
+            }
+        }
+
+        private void updateAutomaticUpdateSummary() {
+            if (automaticUpdatePreference == null || getContext() == null) {
+                return;
+            }
+            if (!UpdatePreferences.automaticChecks(requireContext())) {
+                automaticUpdatePreference.setSummary("Automatic GitHub release checks are off");
+                return;
+            }
+            automaticUpdatePreference.setSummary(UpdateCheckFrequency.summary(
+                    UpdatePreferences.checkIntervalHours(requireContext())));
+        }
+
+        private boolean ensureUpdateNotificationPermission() {
+            if (Build.VERSION.SDK_INT >= 33
+                    && requireContext().checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+                    != PackageManager.PERMISSION_GRANTED) {
+                requestPermissions(new String[]{"android.permission.POST_NOTIFICATIONS"}, 8603);
+                Toast.makeText(requireContext(),
+                        "Allow notifications, then enable update alerts again.",
+                        Toast.LENGTH_LONG).show();
+                return false;
+            }
+            NotificationManager manager = (NotificationManager) requireContext()
+                    .getSystemService(NOTIFICATION_SERVICE);
+            if (manager != null && manager.areNotificationsEnabled()) {
+                return true;
+            }
+            Toast.makeText(requireContext(),
+                    "Enable app notifications, then turn on update alerts again.",
+                    Toast.LENGTH_LONG).show();
+            return false;
         }
 
         private void updateUpdateSummary() {
             if (updateStatusPreference == null || getContext() == null) {
                 return;
             }
+            if (automaticUpdatePreference != null) {
+                automaticUpdatePreference.setChecked(
+                        UpdatePreferences.automaticChecks(requireContext()));
+            }
+            if (updateIntervalPreference != null) {
+                updateIntervalPreference.setValue(
+                        String.valueOf(UpdatePreferences.checkIntervalHours(requireContext())));
+            }
+            if (notifyUpdatePreference != null) {
+                notifyUpdatePreference.setChecked(
+                        UpdatePreferences.notifyUpdatesEnabled(requireContext()));
+            }
+            updateAutomaticUpdateEnabledState();
+            updateAutomaticUpdateSummary();
             GitHubRelease available = UpdatePreferences.availableUpdate(requireContext());
             GitHubRelease latest = UpdatePreferences.latestStable(requireContext());
             long checkedAt = UpdatePreferences.lastCheckMillis(requireContext());

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 public final class UpdateActivity extends AppCompatActivity {
     public static final String EXTRA_VERSION = "release_version";
     public static final String EXTRA_FORCE_CHECK = "force_check";
+    public static final String EXTRA_START_INSTALL = "start_install";
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private LinearLayout content;
@@ -28,6 +29,7 @@ public final class UpdateActivity extends AppCompatActivity {
     private TextView status;
     private boolean waitingForInstallPermission;
     private boolean operationRunning;
+    private boolean startInstallPending;
     private boolean dark;
 
     @Override
@@ -39,7 +41,26 @@ public final class UpdateActivity extends AppCompatActivity {
         String requested = getIntent().getStringExtra(EXTRA_VERSION);
         release = UpdatePreferences.findVersion(this, requested);
         boolean force = getIntent().getBooleanExtra(EXTRA_FORCE_CHECK, false);
+        startInstallPending = getIntent().getBooleanExtra(EXTRA_START_INSTALL, false);
+        UpdateNotificationManager.dismiss(this);
         if (release == null || force) {
+            checkReleases(requested);
+        } else {
+            render();
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        String requested = intent.getStringExtra(EXTRA_VERSION);
+        startInstallPending = intent.getBooleanExtra(EXTRA_START_INSTALL, false);
+        UpdateNotificationManager.dismiss(this);
+        if (requested != null && !requested.trim().isEmpty()) {
+            release = UpdatePreferences.findVersion(this, requested);
+        }
+        if (release == null) {
             checkReleases(requested);
         } else {
             render();
@@ -196,9 +217,17 @@ public final class UpdateActivity extends AppCompatActivity {
                 new LinearLayout.LayoutParams(-1, Ui.dp(this, 56));
         historyParams.setMargins(0, Ui.dp(this, 20), 0, 0);
         content.addView(history, historyParams);
+
+        if (startInstallPending && comparison > 0 && !irreversible) {
+            startInstallPending = false;
+            content.post(this::requestInstall);
+        } else {
+            startInstallPending = false;
+        }
     }
 
     private void renderError(String message) {
+        startInstallPending = false;
         content.removeAllViews();
         LinearLayout card = Ui.card(this, dark);
         TextView title = Ui.text(this, "Update check unavailable", 20, Ui.mainText(dark));

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java
@@ -1,0 +1,77 @@
+package dev.bennett.codexmeter;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Supported automatic GitHub release-check intervals. Pure Java so self-tests can
+ * validate normalization without Android.
+ */
+public final class UpdateCheckFrequency {
+    public static final int HOURLY = 1;
+    public static final int EVERY_6_HOURS = 6;
+    public static final int EVERY_12_HOURS = 12;
+    public static final int DAILY = 24;
+    public static final int WEEKLY = 168;
+
+    public static final int[] SUPPORTED_HOURS = {
+            HOURLY, EVERY_6_HOURS, EVERY_12_HOURS, DAILY, WEEKLY
+    };
+
+    private UpdateCheckFrequency() {
+    }
+
+    /** Maps stored hours onto a supported interval; unknown values become daily. */
+    public static int normalize(int hours) {
+        for (int supported : SUPPORTED_HOURS) {
+            if (hours == supported) {
+                return supported;
+            }
+        }
+        return DAILY;
+    }
+
+    public static long periodMillis(int hours) {
+        return TimeUnit.HOURS.toMillis(normalize(hours));
+    }
+
+    /**
+     * Flex window for {@link android.app.job.JobInfo#setPeriodic(long, long)}. Kept well
+     * under the period so checks stay near the chosen cadence while Android may still
+     * batch work for battery.
+     */
+    public static long flexMillis(int hours) {
+        switch (normalize(hours)) {
+            case HOURLY:
+                return TimeUnit.MINUTES.toMillis(15);
+            case EVERY_6_HOURS:
+                return TimeUnit.HOURS.toMillis(1);
+            case EVERY_12_HOURS:
+                return TimeUnit.HOURS.toMillis(2);
+            case WEEKLY:
+                return TimeUnit.HOURS.toMillis(12);
+            case DAILY:
+            default:
+                return TimeUnit.HOURS.toMillis(6);
+        }
+    }
+
+    public static String label(int hours) {
+        switch (normalize(hours)) {
+            case HOURLY:
+                return "Every hour";
+            case EVERY_6_HOURS:
+                return "Every 6 hours";
+            case EVERY_12_HOURS:
+                return "Every 12 hours";
+            case WEEKLY:
+                return "Weekly";
+            case DAILY:
+            default:
+                return "Daily";
+        }
+    }
+
+    public static String summary(int hours) {
+        return "Check signed GitHub releases " + label(normalize(hours)).toLowerCase();
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java
@@ -1,0 +1,131 @@
+package dev.bennett.codexmeter;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+/** Posts a one-shot “update available” notification with Open and Update actions. */
+public final class UpdateNotificationManager {
+    static final String CHANNEL_ID = "codex_update_available";
+    static final int NOTIFICATION_ID = 73450;
+
+    private UpdateNotificationManager() {
+    }
+
+    public static void ensureChannel(Context context) {
+        NotificationManager manager = manager(context);
+        if (manager == null) {
+            return;
+        }
+        NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                "App updates", NotificationManager.IMPORTANCE_DEFAULT);
+        channel.setDescription("Alerts when a signed Codex Meter release is available");
+        channel.enableVibration(true);
+        manager.createNotificationChannel(channel);
+    }
+
+    /** After release metadata changes, notify once per available version when enabled. */
+    public static void onReleasesUpdated(Context context) {
+        if (context == null) {
+            return;
+        }
+        Context app = application(context);
+        if (!UpdatePreferences.notifyUpdatesEnabled(app)
+                || !UpdatePreferences.automaticChecks(app)) {
+            return;
+        }
+        GitHubRelease update = UpdatePreferences.availableUpdate(app);
+        if (update == null) {
+            dismiss(app);
+            UpdatePreferences.clearNotifiedVersion(app);
+            return;
+        }
+        String already = UpdatePreferences.notifiedVersion(app);
+        if (update.version.equals(already)) {
+            return;
+        }
+        if (post(app, update)) {
+            UpdatePreferences.setNotifiedVersion(app, update.version);
+        }
+    }
+
+    public static void dismiss(Context context) {
+        NotificationManager manager = manager(context);
+        if (manager != null) {
+            manager.cancel(NOTIFICATION_ID);
+        }
+    }
+
+    private static boolean post(Context context, GitHubRelease release) {
+        NotificationManager manager = manager(context);
+        if (manager == null) {
+            return false;
+        }
+        ensureChannel(context);
+        if (!canPost(context, manager)) {
+            return false;
+        }
+        String title = "Codex Meter " + release.version + " is available";
+        String text = "A signed GitHub release is ready to install.";
+        PendingIntent open = activityPending(context, NOTIFICATION_ID,
+                updateIntent(context, release.version, false));
+        PendingIntent update = activityPending(context, NOTIFICATION_ID + 1,
+                updateIntent(context, release.version, true));
+        Notification notification = new Notification.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setStyle(new Notification.BigTextStyle().bigText(text))
+                .setContentIntent(open)
+                .addAction(new Notification.Action.Builder(R.drawable.ic_notification,
+                        "Open", open).build())
+                .addAction(new Notification.Action.Builder(R.drawable.ic_notification,
+                        "Update", update).build())
+                .setAutoCancel(true)
+                .setCategory(Notification.CATEGORY_STATUS)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
+                .setShowWhen(true)
+                .build();
+        manager.notify(NOTIFICATION_ID, notification);
+        return true;
+    }
+
+    private static Intent updateIntent(Context context, String version, boolean startInstall) {
+        Intent intent = new Intent(context, UpdateActivity.class)
+                .putExtra(UpdateActivity.EXTRA_VERSION, version)
+                .putExtra(UpdateActivity.EXTRA_START_INSTALL, startInstall)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP
+                        | Intent.FLAG_ACTIVITY_NEW_TASK);
+        return intent;
+    }
+
+    private static PendingIntent activityPending(Context context, int requestCode, Intent intent) {
+        return PendingIntent.getActivity(context, requestCode, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    }
+
+    private static boolean canPost(Context context, NotificationManager manager) {
+        if (!manager.areNotificationsEnabled()
+                || (Build.VERSION.SDK_INT >= 33
+                && context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+                != PackageManager.PERMISSION_GRANTED)) {
+            return false;
+        }
+        NotificationChannel channel = manager.getNotificationChannel(CHANNEL_ID);
+        return channel != null && channel.getImportance() != NotificationManager.IMPORTANCE_NONE;
+    }
+
+    private static NotificationManager manager(Context context) {
+        return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    private static Context application(Context context) {
+        Context app = context.getApplicationContext();
+        return app == null ? context : app;
+    }
+}

--- a/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
+++ b/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
@@ -9,6 +9,9 @@ import java.util.List;
 public final class UpdatePreferences {
     private static final String PREFS = "codex_meter_updates_v1";
     private static final String KEY_AUTOMATIC = "automatic";
+    private static final String KEY_NOTIFY = "notify_updates";
+    private static final String KEY_CHECK_INTERVAL_HOURS = "check_interval_hours";
+    private static final String KEY_NOTIFIED_VERSION = "notified_version";
     private static final String KEY_ETAG = "etag";
     private static final String KEY_RELEASES = "releases";
     private static final String KEY_LAST_CHECK = "last_check";
@@ -27,7 +30,56 @@ public final class UpdatePreferences {
     }
 
     public static void setAutomaticChecks(Context context, boolean enabled) {
-        prefs(context).edit().putBoolean(KEY_AUTOMATIC, enabled).apply();
+        SharedPreferences.Editor editor = prefs(context).edit().putBoolean(KEY_AUTOMATIC, enabled);
+        if (!enabled) {
+            editor.putBoolean(KEY_NOTIFY, false);
+        }
+        editor.apply();
+        if (!enabled) {
+            UpdateNotificationManager.dismiss(context);
+            clearNotifiedVersion(context);
+        }
+    }
+
+    public static boolean notifyUpdatesEnabled(Context context) {
+        return automaticChecks(context) && prefs(context).getBoolean(KEY_NOTIFY, false);
+    }
+
+    public static void setNotifyUpdatesEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_NOTIFY, enabled && automaticChecks(context)).apply();
+        if (!enabled) {
+            UpdateNotificationManager.dismiss(context);
+            clearNotifiedVersion(context);
+        }
+    }
+
+    public static int checkIntervalHours(Context context) {
+        return UpdateCheckFrequency.normalize(
+                prefs(context).getInt(KEY_CHECK_INTERVAL_HOURS, UpdateCheckFrequency.DAILY));
+    }
+
+    public static void setCheckIntervalHours(Context context, int hours) {
+        prefs(context).edit()
+                .putInt(KEY_CHECK_INTERVAL_HOURS, UpdateCheckFrequency.normalize(hours))
+                .apply();
+    }
+
+    public static String notifiedVersion(Context context) {
+        return prefs(context).getString(KEY_NOTIFIED_VERSION, "");
+    }
+
+    public static void setNotifiedVersion(Context context, String version) {
+        SharedPreferences.Editor editor = prefs(context).edit();
+        if (version == null || version.trim().isEmpty()) {
+            editor.remove(KEY_NOTIFIED_VERSION);
+        } else {
+            editor.putString(KEY_NOTIFIED_VERSION, version.trim());
+        }
+        editor.apply();
+    }
+
+    public static void clearNotifiedVersion(Context context) {
+        prefs(context).edit().remove(KEY_NOTIFIED_VERSION).apply();
     }
 
     public static long lastCheckMillis(Context context) {
@@ -62,6 +114,7 @@ public final class UpdatePreferences {
             cachedReleases = parsed;
         }
         broadcast(context);
+        UpdateNotificationManager.onReleasesUpdated(context);
     }
 
     public static void markNotModified(Context context) {
@@ -70,6 +123,7 @@ public final class UpdatePreferences {
                 .remove(KEY_LAST_ERROR)
                 .apply();
         broadcast(context);
+        UpdateNotificationManager.onReleasesUpdated(context);
     }
 
     public static void saveError(Context context, String error) {

--- a/app/src/main/res/values/settings_arrays.xml
+++ b/app/src/main/res/values/settings_arrays.xml
@@ -20,6 +20,20 @@
     <string-array name="settings_refresh_values">
         <item>5</item><item>10</item><item>15</item><item>30</item><item>60</item><item>120</item>
     </string-array>
+    <string-array name="settings_update_interval_entries">
+        <item>Every hour</item>
+        <item>Every 6 hours</item>
+        <item>Every 12 hours</item>
+        <item>Daily</item>
+        <item>Weekly</item>
+    </string-array>
+    <string-array name="settings_update_interval_values">
+        <item>1</item>
+        <item>6</item>
+        <item>12</item>
+        <item>24</item>
+        <item>168</item>
+    </string-array>
     <string-array name="settings_metric_entries">
         <item>Both</item><item>5-hour</item><item>Weekly</item>
     </string-array>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -36,7 +36,17 @@
         <SwitchPreferenceCompat
             android:key="automatic_update_checks_ui"
             android:title="Check automatically"
-            android:summary="Check signed GitHub releases about once a day" />
+            android:summary="Check signed GitHub releases on a schedule" />
+        <ListPreference
+            android:entries="@array/settings_update_interval_entries"
+            android:entryValues="@array/settings_update_interval_values"
+            android:key="update_check_interval_ui"
+            android:title="Check frequency"
+            app:useSimpleSummaryProvider="true" />
+        <SwitchPreferenceCompat
+            android:key="notify_update_available_ui"
+            android:title="Notify when update available"
+            android:summary="Show a notification with Open and Update actions" />
         <Preference
             android:key="update_status"
             android:title="Installed version"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -47,6 +47,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
@@ -90,6 +91,25 @@ grep -q 'Open on GitHub' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java"
 grep -q 'Open on GitHub' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java"
+grep -q 'UpdateCheckFrequency' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateScheduler.java"
+grep -q 'notify_update_available_ui' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'update_check_interval_ui' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'settings_update_interval_entries' \
+  "$ROOT/app/src/main/res/values/settings_arrays.xml"
+grep -q 'EXTRA_START_INSTALL' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java"
+grep -q '"Open", open' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java"
+grep -q '"Update", update' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java"
+grep -q 'UpdateNotificationManager.onReleasesUpdated' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java"
+grep -q 'testUpdateCheckFrequency' "$ROOT/tests/ParserSelfTest.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java"
 grep -q 'com.samsung.android.support.ongoing_activity' "$ROOT/app/src/main/AndroidManifest.xml"
 
 grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"

--- a/tests/ParserSelfTest.java
+++ b/tests/ParserSelfTest.java
@@ -32,6 +32,7 @@ public final class ParserSelfTest {
         testReleaseChecksums();
         testReleaseNotesMarkdown();
         testReleaseUpdatePolicy();
+        testUpdateCheckFrequency();
         System.out.println("All parser, updater, OAuth, onboarding, and widget-option self-tests passed.");
     }
 
@@ -599,6 +600,46 @@ public final class ParserSelfTest {
         check(ReleaseUpdatePolicy.irreversibleDetail()
                         .contains(ReleaseUpdatePolicy.FIRST_IN_APP_UPDATE_VERSION),
                 "irreversible detail cites threshold version");
+    }
+
+    private static void testUpdateCheckFrequency() {
+        check(UpdateCheckFrequency.normalize(1) == UpdateCheckFrequency.HOURLY,
+                "hourly interval preserved");
+        check(UpdateCheckFrequency.normalize(6) == UpdateCheckFrequency.EVERY_6_HOURS,
+                "6-hour interval preserved");
+        check(UpdateCheckFrequency.normalize(12) == UpdateCheckFrequency.EVERY_12_HOURS,
+                "12-hour interval preserved");
+        check(UpdateCheckFrequency.normalize(24) == UpdateCheckFrequency.DAILY,
+                "daily interval preserved");
+        check(UpdateCheckFrequency.normalize(168) == UpdateCheckFrequency.WEEKLY,
+                "weekly interval preserved");
+        check(UpdateCheckFrequency.normalize(0) == UpdateCheckFrequency.DAILY,
+                "unknown interval defaults to daily");
+        check(UpdateCheckFrequency.normalize(48) == UpdateCheckFrequency.DAILY,
+                "unsupported interval defaults to daily");
+        check(UpdateCheckFrequency.periodMillis(UpdateCheckFrequency.HOURLY)
+                        == TimeUnit.HOURS.toMillis(1),
+                "hourly period is one hour");
+        check(UpdateCheckFrequency.periodMillis(UpdateCheckFrequency.WEEKLY)
+                        == TimeUnit.DAYS.toMillis(7),
+                "weekly period is seven days");
+        check(UpdateCheckFrequency.flexMillis(UpdateCheckFrequency.DAILY)
+                        == TimeUnit.HOURS.toMillis(6),
+                "daily flex stays at six hours");
+        check(UpdateCheckFrequency.flexMillis(UpdateCheckFrequency.HOURLY)
+                        < UpdateCheckFrequency.periodMillis(UpdateCheckFrequency.HOURLY),
+                "hourly flex is shorter than period");
+        check(UpdateCheckFrequency.label(UpdateCheckFrequency.EVERY_6_HOURS)
+                        .equals("Every 6 hours"),
+                "6-hour label");
+        check(UpdateCheckFrequency.summary(UpdateCheckFrequency.WEEKLY)
+                        .toLowerCase().contains("weekly"),
+                "weekly summary mentions weekly");
+        for (int hours : UpdateCheckFrequency.SUPPORTED_HOURS) {
+            check(UpdateCheckFrequency.flexMillis(hours)
+                            <= UpdateCheckFrequency.periodMillis(hours),
+                    "flex does not exceed period for " + hours + "h");
+        }
     }
 
     private static String jwt(String payload) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Extends the App updates settings so automatic GitHub release checks are no longer hard-wired to once a day, and so users can opt into a notification when a newer signed release shows up.

## Changes
- **Check frequency** list preference: Every hour / Every 6 hours / Every 12 hours / Daily / Weekly (default remains Daily)
- **Notify when update available** toggle (requires automatic checks + notification permission)
- Update notification with **Open** (review in `UpdateActivity`) and **Update** (opens the same screen and starts the verified install flow)
- One notification per available version; cleared after install / package replace / toggle off
- Scheduler reads the chosen interval and reschedules the persisted JobScheduler job accordingly

## Verification
- `./run-tests.sh` passed (includes new `UpdateCheckFrequency` self-tests and source greps)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f09e40d6-7a32-4a16-ae1f-9f277f57abb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f09e40d6-7a32-4a16-ae1f-9f277f57abb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

