### PR TITLE
Add Android settings and authentication export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Android settings transfer: export and import selected sections (app settings, notifications, Now Bar, and ChatGPT authentication) from Settings, with explicit warnings when authentication tokens are included.
+
+### Development
+
+- Added pure-Java coverage for transfer document parsing, section selection, and embedded authentication warnings.
+
 ## 2.3.3 — 2026-07-17
 
 ### Added

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -1,10 +1,12 @@
 package dev.bennett.codexmeter;
 
+import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.GradientDrawable;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -31,8 +33,11 @@ import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 import dev.oneuiproject.oneui.widget.CardItemView;
 import java.math.BigDecimal;
 import java.text.DecimalFormatSymbols;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 /** Settings built from the One UI Design Library preference components used by its sample app. */
@@ -53,6 +58,9 @@ public final class SettingsActivity extends AppCompatActivity {
     }
 
     public static final class SettingsFragment extends PreferenceFragmentCompat {
+        private static final int REQUEST_EXPORT_TRANSFER = 9201;
+        private static final int REQUEST_IMPORT_TRANSFER = 9202;
+
         private Preference expiryTimesPreference;
         private Preference permissionPreference;
         private Preference testNotificationPreference;
@@ -67,6 +75,11 @@ public final class SettingsActivity extends AppCompatActivity {
         private SwitchPreferenceCompat automaticUpdatePreference;
         private ListPreference updateIntervalPreference;
         private SwitchPreferenceCompat notifyUpdatePreference;
+        private boolean pendingExportAppSettings;
+        private boolean pendingExportNotifications;
+        private boolean pendingExportNowBar;
+        private boolean pendingExportAuthentication;
+        private SettingsTransfer.Document pendingImportDocument;
 
         @Override
         public void onCreatePreferences(Bundle bundle, String rootKey) {
@@ -78,10 +91,25 @@ public final class SettingsActivity extends AppCompatActivity {
             bindUpdates();
             bindNotifications();
             bindNowBar();
+            bindTransfer();
             findPreference("about_codex_meter").setOnPreferenceClickListener(preference -> {
                 Ui.startSecondaryActivity(requireActivity(), AboutActivity.class);
                 return true;
             });
+        }
+
+        @Override
+        public void onActivityResult(int requestCode, int resultCode, Intent data) {
+            super.onActivityResult(requestCode, resultCode, data);
+            if (resultCode != Activity.RESULT_OK || data == null || data.getData() == null) {
+                return;
+            }
+            Uri uri = data.getData();
+            if (requestCode == REQUEST_EXPORT_TRANSFER) {
+                finishExport(uri);
+            } else if (requestCode == REQUEST_IMPORT_TRANSFER) {
+                beginImport(uri);
+            }
         }
 
         @Override
@@ -928,6 +956,250 @@ public final class SettingsActivity extends AppCompatActivity {
             permissionPreference.setSummary(allowed ? "Allowed" : "Not allowed");
             if (testNotificationPreference != null) {
                 testNotificationPreference.setEnabled(allowed && ResetAlertPreferences.enabled(requireContext()));
+            }
+        }
+
+        private void bindTransfer() {
+            findPreference("export_settings_transfer").setOnPreferenceClickListener(preference -> {
+                showExportSectionDialog();
+                return true;
+            });
+            findPreference("import_settings_transfer").setOnPreferenceClickListener(preference -> {
+                Intent open = new Intent(Intent.ACTION_OPEN_DOCUMENT)
+                        .addCategory(Intent.CATEGORY_OPENABLE)
+                        .setType("application/json");
+                open.putExtra(Intent.EXTRA_MIME_TYPES, new String[] {
+                        "application/json",
+                        "text/plain",
+                        "text/json",
+                        "*/*"
+                });
+                try {
+                    startActivityForResult(open, REQUEST_IMPORT_TRANSFER);
+                } catch (RuntimeException exception) {
+                    Toast.makeText(requireContext(),
+                            "No file picker is available to import a transfer file.",
+                            Toast.LENGTH_LONG).show();
+                }
+                return true;
+            });
+        }
+
+        private void showExportSectionDialog() {
+            boolean signedIn = SecureTokenStore.isSignedIn(requireContext());
+            String[] labels = {
+                    SettingsTransfer.sectionTitle(SettingsTransfer.SECTION_APP_SETTINGS)
+                            + "\n" + SettingsTransfer.sectionSummary(
+                            SettingsTransfer.SECTION_APP_SETTINGS),
+                    SettingsTransfer.sectionTitle(SettingsTransfer.SECTION_NOTIFICATIONS)
+                            + "\n" + SettingsTransfer.sectionSummary(
+                            SettingsTransfer.SECTION_NOTIFICATIONS),
+                    SettingsTransfer.sectionTitle(SettingsTransfer.SECTION_NOW_BAR)
+                            + "\n" + SettingsTransfer.sectionSummary(
+                            SettingsTransfer.SECTION_NOW_BAR),
+                    SettingsTransfer.sectionTitle(SettingsTransfer.SECTION_AUTHENTICATION)
+                            + "\n" + (signedIn
+                            ? SettingsTransfer.sectionSummary(
+                            SettingsTransfer.SECTION_AUTHENTICATION)
+                            : "Sign in first to export ChatGPT authentication")
+            };
+            boolean[] checked = {true, true, true, false};
+            new AlertDialog.Builder(requireContext())
+                    .setTitle("Export sections")
+                    .setMultiChoiceItems(labels, checked, (dialog, which, isChecked) -> {
+                        if (which == 3 && isChecked && !signedIn) {
+                            checked[3] = false;
+                            ((AlertDialog) dialog).getListView().setItemChecked(3, false);
+                            Toast.makeText(requireContext(),
+                                    "Sign in before exporting authentication.",
+                                    Toast.LENGTH_LONG).show();
+                            return;
+                        }
+                        checked[which] = isChecked;
+                    })
+                    .setNegativeButton("Cancel", null)
+                    .setPositiveButton("Continue", (dialog, which) -> {
+                        boolean any = checked[0] || checked[1] || checked[2] || checked[3];
+                        if (!any) {
+                            Toast.makeText(requireContext(),
+                                    "Select at least one section to export.",
+                                    Toast.LENGTH_LONG).show();
+                            return;
+                        }
+                        if (checked[3]) {
+                            confirmSensitiveExport(checked[0], checked[1], checked[2], true);
+                        } else {
+                            launchExportPicker(checked[0], checked[1], checked[2], false);
+                        }
+                    })
+                    .show();
+        }
+
+        private void confirmSensitiveExport(boolean appSettings, boolean notifications,
+                boolean nowBar, boolean authentication) {
+            new AlertDialog.Builder(requireContext())
+                    .setTitle("Authentication will be included")
+                    .setMessage(SettingsTransfer.SECURITY_WARNING
+                            + "\n\nOnly continue if you are moving Codex Meter to another device "
+                            + "you control.")
+                    .setNegativeButton("Cancel", null)
+                    .setPositiveButton("Export anyway", (dialog, which) ->
+                            launchExportPicker(appSettings, notifications, nowBar, authentication))
+                    .show();
+        }
+
+        private void launchExportPicker(boolean appSettings, boolean notifications,
+                boolean nowBar, boolean authentication) {
+            pendingExportAppSettings = appSettings;
+            pendingExportNotifications = notifications;
+            pendingExportNowBar = nowBar;
+            pendingExportAuthentication = authentication;
+            String stamp = new SimpleDateFormat("yyyyMMdd-HHmm", Locale.US).format(new Date());
+            String name = pendingExportAuthentication
+                    ? "codex-meter-transfer-AUTH-" + stamp + ".json"
+                    : "codex-meter-transfer-" + stamp + ".json";
+            Intent create = new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                    .addCategory(Intent.CATEGORY_OPENABLE)
+                    .setType("application/json")
+                    .putExtra(Intent.EXTRA_TITLE, name);
+            try {
+                startActivityForResult(create, REQUEST_EXPORT_TRANSFER);
+            } catch (RuntimeException exception) {
+                Toast.makeText(requireContext(),
+                        "No file picker is available to export a transfer file.",
+                        Toast.LENGTH_LONG).show();
+            }
+        }
+
+        private void finishExport(Uri uri) {
+            try {
+                SettingsTransfer.Document document = SettingsTransferStore.collect(requireContext(),
+                        pendingExportAppSettings, pendingExportNotifications,
+                        pendingExportNowBar, pendingExportAuthentication);
+                SettingsTransferStore.write(requireContext(), uri, document);
+                String message = document.hasAuthentication()
+                        ? "Exported. Keep this file private — it includes ChatGPT authentication."
+                        : "Settings exported.";
+                Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show();
+            } catch (Exception exception) {
+                Toast.makeText(requireContext(),
+                        exception.getMessage() == null || exception.getMessage().isEmpty()
+                                ? "Could not export transfer file."
+                                : exception.getMessage(),
+                        Toast.LENGTH_LONG).show();
+            }
+        }
+
+        private void beginImport(Uri uri) {
+            try {
+                pendingImportDocument = SettingsTransferStore.read(requireContext(), uri);
+                showImportSectionDialog(pendingImportDocument);
+            } catch (Exception exception) {
+                pendingImportDocument = null;
+                Toast.makeText(requireContext(),
+                        exception.getMessage() == null || exception.getMessage().isEmpty()
+                                ? "Could not read transfer file."
+                                : exception.getMessage(),
+                        Toast.LENGTH_LONG).show();
+            }
+        }
+
+        private void showImportSectionDialog(SettingsTransfer.Document document) {
+            List<String> present = document.presentSections();
+            if (present.isEmpty()) {
+                Toast.makeText(requireContext(), "This transfer file has no sections.",
+                        Toast.LENGTH_LONG).show();
+                return;
+            }
+            String[] labels = new String[present.size()];
+            boolean[] checked = new boolean[present.size()];
+            for (int i = 0; i < present.size(); i++) {
+                String section = present.get(i);
+                String warning = SettingsTransfer.isAuthenticationSection(section)
+                        ? "\nWarning: replaces ChatGPT sign-in on this device"
+                        : "";
+                labels[i] = SettingsTransfer.sectionTitle(section)
+                        + "\n" + SettingsTransfer.sectionSummary(section) + warning;
+                checked[i] = !SettingsTransfer.isAuthenticationSection(section);
+            }
+            new AlertDialog.Builder(requireContext())
+                    .setTitle("Import sections")
+                    .setMultiChoiceItems(labels, checked,
+                            (dialog, which, isChecked) -> checked[which] = isChecked)
+                    .setNegativeButton("Cancel", null)
+                    .setPositiveButton("Continue", (dialog, which) -> {
+                        boolean appSettings = false;
+                        boolean notifications = false;
+                        boolean nowBar = false;
+                        boolean authentication = false;
+                        for (int i = 0; i < present.size(); i++) {
+                            if (!checked[i]) continue;
+                            String section = present.get(i);
+                            if (SettingsTransfer.SECTION_APP_SETTINGS.equals(section)) {
+                                appSettings = true;
+                            } else if (SettingsTransfer.SECTION_NOTIFICATIONS.equals(section)) {
+                                notifications = true;
+                            } else if (SettingsTransfer.SECTION_NOW_BAR.equals(section)) {
+                                nowBar = true;
+                            } else if (SettingsTransfer.SECTION_AUTHENTICATION.equals(section)) {
+                                authentication = true;
+                            }
+                        }
+                        if (!(appSettings || notifications || nowBar || authentication)) {
+                            Toast.makeText(requireContext(),
+                                    "Select at least one section to import.",
+                                    Toast.LENGTH_LONG).show();
+                            return;
+                        }
+                        if (authentication) {
+                            confirmSensitiveImport(document, appSettings, notifications, nowBar,
+                                    true);
+                        } else {
+                            finishImport(document, appSettings, notifications, nowBar, false);
+                        }
+                    })
+                    .show();
+        }
+
+        private void confirmSensitiveImport(SettingsTransfer.Document document,
+                boolean appSettings, boolean notifications, boolean nowBar,
+                boolean authentication) {
+            new AlertDialog.Builder(requireContext())
+                    .setTitle("Import authentication?")
+                    .setMessage(SettingsTransfer.SECURITY_WARNING
+                            + "\n\nThis replaces ChatGPT sign-in on this device with the tokens "
+                            + "from the file.")
+                    .setNegativeButton("Cancel", null)
+                    .setPositiveButton("Import anyway", (dialog, which) ->
+                            finishImport(document, appSettings, notifications, nowBar,
+                                    authentication))
+                    .show();
+        }
+
+        private void finishImport(SettingsTransfer.Document document, boolean appSettings,
+                boolean notifications, boolean nowBar, boolean authentication) {
+            try {
+                SettingsTransferStore.ApplyResult result = SettingsTransferStore.apply(
+                        requireContext(), document, appSettings, notifications, nowBar,
+                        authentication);
+                pendingImportDocument = null;
+                StringBuilder message = new StringBuilder("Imported ");
+                for (int i = 0; i < result.appliedSections.size(); i++) {
+                    if (i > 0) message.append(", ");
+                    message.append(SettingsTransfer.sectionTitle(result.appliedSections.get(i)));
+                }
+                message.append('.');
+                if (result.authenticationImported) {
+                    message.append(" Authentication replaced — keep the file private.");
+                }
+                Toast.makeText(requireContext(), message.toString(), Toast.LENGTH_LONG).show();
+                requireActivity().recreate();
+            } catch (Exception exception) {
+                Toast.makeText(requireContext(),
+                        exception.getMessage() == null || exception.getMessage().isEmpty()
+                                ? "Could not import transfer file."
+                                : exception.getMessage(),
+                        Toast.LENGTH_LONG).show();
             }
         }
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java
@@ -1,0 +1,318 @@
+package dev.bennett.codexmeter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Portable Codex Meter transfer document. Pure JSON — no Android APIs — so the
+ * format can be round-tripped in {@link ParserSelfTest}.
+ *
+ * <p>Authentication sections contain usable ChatGPT OAuth tokens and must never
+ * be shared. The document always embeds {@link #SECURITY_WARNING} when auth is
+ * present so a casual file open still surfaces the risk.
+ */
+public final class SettingsTransfer {
+    public static final String FORMAT = "codex_meter_transfer";
+    public static final int VERSION = 1;
+
+    public static final String SECTION_APP_SETTINGS = "app_settings";
+    public static final String SECTION_NOTIFICATIONS = "notifications";
+    public static final String SECTION_NOW_BAR = "now_bar";
+    public static final String SECTION_AUTHENTICATION = "authentication";
+
+    public static final String SECURITY_WARNING =
+            "IMPORTANT: This file contains ChatGPT authentication tokens. "
+                    + "Anyone with this file can access your ChatGPT account. "
+                    + "Do not share it, upload it, or send it to anyone. "
+                    + "Keep it only on devices you trust.";
+
+    public static final String[] ALL_SECTIONS = {
+            SECTION_APP_SETTINGS,
+            SECTION_NOTIFICATIONS,
+            SECTION_NOW_BAR,
+            SECTION_AUTHENTICATION
+    };
+
+    public static final String[] SETTINGS_SECTIONS = {
+            SECTION_APP_SETTINGS,
+            SECTION_NOTIFICATIONS,
+            SECTION_NOW_BAR
+    };
+
+    private SettingsTransfer() {
+    }
+
+    public static boolean isKnownSection(String section) {
+        if (section == null || section.isEmpty()) {
+            return false;
+        }
+        for (String known : ALL_SECTIONS) {
+            if (known.equals(section)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isAuthenticationSection(String section) {
+        return SECTION_AUTHENTICATION.equals(section);
+    }
+
+    public static Document create(long exportedAtMillis, JSONObject appSettings,
+            JSONObject notifications, JSONObject nowBar, JSONObject authentication)
+            throws JSONException {
+        Document document = new Document();
+        document.exportedAtMillis = Math.max(0L, exportedAtMillis);
+        document.appSettings = copyObject(appSettings);
+        document.notifications = copyObject(notifications);
+        document.nowBar = copyObject(nowBar);
+        document.authentication = copyObject(authentication);
+        return document;
+    }
+
+    public static Document parse(String json) throws Exception {
+        if (json == null || json.trim().isEmpty()) {
+            throw new IllegalArgumentException("Transfer file is empty.");
+        }
+        return parse(new JSONObject(json));
+    }
+
+    public static Document parse(JSONObject json) throws Exception {
+        if (json == null) {
+            throw new IllegalArgumentException("Transfer file is empty.");
+        }
+        String format = json.optString("format", "");
+        if (!FORMAT.equals(format)) {
+            throw new IllegalArgumentException("Not a Codex Meter transfer file.");
+        }
+        int version = json.optInt("version", 0);
+        if (version < 1 || version > VERSION) {
+            throw new IllegalArgumentException("Unsupported transfer file version: " + version);
+        }
+        Document document = new Document();
+        document.exportedAtMillis = Math.max(0L, json.optLong("exported_at", 0L));
+        JSONObject sections = json.optJSONObject("sections");
+        if (sections == null) {
+            sections = new JSONObject();
+        }
+        document.appSettings = copyObject(sections.optJSONObject(SECTION_APP_SETTINGS));
+        document.notifications = copyObject(sections.optJSONObject(SECTION_NOTIFICATIONS));
+        document.nowBar = copyObject(sections.optJSONObject(SECTION_NOW_BAR));
+        document.authentication = copyObject(sections.optJSONObject(SECTION_AUTHENTICATION));
+        if (!document.hasAnySection()) {
+            throw new IllegalArgumentException("Transfer file does not contain any sections.");
+        }
+        return document;
+    }
+
+    public static JSONObject widgetOptionsToJson(WidgetOptions options) throws JSONException {
+        WidgetOptions safe = options == null ? WidgetOptions.defaults() : options;
+        JSONObject json = new JSONObject();
+        json.put("style", safe.layout);
+        json.put("density", safe.density);
+        json.put("surface_style", safe.surfaceStyle);
+        json.put("graphic_scale", safe.graphicScale);
+        json.put("theme", safe.theme);
+        json.put("accent", safe.accent);
+        json.put("opacity", safe.opacity);
+        json.put("reset_mode", safe.resetMode);
+        json.put("display_mode", safe.displayMode);
+        json.put("metric_mode", safe.metricMode);
+        json.put("show_title", safe.showTitle);
+        json.put("show_plan", safe.showPlan);
+        json.put("show_updated", safe.showUpdated);
+        json.put("show_refresh", safe.showRefresh);
+        json.put("show_reset_credits", safe.showResetCredits);
+        json.put("show_reset_action", safe.showResetAction);
+        json.put("show_percent_symbol", safe.showPercentSymbol);
+        return json;
+    }
+
+    public static WidgetOptions widgetOptionsFromJson(JSONObject json) {
+        if (json == null) {
+            return WidgetOptions.defaults();
+        }
+        WidgetOptions options = new WidgetOptions(
+                json.optString("style", WidgetOptions.STYLE_RINGS),
+                json.optString("density", WidgetOptions.DENSITY_AUTO),
+                json.optString("surface_style", WidgetOptions.SURFACE_ONE_UI),
+                json.optString("graphic_scale", WidgetOptions.GRAPHIC_AUTO),
+                json.optString("theme", WidgetOptions.THEME_SYSTEM),
+                json.optString("accent", WidgetOptions.ACCENT_BLUE),
+                json.optInt("opacity", 88),
+                json.optString("reset_mode", WidgetOptions.RESET_HIDDEN),
+                json.optString("display_mode", WidgetOptions.DISPLAY_REMAINING),
+                json.optString("metric_mode", WidgetOptions.METRIC_BOTH),
+                json.optBoolean("show_title", false),
+                json.optBoolean("show_plan", false),
+                json.optBoolean("show_updated", false),
+                json.optBoolean("show_refresh", true),
+                json.optBoolean("show_reset_credits", false),
+                json.optBoolean("show_reset_action", false));
+        return options.withPercentSymbol(json.optBoolean("show_percent_symbol", true));
+    }
+
+    public static JSONArray leadTimesToJson(List<Long> leadTimes) {
+        JSONArray array = new JSONArray();
+        if (leadTimes != null) {
+            for (Long leadTime : leadTimes) {
+                if (leadTime != null && leadTime > 0L) {
+                    array.put(leadTime.longValue());
+                }
+            }
+        }
+        return array;
+    }
+
+    public static List<Long> leadTimesFromJson(JSONArray array) {
+        if (array == null || array.length() == 0) {
+            return Collections.emptyList();
+        }
+        List<Long> values = new ArrayList<>();
+        for (int i = 0; i < array.length(); i++) {
+            long value = array.optLong(i, -1L);
+            if (value > 0L) {
+                values.add(value);
+            }
+        }
+        Collections.sort(values);
+        return values;
+    }
+
+    public static String sectionTitle(String section) {
+        if (SECTION_APP_SETTINGS.equals(section)) {
+            return "App settings";
+        }
+        if (SECTION_NOTIFICATIONS.equals(section)) {
+            return "Notifications";
+        }
+        if (SECTION_NOW_BAR.equals(section)) {
+            return "Now Bar";
+        }
+        if (SECTION_AUTHENTICATION.equals(section)) {
+            return "Authentication";
+        }
+        return section == null ? "" : section;
+    }
+
+    public static String sectionSummary(String section) {
+        if (SECTION_APP_SETTINGS.equals(section)) {
+            return "Theme, refresh, updates, and default widget look";
+        }
+        if (SECTION_NOTIFICATIONS.equals(section)) {
+            return "Low-usage alerts and reset-credit reminders";
+        }
+        if (SECTION_NOW_BAR.equals(section)) {
+            return "Display mode, percentage mode, and auto-start";
+        }
+        if (SECTION_AUTHENTICATION.equals(section)) {
+            return "ChatGPT sign-in tokens (sensitive)";
+        }
+        return "";
+    }
+
+    private static JSONObject copyObject(JSONObject json) throws JSONException {
+        if (json == null) {
+            return null;
+        }
+        return new JSONObject(json.toString());
+    }
+
+    public static final class Document {
+        public long exportedAtMillis;
+        public JSONObject appSettings;
+        public JSONObject notifications;
+        public JSONObject nowBar;
+        public JSONObject authentication;
+
+        public boolean hasAppSettings() {
+            return appSettings != null;
+        }
+
+        public boolean hasNotifications() {
+            return notifications != null;
+        }
+
+        public boolean hasNowBar() {
+            return nowBar != null;
+        }
+
+        public boolean hasAuthentication() {
+            return authentication != null;
+        }
+
+        public boolean hasAnySection() {
+            return hasAppSettings() || hasNotifications() || hasNowBar() || hasAuthentication();
+        }
+
+        public boolean containsSection(String section) {
+            if (SECTION_APP_SETTINGS.equals(section)) {
+                return hasAppSettings();
+            }
+            if (SECTION_NOTIFICATIONS.equals(section)) {
+                return hasNotifications();
+            }
+            if (SECTION_NOW_BAR.equals(section)) {
+                return hasNowBar();
+            }
+            if (SECTION_AUTHENTICATION.equals(section)) {
+                return hasAuthentication();
+            }
+            return false;
+        }
+
+        public List<String> presentSections() {
+            List<String> sections = new ArrayList<>();
+            for (String section : ALL_SECTIONS) {
+                if (containsSection(section)) {
+                    sections.add(section);
+                }
+            }
+            return sections;
+        }
+
+        public JSONObject toJson() throws JSONException {
+            JSONObject root = new JSONObject();
+            root.put("format", FORMAT);
+            root.put("version", VERSION);
+            root.put("exported_at", exportedAtMillis);
+            JSONObject sections = new JSONObject();
+            if (appSettings != null) {
+                sections.put(SECTION_APP_SETTINGS, appSettings);
+            }
+            if (notifications != null) {
+                sections.put(SECTION_NOTIFICATIONS, notifications);
+            }
+            if (nowBar != null) {
+                sections.put(SECTION_NOW_BAR, nowBar);
+            }
+            if (authentication != null) {
+                sections.put(SECTION_AUTHENTICATION, authentication);
+            }
+            root.put("sections", sections);
+            root.put("contains_authentication", authentication != null);
+            if (authentication != null) {
+                root.put("security_warning", SECURITY_WARNING);
+            }
+            return root;
+        }
+
+        public String toJsonString() throws JSONException {
+            return toJson().toString(2);
+        }
+
+        public Document selecting(boolean appSettingsSelected, boolean notificationsSelected,
+                boolean nowBarSelected, boolean authenticationSelected) throws JSONException {
+            return create(
+                    exportedAtMillis,
+                    appSettingsSelected ? appSettings : null,
+                    notificationsSelected ? notifications : null,
+                    nowBarSelected ? nowBar : null,
+                    authenticationSelected ? authentication : null);
+        }
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java
@@ -133,27 +133,37 @@ public final class SettingsTransfer {
     }
 
     public static WidgetOptions widgetOptionsFromJson(JSONObject json) {
+        return widgetOptionsFromJson(json, WidgetOptions.defaults());
+    }
+
+    /**
+     * Parses widget options, filling only missing keys from {@code base} so partial
+     * transfer objects cannot silently reset device defaults to product defaults.
+     */
+    public static WidgetOptions widgetOptionsFromJson(JSONObject json, WidgetOptions base) {
+        WidgetOptions fallback = base == null ? WidgetOptions.defaults() : base;
         if (json == null) {
-            return WidgetOptions.defaults();
+            return fallback;
         }
         WidgetOptions options = new WidgetOptions(
-                json.optString("style", WidgetOptions.STYLE_RINGS),
-                json.optString("density", WidgetOptions.DENSITY_AUTO),
-                json.optString("surface_style", WidgetOptions.SURFACE_ONE_UI),
-                json.optString("graphic_scale", WidgetOptions.GRAPHIC_AUTO),
-                json.optString("theme", WidgetOptions.THEME_SYSTEM),
-                json.optString("accent", WidgetOptions.ACCENT_BLUE),
-                json.optInt("opacity", 88),
-                json.optString("reset_mode", WidgetOptions.RESET_HIDDEN),
-                json.optString("display_mode", WidgetOptions.DISPLAY_REMAINING),
-                json.optString("metric_mode", WidgetOptions.METRIC_BOTH),
-                json.optBoolean("show_title", false),
-                json.optBoolean("show_plan", false),
-                json.optBoolean("show_updated", false),
-                json.optBoolean("show_refresh", true),
-                json.optBoolean("show_reset_credits", false),
-                json.optBoolean("show_reset_action", false));
-        return options.withPercentSymbol(json.optBoolean("show_percent_symbol", true));
+                stringOr(json, "style", fallback.layout),
+                stringOr(json, "density", fallback.density),
+                stringOr(json, "surface_style", fallback.surfaceStyle),
+                stringOr(json, "graphic_scale", fallback.graphicScale),
+                stringOr(json, "theme", fallback.theme),
+                stringOr(json, "accent", fallback.accent),
+                intOr(json, "opacity", fallback.opacity),
+                stringOr(json, "reset_mode", fallback.resetMode),
+                stringOr(json, "display_mode", fallback.displayMode),
+                stringOr(json, "metric_mode", fallback.metricMode),
+                booleanOr(json, "show_title", fallback.showTitle),
+                booleanOr(json, "show_plan", fallback.showPlan),
+                booleanOr(json, "show_updated", fallback.showUpdated),
+                booleanOr(json, "show_refresh", fallback.showRefresh),
+                booleanOr(json, "show_reset_credits", fallback.showResetCredits),
+                booleanOr(json, "show_reset_action", fallback.showResetAction));
+        return options.withPercentSymbol(
+                booleanOr(json, "show_percent_symbol", fallback.showPercentSymbol));
     }
 
     public static JSONArray leadTimesToJson(List<Long> leadTimes) {
@@ -169,7 +179,11 @@ public final class SettingsTransfer {
     }
 
     public static List<Long> leadTimesFromJson(JSONArray array) {
-        if (array == null || array.length() == 0) {
+        if (array == null) {
+            throw new IllegalArgumentException(
+                    "reset_credit_expiry_lead_times must be a JSON array.");
+        }
+        if (array.length() == 0) {
             return Collections.emptyList();
         }
         List<Long> values = new ArrayList<>();
@@ -181,6 +195,30 @@ public final class SettingsTransfer {
         }
         Collections.sort(values);
         return values;
+    }
+
+    /** Requires a JSON array when the lead-times key is present; rejects wrong types. */
+    public static List<Long> requireLeadTimes(JSONObject json, String key) throws JSONException {
+        if (json == null || !json.has(key) || json.isNull(key)) {
+            throw new IllegalArgumentException(key + " must be a JSON array.");
+        }
+        Object raw = json.get(key);
+        if (!(raw instanceof JSONArray)) {
+            throw new IllegalArgumentException(key + " must be a JSON array.");
+        }
+        return leadTimesFromJson((JSONArray) raw);
+    }
+
+    private static String stringOr(JSONObject json, String key, String fallback) {
+        return json.has(key) ? json.optString(key, fallback) : fallback;
+    }
+
+    private static int intOr(JSONObject json, String key, int fallback) {
+        return json.has(key) ? json.optInt(key, fallback) : fallback;
+    }
+
+    private static boolean booleanOr(JSONObject json, String key, boolean fallback) {
+        return json.has(key) ? json.optBoolean(key, fallback) : fallback;
     }
 
     public static String sectionTitle(String section) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java
@@ -183,18 +183,57 @@ public final class SettingsTransfer {
             throw new IllegalArgumentException(
                     "reset_credit_expiry_lead_times must be a JSON array.");
         }
-        if (array.length() == 0) {
-            return Collections.emptyList();
-        }
         List<Long> values = new ArrayList<>();
         for (int i = 0; i < array.length(); i++) {
-            long value = array.optLong(i, -1L);
-            if (value > 0L) {
-                values.add(value);
-            }
+            values.add(parseLeadTimeEntry(array, i));
         }
         Collections.sort(values);
         return values;
+    }
+
+    private static long parseLeadTimeEntry(JSONArray array, int index) {
+        Object raw;
+        try {
+            raw = array.get(index);
+        } catch (JSONException exception) {
+            throw new IllegalArgumentException(
+                    "reset_credit_expiry_lead_times contains an invalid entry.");
+        }
+        if (raw == null || raw == JSONObject.NULL) {
+            throw new IllegalArgumentException(
+                    "reset_credit_expiry_lead_times contains a null entry.");
+        }
+        long value;
+        if (raw instanceof Number) {
+            double asDouble = ((Number) raw).doubleValue();
+            if (Double.isNaN(asDouble) || Double.isInfinite(asDouble)
+                    || asDouble != Math.rint(asDouble)) {
+                throw new IllegalArgumentException(
+                        "reset_credit_expiry_lead_times contains a non-integer entry.");
+            }
+            value = ((Number) raw).longValue();
+        } else if (raw instanceof String) {
+            String text = ((String) raw).trim();
+            if (text.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "reset_credit_expiry_lead_times contains an empty entry.");
+            }
+            try {
+                value = Long.parseLong(text);
+            } catch (NumberFormatException exception) {
+                throw new IllegalArgumentException(
+                        "reset_credit_expiry_lead_times contains a non-numeric entry.");
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "reset_credit_expiry_lead_times contains a non-numeric entry.");
+        }
+        if (value < ResetCreditExpiryReminder.MIN_LEAD_TIME_MS
+                || value > ResetCreditExpiryReminder.MAX_LEAD_TIME_MS) {
+            throw new IllegalArgumentException(
+                    "reset_credit_expiry_lead_times contains an out-of-range entry.");
+        }
+        return value;
     }
 
     /** Requires a JSON array when the lead-times key is present; rejects wrong types. */

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -136,7 +136,9 @@ public final class SettingsTransferStore {
         } else {
             ReleaseUpdateScheduler.cancel(app);
         }
-        if (NowBarManager.isActive(app) && !NowBarManager.repostActive(app)) {
+        // Only reconcile an active Now Bar when that section was imported. Unrelated
+        // imports must not stop a live monitor if a transient repost fails.
+        if (applyNowBar && NowBarManager.isActive(app) && !NowBarManager.repostActive(app)) {
             NowBarManager.stop(app, false);
         }
         WidgetRenderer.updateAll(app);
@@ -147,7 +149,14 @@ public final class SettingsTransferStore {
                 try {
                     UsageSnapshot snapshot = UsageApi.refreshAndCache(app);
                     RefreshScheduler.scheduleAtNextReset(app, snapshot);
-                } catch (Exception ignored) {
+                    WidgetRenderer.updateAll(app);
+                } catch (Exception exception) {
+                    String message = exception.getMessage();
+                    if (message == null || message.trim().isEmpty()) {
+                        message = "Imported authentication could not refresh usage.";
+                    }
+                    AppPreferences.setLastError(app, message);
+                    WidgetRenderer.updateAll(app);
                 }
             }, "codex-transfer-refresh").start();
         }
@@ -210,12 +219,13 @@ public final class SettingsTransferStore {
         JSONObject widget = json.optJSONObject("default_widget");
         if (widget != null) {
             AppPreferences.saveDefaultWidgetOptions(context,
-                    SettingsTransfer.widgetOptionsFromJson(widget));
+                    SettingsTransfer.widgetOptionsFromJson(widget,
+                            AppPreferences.loadDefaultWidgetOptions(context)));
         }
         return !previousTheme.equals(AppPreferences.getAppTheme(context));
     }
 
-    private static void applyNotifications(Context context, JSONObject json) {
+    private static void applyNotifications(Context context, JSONObject json) throws Exception {
         ResetAlertPreferences.save(context,
                 json.optString("style", ResetAlertPreferences.getStyle(context)),
                 json.optString("metric", ResetAlertPreferences.getMetric(context)),
@@ -231,8 +241,7 @@ public final class SettingsTransferStore {
                         ResetAlertPreferences.resetCreditExpiryEnabled(context)));
         if (json.has("reset_credit_expiry_lead_times")) {
             ResetAlertPreferences.setResetCreditExpiryLeadTimes(context,
-                    SettingsTransfer.leadTimesFromJson(
-                            json.optJSONArray("reset_credit_expiry_lead_times")));
+                    SettingsTransfer.requireLeadTimes(json, "reset_credit_expiry_lead_times"));
         }
         if (ResetAlertPreferences.enabled(context)) {
             ResetNotificationManager.ensureChannel(context);

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -226,6 +226,12 @@ public final class SettingsTransferStore {
     }
 
     private static void applyNotifications(Context context, JSONObject json) throws Exception {
+        // Validate lead times before any preference writes so a bad transfer cannot
+        // partially overwrite notification settings.
+        List<Long> leadTimes = null;
+        if (json.has("reset_credit_expiry_lead_times")) {
+            leadTimes = SettingsTransfer.requireLeadTimes(json, "reset_credit_expiry_lead_times");
+        }
         ResetAlertPreferences.save(context,
                 json.optString("style", ResetAlertPreferences.getStyle(context)),
                 json.optString("metric", ResetAlertPreferences.getMetric(context)),
@@ -239,9 +245,8 @@ public final class SettingsTransferStore {
         ResetAlertPreferences.setResetCreditExpiryEnabled(context,
                 json.optBoolean("reset_credit_expiry",
                         ResetAlertPreferences.resetCreditExpiryEnabled(context)));
-        if (json.has("reset_credit_expiry_lead_times")) {
-            ResetAlertPreferences.setResetCreditExpiryLeadTimes(context,
-                    SettingsTransfer.requireLeadTimes(json, "reset_credit_expiry_lead_times"));
+        if (leadTimes != null) {
+            ResetAlertPreferences.setResetCreditExpiryLeadTimes(context, leadTimes);
         }
         if (ResetAlertPreferences.enabled(context)) {
             ResetNotificationManager.ensureChannel(context);

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -1,0 +1,288 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import android.net.Uri;
+import dev.bennett.codexmeter.wear.PhoneWearSync;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.json.JSONObject;
+
+/** Reads and writes {@link SettingsTransfer} documents against on-device preferences. */
+public final class SettingsTransferStore {
+    private SettingsTransferStore() {
+    }
+
+    public static SettingsTransfer.Document collect(Context context, boolean includeAppSettings,
+            boolean includeNotifications, boolean includeNowBar, boolean includeAuthentication)
+            throws Exception {
+        if (context == null) {
+            throw new IllegalArgumentException("Context is required.");
+        }
+        if (!includeAppSettings && !includeNotifications && !includeNowBar
+                && !includeAuthentication) {
+            throw new IllegalArgumentException("Select at least one section to export.");
+        }
+        Context app = context.getApplicationContext();
+        JSONObject appSettings = includeAppSettings ? collectAppSettings(app) : null;
+        JSONObject notifications = includeNotifications ? collectNotifications(app) : null;
+        JSONObject nowBar = includeNowBar ? collectNowBar(app) : null;
+        JSONObject authentication = null;
+        if (includeAuthentication) {
+            AuthTokens tokens = SecureTokenStore.load(app);
+            if (tokens == null || !tokens.isUsable()) {
+                throw new IllegalStateException(
+                        "No ChatGPT authentication is saved on this device to export.");
+            }
+            authentication = tokens.toJson();
+        }
+        return SettingsTransfer.create(System.currentTimeMillis(), appSettings, notifications,
+                nowBar, authentication);
+    }
+
+    public static void write(Context context, Uri uri, SettingsTransfer.Document document)
+            throws Exception {
+        if (context == null || uri == null || document == null) {
+            throw new IllegalArgumentException("Export target is incomplete.");
+        }
+        if (!document.hasAnySection()) {
+            throw new IllegalArgumentException("Select at least one section to export.");
+        }
+        byte[] bytes = document.toJsonString().getBytes(StandardCharsets.UTF_8);
+        try (OutputStream output = context.getContentResolver().openOutputStream(uri, "wt")) {
+            if (output == null) {
+                throw new Exception("Could not open the export file for writing.");
+            }
+            output.write(bytes);
+            output.flush();
+        }
+    }
+
+    public static SettingsTransfer.Document read(Context context, Uri uri) throws Exception {
+        if (context == null || uri == null) {
+            throw new IllegalArgumentException("Import source is incomplete.");
+        }
+        try (InputStream input = context.getContentResolver().openInputStream(uri)) {
+            if (input == null) {
+                throw new Exception("Could not open the import file for reading.");
+            }
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            byte[] chunk = new byte[4096];
+            int read;
+            while ((read = input.read(chunk)) >= 0) {
+                buffer.write(chunk, 0, read);
+                if (buffer.size() > 1024 * 1024) {
+                    throw new IllegalArgumentException("Transfer file is too large.");
+                }
+            }
+            return SettingsTransfer.parse(new String(buffer.toByteArray(), StandardCharsets.UTF_8));
+        }
+    }
+
+    public static ApplyResult apply(Context context, SettingsTransfer.Document document,
+            boolean applyAppSettings, boolean applyNotifications, boolean applyNowBar,
+            boolean applyAuthentication) throws Exception {
+        if (context == null || document == null) {
+            throw new IllegalArgumentException("Import source is incomplete.");
+        }
+        Context app = context.getApplicationContext();
+        List<String> applied = new ArrayList<>();
+        boolean themeChanged = false;
+        boolean authImported = false;
+
+        if (applyAppSettings) {
+            if (!document.hasAppSettings()) {
+                throw new IllegalArgumentException("This file has no app settings to import.");
+            }
+            themeChanged = applyAppSettings(app, document.appSettings);
+            applied.add(SettingsTransfer.SECTION_APP_SETTINGS);
+        }
+        if (applyNotifications) {
+            if (!document.hasNotifications()) {
+                throw new IllegalArgumentException("This file has no notification settings to import.");
+            }
+            applyNotifications(app, document.notifications);
+            applied.add(SettingsTransfer.SECTION_NOTIFICATIONS);
+        }
+        if (applyNowBar) {
+            if (!document.hasNowBar()) {
+                throw new IllegalArgumentException("This file has no Now Bar settings to import.");
+            }
+            applyNowBar(app, document.nowBar);
+            applied.add(SettingsTransfer.SECTION_NOW_BAR);
+        }
+        if (applyAuthentication) {
+            if (!document.hasAuthentication()) {
+                throw new IllegalArgumentException("This file has no authentication to import.");
+            }
+            applyAuthentication(app, document.authentication);
+            applied.add(SettingsTransfer.SECTION_AUTHENTICATION);
+            authImported = true;
+        }
+        if (applied.isEmpty()) {
+            throw new IllegalArgumentException("Select at least one section to import.");
+        }
+
+        RefreshScheduler.schedulePeriodic(app);
+        ResetAlertScheduler.scheduleFromSnapshot(app, AppPreferences.loadSnapshot(app));
+        ResetNotificationManager.onResetCreditExpirySettingsChanged(app,
+                AppPreferences.loadResetCredits(app));
+        if (UpdatePreferences.automaticChecks(app)) {
+            ReleaseUpdateScheduler.ensureScheduled(app);
+        } else {
+            ReleaseUpdateScheduler.cancel(app);
+        }
+        if (NowBarManager.isActive(app) && !NowBarManager.repostActive(app)) {
+            NowBarManager.stop(app, false);
+        }
+        WidgetRenderer.updateAll(app);
+        PhoneWearSync.pushSettings(app);
+
+        if (authImported) {
+            new Thread(() -> {
+                try {
+                    UsageSnapshot snapshot = UsageApi.refreshAndCache(app);
+                    RefreshScheduler.scheduleAtNextReset(app, snapshot);
+                } catch (Exception ignored) {
+                }
+            }, "codex-transfer-refresh").start();
+        }
+
+        return new ApplyResult(applied, themeChanged, authImported);
+    }
+
+    private static JSONObject collectAppSettings(Context context) throws Exception {
+        JSONObject json = new JSONObject();
+        json.put("app_theme", AppPreferences.getAppTheme(context));
+        json.put("refresh_minutes", AppPreferences.getRefreshMinutes(context));
+        json.put("refresh_on_launch", AppPreferences.getRefreshOnLaunch(context));
+        json.put("automatic_update_checks", UpdatePreferences.automaticChecks(context));
+        json.put("notify_updates", UpdatePreferences.notifyUpdatesEnabled(context));
+        json.put("check_interval_hours", UpdatePreferences.checkIntervalHours(context));
+        json.put("default_widget", SettingsTransfer.widgetOptionsToJson(
+                AppPreferences.loadDefaultWidgetOptions(context)));
+        return json;
+    }
+
+    private static JSONObject collectNotifications(Context context) throws Exception {
+        JSONObject json = new JSONObject();
+        json.put("style", ResetAlertPreferences.getStyle(context));
+        json.put("metric", ResetAlertPreferences.getMetric(context));
+        json.put("threshold", ResetAlertPreferences.getThreshold(context));
+        json.put("unexpected_refills", ResetAlertPreferences.unexpectedRefillsEnabled(context));
+        json.put("reset_credit_increases",
+                ResetAlertPreferences.resetCreditIncreasesEnabled(context));
+        json.put("reset_credit_expiry", ResetAlertPreferences.resetCreditExpiryEnabled(context));
+        json.put("reset_credit_expiry_lead_times", SettingsTransfer.leadTimesToJson(
+                ResetAlertPreferences.getResetCreditExpiryLeadTimes(context)));
+        return json;
+    }
+
+    private static JSONObject collectNowBar(Context context) throws Exception {
+        JSONObject json = new JSONObject();
+        json.put("display_mode", NowBarPreferences.getDisplayMode(context));
+        json.put("percent_mode", NowBarPreferences.getPercentMode(context));
+        json.put("auto_enabled", NowBarPreferences.isAutoStartEnabled(context));
+        json.put("metric", NowBarPreferences.getMetric(context));
+        json.put("threshold", NowBarPreferences.getThreshold(context));
+        return json;
+    }
+
+    private static boolean applyAppSettings(Context context, JSONObject json) throws Exception {
+        String previousTheme = AppPreferences.getAppTheme(context);
+        String theme = json.optString("app_theme", previousTheme);
+        AppPreferences.setAppTheme(context, theme);
+        AppPreferences.setRefreshMinutes(context, json.optInt("refresh_minutes",
+                AppPreferences.getRefreshMinutes(context)));
+        AppPreferences.setRefreshOnLaunch(context, json.optBoolean("refresh_on_launch",
+                AppPreferences.getRefreshOnLaunch(context)));
+        boolean automatic = json.optBoolean("automatic_update_checks",
+                UpdatePreferences.automaticChecks(context));
+        UpdatePreferences.setAutomaticChecks(context, automatic);
+        UpdatePreferences.setCheckIntervalHours(context, json.optInt("check_interval_hours",
+                UpdatePreferences.checkIntervalHours(context)));
+        UpdatePreferences.setNotifyUpdatesEnabled(context,
+                json.optBoolean("notify_updates", UpdatePreferences.notifyUpdatesEnabled(context)));
+        JSONObject widget = json.optJSONObject("default_widget");
+        if (widget != null) {
+            AppPreferences.saveDefaultWidgetOptions(context,
+                    SettingsTransfer.widgetOptionsFromJson(widget));
+        }
+        return !previousTheme.equals(AppPreferences.getAppTheme(context));
+    }
+
+    private static void applyNotifications(Context context, JSONObject json) {
+        ResetAlertPreferences.save(context,
+                json.optString("style", ResetAlertPreferences.getStyle(context)),
+                json.optString("metric", ResetAlertPreferences.getMetric(context)),
+                json.optInt("threshold", ResetAlertPreferences.getThreshold(context)));
+        ResetAlertPreferences.setUnexpectedRefillsEnabled(context,
+                json.optBoolean("unexpected_refills",
+                        ResetAlertPreferences.unexpectedRefillsEnabled(context)));
+        ResetAlertPreferences.setResetCreditIncreasesEnabled(context,
+                json.optBoolean("reset_credit_increases",
+                        ResetAlertPreferences.resetCreditIncreasesEnabled(context)));
+        ResetAlertPreferences.setResetCreditExpiryEnabled(context,
+                json.optBoolean("reset_credit_expiry",
+                        ResetAlertPreferences.resetCreditExpiryEnabled(context)));
+        if (json.has("reset_credit_expiry_lead_times")) {
+            ResetAlertPreferences.setResetCreditExpiryLeadTimes(context,
+                    SettingsTransfer.leadTimesFromJson(
+                            json.optJSONArray("reset_credit_expiry_lead_times")));
+        }
+        if (ResetAlertPreferences.enabled(context)) {
+            ResetNotificationManager.ensureChannel(context);
+            ResetNotificationManager.onUsageUpdated(context, AppPreferences.loadSnapshot(context));
+            ResetNotificationManager.onResetCreditsUpdated(context,
+                    AppPreferences.loadResetCredits(context));
+        } else {
+            ResetNotificationManager.clearNotificationHistory(context);
+        }
+    }
+
+    private static void applyNowBar(Context context, JSONObject json) {
+        NowBarPreferences.setDisplayMode(context, json.optString("display_mode",
+                NowBarPreferences.getDisplayMode(context)));
+        NowBarPreferences.setPercentMode(context, json.optString("percent_mode",
+                NowBarPreferences.getPercentMode(context)));
+        NowBarPreferences.save(context,
+                json.optBoolean("auto_enabled", NowBarPreferences.isAutoStartEnabled(context)),
+                json.optString("metric", NowBarPreferences.getMetric(context)),
+                json.optInt("threshold", NowBarPreferences.getThreshold(context)));
+        NowBarPreferences.clearSuppression(context);
+        if (NowBarPreferences.isAutoStartEnabled(context)) {
+            NowBarManager.maybeAutoStart(context, AppPreferences.loadSnapshot(context));
+        }
+    }
+
+    private static void applyAuthentication(Context context, JSONObject json) throws Exception {
+        AuthTokens tokens = AuthTokens.fromJson(json);
+        if (!tokens.isUsable()) {
+            throw new IllegalArgumentException(
+                    "Imported authentication is incomplete or invalid.");
+        }
+        SecureTokenStore.save(context, tokens);
+        AppPreferences.clearSnapshot(context);
+        AppPreferences.setOAuthPending(context, false, "");
+        AppPreferences.completeOnboarding(context);
+    }
+
+    public static final class ApplyResult {
+        public final List<String> appliedSections;
+        public final boolean themeChanged;
+        public final boolean authenticationImported;
+
+        ApplyResult(List<String> appliedSections, boolean themeChanged,
+                boolean authenticationImported) {
+            this.appliedSections = appliedSections == null
+                    ? Collections.emptyList()
+                    : Collections.unmodifiableList(new ArrayList<>(appliedSections));
+            this.themeChanged = themeChanged;
+            this.authenticationImported = authenticationImported;
+        }
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -226,12 +226,11 @@ public final class SettingsTransferStore {
     }
 
     private static void applyNotifications(Context context, JSONObject json) throws Exception {
-        // Validate lead times before any preference writes so a bad transfer cannot
-        // partially overwrite notification settings.
-        List<Long> leadTimes = null;
-        if (json.has("reset_credit_expiry_lead_times")) {
-            leadTimes = SettingsTransfer.requireLeadTimes(json, "reset_credit_expiry_lead_times");
-        }
+        // Fail closed before any preference writes: malformed lead times must leave
+        // style/metric/threshold/enablement flags completely untouched.
+        final List<Long> leadTimes = json.has("reset_credit_expiry_lead_times")
+                ? SettingsTransfer.requireLeadTimes(json, "reset_credit_expiry_lead_times")
+                : null;
         ResetAlertPreferences.save(context,
                 json.optString("style", ResetAlertPreferences.getStyle(context)),
                 json.optString("metric", ResetAlertPreferences.getMetric(context)),

--- a/android/app/src/main/res/xml/preferences_settings.xml
+++ b/android/app/src/main/res/xml/preferences_settings.xml
@@ -156,6 +156,25 @@
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="Transfer">
+        <Preference
+            android:key="export_settings_transfer"
+            android:title="Export"
+            android:summary="Save selected settings and optional sign-in data to a file"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="import_settings_transfer"
+            android:title="Import"
+            android:summary="Restore selected sections from a Codex Meter transfer file"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="transfer_security_notice"
+            android:title="Do not share transfer files with authentication"
+            android:summary="Exported authentication includes ChatGPT tokens. Anyone with that file can use your account. Keep it private."
+            app:iconSpaceReserved="false"
+            app:selectable="false" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="Privacy">
         <Preference
             android:icon="@drawable/ic_oui_privacy"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -149,6 +149,16 @@ grep -q 'malformed lead times rejected' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'non-numeric lead time element rejected' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'parseLeadTimeEntry' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
+python3 - <<'PY'
+from pathlib import Path
+text = Path("app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java").read_text()
+start = text.index("private static void applyNotifications")
+end = text.index("private static void applyNowBar", start)
+block = text[start:end]
+assert "leadTimes = SettingsTransfer.requireLeadTimes" in block
+assert block.index("requireLeadTimes") < block.index("ResetAlertPreferences.save")
+print("notification import validates lead times before saving.")
+PY
 grep -q 'com.samsung.android.support.ongoing_activity' "$ROOT/app/src/main/AndroidManifest.xml"
 
 grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -54,6 +54,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
@@ -116,6 +117,25 @@ grep -q 'UpdateNotificationManager.onReleasesUpdated' \
 grep -q 'testUpdateCheckFrequency' "$ROOT/tests/ParserSelfTest.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
+grep -q 'testSettingsTransfer' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'export_settings_transfer' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'import_settings_transfer' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'transfer_security_notice' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'SECURITY_WARNING' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
+grep -q 'bindTransfer' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'SettingsTransferStore.collect' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'SettingsTransferStore.apply' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'Do not share transfer files with authentication' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
 grep -q 'com.samsung.android.support.ongoing_activity' "$ROOT/app/src/main/AndroidManifest.xml"
 
 grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -55,7 +55,6 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java" \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReminder.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
@@ -147,6 +146,9 @@ grep -q 'AppPreferences.setLastError(app, message)' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
 grep -q 'partial widget keeps current theme' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'malformed lead times rejected' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'non-numeric lead time element rejected' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'parseLeadTimeEntry' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
 grep -q 'com.samsung.android.support.ongoing_activity' "$ROOT/app/src/main/AndroidManifest.xml"
 
 grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -55,6 +55,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReminder.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -149,9 +149,9 @@ grep -q 'malformed lead times rejected' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'non-numeric lead time element rejected' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'parseLeadTimeEntry' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
-python3 - <<'PY'
+python3 - <<PY
 from pathlib import Path
-text = Path("app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java").read_text()
+text = (Path(r"""$ROOT""") / "app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java").read_text()
 start = text.index("private static void applyNotifications")
 end = text.index("private static void applyNowBar", start)
 block = text[start:end]

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -136,6 +136,16 @@ grep -q 'SettingsTransferStore.apply' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 grep -q 'Do not share transfer files with authentication' \
   "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'widgetOptionsFromJson(widget,' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
+grep -q 'requireLeadTimes' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
+grep -q 'applyNowBar && NowBarManager.isActive' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
+grep -q 'AppPreferences.setLastError(app, message)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
+grep -q 'partial widget keeps current theme' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'malformed lead times rejected' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'com.samsung.android.support.ongoing_activity' "$ROOT/app/src/main/AndroidManifest.xml"
 
 grep -q 'app:expanded="true"' "$ROOT/app/src/main/res/layout/activity_settings.xml"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -155,8 +155,8 @@ text = (Path(r"""$ROOT""") / "app/src/main/java/dev/bennett/codexmeter/SettingsT
 start = text.index("private static void applyNotifications")
 end = text.index("private static void applyNowBar", start)
 block = text[start:end]
-assert "leadTimes = SettingsTransfer.requireLeadTimes" in block
-assert block.index("requireLeadTimes") < block.index("ResetAlertPreferences.save")
+assert "SettingsTransfer.requireLeadTimes" in block
+assert block.index("SettingsTransfer.requireLeadTimes") < block.index("ResetAlertPreferences.save")
 print("notification import validates lead times before saving.")
 PY
 grep -q 'com.samsung.android.support.ongoing_activity' "$ROOT/app/src/main/AndroidManifest.xml"

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -553,11 +553,8 @@ public final class ParserSelfTest {
         check(WidgetOptions.ACCENT_CYAN.equals(merged.accent), "partial widget updates accent");
         check(WidgetOptions.THEME_LIGHT.equals(merged.theme),
                 "partial widget keeps current theme");
-        check(WidgetOptions.ACCENT_ROSE.equals(currentDefaults.accent)
-                        || WidgetOptions.STYLE_DIALS.equals(merged.layout),
-                "partial widget keeps current layout");
         check(WidgetOptions.STYLE_DIALS.equals(merged.layout),
-                "partial widget keeps current layout value");
+                "partial widget keeps current layout");
         check(merged.showPlan && merged.showResetCredits,
                 "partial widget keeps current visibility flags");
 

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -541,6 +541,43 @@ public final class ParserSelfTest {
         check("refresh-demo".equals(parsed.authentication.getString("refresh_token")),
                 "auth refresh token restored");
 
+        WidgetOptions currentDefaults = new WidgetOptions(WidgetOptions.STYLE_DIALS,
+                WidgetOptions.DENSITY_COMPACT, WidgetOptions.SURFACE_ONE_UI,
+                WidgetOptions.GRAPHIC_LARGE, WidgetOptions.THEME_LIGHT, WidgetOptions.ACCENT_ROSE,
+                72, WidgetOptions.RESET_RELATIVE, WidgetOptions.DISPLAY_USED,
+                WidgetOptions.METRIC_WEEKLY, true, true, true, false, true, true)
+                .withPercentSymbol(true);
+        WidgetOptions merged = SettingsTransfer.widgetOptionsFromJson(
+                new org.json.JSONObject().put("accent", WidgetOptions.ACCENT_CYAN),
+                currentDefaults);
+        check(WidgetOptions.ACCENT_CYAN.equals(merged.accent), "partial widget updates accent");
+        check(WidgetOptions.THEME_LIGHT.equals(merged.theme),
+                "partial widget keeps current theme");
+        check(WidgetOptions.ACCENT_ROSE.equals(currentDefaults.accent)
+                        || WidgetOptions.STYLE_DIALS.equals(merged.layout),
+                "partial widget keeps current layout");
+        check(WidgetOptions.STYLE_DIALS.equals(merged.layout),
+                "partial widget keeps current layout value");
+        check(merged.showPlan && merged.showResetCredits,
+                "partial widget keeps current visibility flags");
+
+        boolean malformedLeadTimesRejected = false;
+        try {
+            SettingsTransfer.requireLeadTimes(
+                    new org.json.JSONObject().put("reset_credit_expiry_lead_times", "oops"),
+                    "reset_credit_expiry_lead_times");
+        } catch (IllegalArgumentException expected) {
+            malformedLeadTimesRejected = true;
+        }
+        check(malformedLeadTimesRejected, "malformed lead times rejected");
+        boolean nullLeadTimesRejected = false;
+        try {
+            SettingsTransfer.leadTimesFromJson(null);
+        } catch (IllegalArgumentException expected) {
+            nullLeadTimesRejected = true;
+        }
+        check(nullLeadTimesRejected, "null lead times array rejected");
+
         SettingsTransfer.Document settingsOnly = parsed.selecting(true, true, true, false);
         check(settingsOnly.hasAppSettings() && !settingsOnly.hasAuthentication(),
                 "section selection drops auth");

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -567,6 +567,22 @@ public final class ParserSelfTest {
             malformedLeadTimesRejected = true;
         }
         check(malformedLeadTimesRejected, "malformed lead times rejected");
+        boolean badElementRejected = false;
+        try {
+            SettingsTransfer.leadTimesFromJson(new org.json.JSONArray().put("oops"));
+        } catch (IllegalArgumentException expected) {
+            badElementRejected = true;
+        }
+        check(badElementRejected, "non-numeric lead time element rejected");
+        boolean outOfRangeRejected = false;
+        try {
+            SettingsTransfer.leadTimesFromJson(new org.json.JSONArray().put(1L));
+        } catch (IllegalArgumentException expected) {
+            outOfRangeRejected = true;
+        }
+        check(outOfRangeRejected, "out-of-range lead time element rejected");
+        check(SettingsTransfer.leadTimesFromJson(new org.json.JSONArray()).isEmpty(),
+                "empty lead times array remains allowed");
         boolean nullLeadTimesRejected = false;
         try {
             SettingsTransfer.leadTimesFromJson(null);

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -38,6 +38,7 @@ public final class ParserSelfTest {
         testReleaseNotesMarkdown();
         testReleaseUpdatePolicy();
         testUpdateCheckFrequency();
+        testSettingsTransfer();
         System.out.println("All parser, updater, OAuth, onboarding, and widget-option self-tests passed.");
     }
 
@@ -474,6 +475,109 @@ public final class ParserSelfTest {
         check(pkce.state.length() >= 43, "OAuth state entropy");
     }
 
+
+    private static void testSettingsTransfer() throws Exception {
+        WidgetOptions widget = new WidgetOptions(WidgetOptions.STYLE_RINGS,
+                WidgetOptions.DENSITY_COMFORTABLE, WidgetOptions.SURFACE_ONE_UI,
+                WidgetOptions.GRAPHIC_MAX, WidgetOptions.THEME_DARK, WidgetOptions.ACCENT_BLUE,
+                94, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING,
+                WidgetOptions.METRIC_BOTH, false, true, false, true, true, false)
+                .withPercentSymbol(false);
+        org.json.JSONObject appSettings = new org.json.JSONObject()
+                .put("app_theme", WidgetOptions.THEME_DARK)
+                .put("refresh_minutes", 15)
+                .put("refresh_on_launch", false)
+                .put("automatic_update_checks", true)
+                .put("notify_updates", true)
+                .put("check_interval_hours", 24)
+                .put("default_widget", SettingsTransfer.widgetOptionsToJson(widget));
+        org.json.JSONObject notifications = new org.json.JSONObject()
+                .put("style", "notification")
+                .put("metric", "weekly")
+                .put("threshold", 50)
+                .put("unexpected_refills", false)
+                .put("reset_credit_increases", true)
+                .put("reset_credit_expiry", true)
+                .put("reset_credit_expiry_lead_times",
+                        SettingsTransfer.leadTimesToJson(Arrays.asList(
+                                TimeUnit.HOURS.toMillis(1),
+                                TimeUnit.DAYS.toMillis(1))));
+        org.json.JSONObject nowBar = new org.json.JSONObject()
+                .put("display_mode", NowBarDisplayMode.SAMSUNG_COMPATIBILITY)
+                .put("percent_mode", NowBarPercentMode.WEEKLY)
+                .put("auto_enabled", true)
+                .put("metric", "five_hour")
+                .put("threshold", 10);
+        org.json.JSONObject authentication = new org.json.JSONObject()
+                .put("access_token", "access-demo")
+                .put("refresh_token", "refresh-demo")
+                .put("id_token", "id-demo")
+                .put("expires_at", 1_700_000_000_000L)
+                .put("account_id", "acct_demo")
+                .put("email", "demo@example.com");
+
+        SettingsTransfer.Document full = SettingsTransfer.create(1_700_000_000_000L, appSettings,
+                notifications, nowBar, authentication);
+        String json = full.toJsonString();
+        check(json.contains("\"contains_authentication\": true"), "auth flag present");
+        check(json.contains(SettingsTransfer.SECURITY_WARNING), "security warning embedded");
+        SettingsTransfer.Document parsed = SettingsTransfer.parse(json);
+        check(parsed.hasAppSettings() && parsed.hasNotifications()
+                        && parsed.hasNowBar() && parsed.hasAuthentication(),
+                "all sections round-trip");
+        check(parsed.presentSections().size() == 4, "four present sections");
+        WidgetOptions restored = SettingsTransfer.widgetOptionsFromJson(
+                parsed.appSettings.getJSONObject("default_widget"));
+        check(WidgetOptions.THEME_DARK.equals(restored.theme), "widget theme restored");
+        check(WidgetOptions.ACCENT_BLUE.equals(restored.accent), "widget accent restored");
+        check(!restored.showPercentSymbol, "percent symbol flag restored");
+        check(parsed.notifications.getInt("threshold") == 50, "notification threshold restored");
+        check(SettingsTransfer.leadTimesFromJson(
+                parsed.notifications.getJSONArray("reset_credit_expiry_lead_times")).size() == 2,
+                "lead times restored");
+        check(NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(
+                        parsed.nowBar.getString("display_mode")),
+                "Now Bar mode restored");
+        check("refresh-demo".equals(parsed.authentication.getString("refresh_token")),
+                "auth refresh token restored");
+
+        SettingsTransfer.Document settingsOnly = parsed.selecting(true, true, true, false);
+        check(settingsOnly.hasAppSettings() && !settingsOnly.hasAuthentication(),
+                "section selection drops auth");
+        check(!settingsOnly.toJson().optBoolean("contains_authentication", true),
+                "settings-only export clears auth flag");
+        check(!settingsOnly.toJson().has("security_warning"),
+                "settings-only export omits security warning");
+
+        boolean rejected = false;
+        try {
+            SettingsTransfer.parse(new org.json.JSONObject()
+                    .put("format", "not_codex")
+                    .put("version", 1)
+                    .put("sections", new org.json.JSONObject().put("app_settings", appSettings)));
+        } catch (IllegalArgumentException expected) {
+            rejected = true;
+        }
+        check(rejected, "unknown format rejected");
+
+        boolean emptyRejected = false;
+        try {
+            SettingsTransfer.parse(new org.json.JSONObject()
+                    .put("format", SettingsTransfer.FORMAT)
+                    .put("version", SettingsTransfer.VERSION)
+                    .put("sections", new org.json.JSONObject()));
+        } catch (IllegalArgumentException expected) {
+            emptyRejected = true;
+        }
+        check(emptyRejected, "empty sections rejected");
+        check(SettingsTransfer.isAuthenticationSection(
+                        SettingsTransfer.SECTION_AUTHENTICATION),
+                "auth section detector");
+        check("App settings".equals(
+                        SettingsTransfer.sectionTitle(SettingsTransfer.SECTION_APP_SETTINGS)),
+                "section title helper");
+        System.out.println("Settings transfer JSON sections and auth warning round-trip cleanly.");
+    }
 
     private static void testWidgetOptions() {
         WidgetOptions migrated = new WidgetOptions(WidgetOptions.LAYOUT_DETAILED,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an easy **Transfer** section in Android Settings so users can export and import selected Codex Meter data between devices.

### Sections
Users can pick any combination of:
- **App settings** — theme, refresh, update checks, default widget look
- **Notifications** — low-usage alerts and reset-credit reminders
- **Now Bar** — display mode, percentage mode, auto-start
- **Authentication** — ChatGPT OAuth tokens (optional, off by default)

### Security
- Persistent Settings notice: do not share transfer files that include authentication
- Extra confirmation dialog before exporting or importing authentication
- Auth-inclusive export filenames are marked `AUTH`
- Transfer JSON embeds `contains_authentication` and a `security_warning` when tokens are present

### Implementation
- `SettingsTransfer` — portable JSON document format (pure Java, unit-tested)
- `SettingsTransferStore` — collect/apply against preferences + Keystore-backed `SecureTokenStore`
- SAF `CREATE_DOCUMENT` / `OPEN_DOCUMENT` for save/open without storage permissions

### Greptile follow-ups
- Partial widget JSON merges onto current device defaults
- Malformed lead-time arrays are rejected instead of clearing reminders
- Now Bar stop/repost is scoped to Now Bar imports only
- Failed post-auth refresh surfaces via `AppPreferences.setLastError`

### Verification
- `./run-tests.sh` passed
- `./build.sh` passed (phone + Wear release APKs)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e40ceeb3-8f72-41b3-bafa-80ffe8e21cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e40ceeb3-8f72-41b3-bafa-80ffe8e21cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

