### PR TITLE
Fix Cloud Agent install hook for android/gradlew

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Codex Meter",
+  "install": "export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ANDROID_SDK_ROOT=$HOME/android-sdk ANDROID_HOME=$HOME/android-sdk && ./android/gradlew --version"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud Agent setup was failing with `INSTALL_FAILED` (exit **127**) because the recorded SETUP_FLOW install command ran `./gradlew --version`, but this monorepo’s wrapper lives at `android/gradlew`.

## Fix

Adds `.cursor/environment.json` so repo config overrides the broken personal SETUP_FLOW install command:

```json
{
  "name": "Codex Meter",
  "install": "export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ANDROID_SDK_ROOT=$HOME/android-sdk ANDROID_HOME=$HOME/android-sdk && ./android/gradlew --version"
}
```

## Notes

- Verified `./android/gradlew --version` succeeds on the current snapshot (Gradle 9.6.1 / JDK 21).
- Optional cleanup: clear or update the dashboard “Update command” under the personal environment so it no longer says `./gradlew --version` ([environment](https://cursor.com/dashboard/cloud-agents/environments/r/github.com/benitbuhner/codex-meter)). Repo `environment.json` takes precedence once merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e40ceeb3-8f72-41b3-bafa-80ffe8e21cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e40ceeb3-8f72-41b3-bafa-80ffe8e21cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

