### PR TITLE
Use official One UI blue with optional Material You

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 public final class AppPreferences {
     private static final String KEY_APP_STYLE = "app_surface_style";
     private static final String KEY_APP_THEME = "app_theme";
+    private static final String KEY_MATERIAL_YOU = "material_you";
     private static final String KEY_ERROR = "last_error";
     private static final String KEY_ERROR_AT = "last_error_at";
     private static final String KEY_OAUTH_PENDING = "oauth_pending";
@@ -214,6 +215,15 @@ public final class AppPreferences {
             str = WidgetOptions.THEME_SYSTEM;
         }
         prefs(context).edit().putString(KEY_APP_THEME, str).commit();
+    }
+
+    /** When enabled, accents follow Android Material You system colors (API 31+). */
+    public static boolean isMaterialYouEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_MATERIAL_YOU, false);
+    }
+
+    public static void setMaterialYouEnabled(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_MATERIAL_YOU, enabled).commit();
     }
 
     public static String getAppStyle(Context context) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -33,6 +33,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 public final class MainActivity extends AppCompatActivity {
     private static final int MENU_SETTINGS = 8101;
     private String appliedTheme;
+    private boolean appliedMaterialYou;
     private LinearLayout content;
     private SwipeRefreshLayout swipeRefresh;
     private boolean dark;
@@ -76,6 +77,7 @@ public final class MainActivity extends AppCompatActivity {
     @Override // android.app.Activity
     protected void onCreate(Bundle bundle) {
         this.appliedTheme = AppPreferences.getAppTheme(this);
+        this.appliedMaterialYou = AppPreferences.isMaterialYouEnabled(this);
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
         if (routeToOnboarding(getIntent())) {
@@ -130,7 +132,9 @@ public final class MainActivity extends AppCompatActivity {
         super.onResume();
         String appTheme = AppPreferences.getAppTheme(this);
         boolean zIsDark = Ui.isDark(this);
-        if (!appTheme.equals(this.appliedTheme) || zIsDark != this.dark) {
+        boolean materialYou = AppPreferences.isMaterialYouEnabled(this);
+        if (!appTheme.equals(this.appliedTheme) || zIsDark != this.dark
+                || materialYou != this.appliedMaterialYou) {
             recreate();
         } else {
             handleLaunchIntent(getIntent());

--- a/android/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -371,7 +371,7 @@ public final class NowBarManager {
                 .setOnlyAlertOnce(true)
                 .setCategory(Notification.CATEGORY_PROGRESS)
                 .setVisibility(Notification.VISIBILITY_PUBLIC)
-                .setColor(Color.rgb(56, 122, 255))
+                .setColor(Color.rgb(3, 129, 254))
                 .setShowWhen(false)
                 .addAction(new Notification.Action.Builder(
                         stopActionIcon, "Stop", stopIntent).build());
@@ -448,7 +448,7 @@ public final class NowBarManager {
         Bundle extras = new Bundle();
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "style", 1);
         extras.putParcelable(SAMSUNG_ONGOING_PREFIX + "chipIcon", chipIcon);
-        extras.putInt(SAMSUNG_ONGOING_PREFIX + "chipBgColor", Color.rgb(56, 122, 255));
+        extras.putInt(SAMSUNG_ONGOING_PREFIX + "chipBgColor", Color.rgb(3, 129, 254));
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "chipExpandedText",
                 "Codex · " + focusLabel + focusRemaining + "%");
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "primaryInfo",
@@ -601,7 +601,7 @@ public final class NowBarManager {
                             Icon.createWithResource(context, R.drawable.ic_now_bar_progress_dot))
                     .setProgressSegments(Collections.singletonList(
                             new Notification.ProgressStyle.Segment(100)
-                                    .setColor(Color.rgb(56, 122, 255))));
+                                    .setColor(Color.rgb(3, 129, 254))));
             builder.setStyle(style).setShortCriticalText(criticalText);
         }
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/OAuthBrowserPage.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/OAuthBrowserPage.java
@@ -22,7 +22,7 @@ public final class OAuthBrowserPage {
                 + "<meta name=\"color-scheme\" content=\"light dark\"><title>Codex Meter</title>"
                 + "<style>"
                 + ":root{color-scheme:light dark;--bg:#f1f1f3;--card:#fcfcff;--text:#000;--sub:#747477;"
-                + "--accent:#387aff;--on:#fff;--soft:#e8efff;--ring:#d9d9de}"
+                + "--accent:#0381fe;--on:#fff;--soft:#e8efff;--ring:#d9d9de}"
                 + "*{box-sizing:border-box}body{margin:0;min-height:100vh;background:var(--bg);color:var(--text);"
                 + "font-family:SamsungOne,'Samsung Sans',system-ui,-apple-system,sans-serif;display:grid;"
                 + "place-items:center;padding:24px}.card{width:min(440px,100%);background:var(--card);"

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -204,6 +204,7 @@ public final class SettingsActivity extends AppCompatActivity {
             boolean useSystem = WidgetOptions.THEME_SYSTEM.equals(selected);
             HorizontalRadioPreference theme = findPreference("app_theme");
             SwitchPreferenceCompat system = findPreference("theme_system_ui");
+            SwitchPreferenceCompat materialYou = findPreference("material_you");
             system.setEnabled(true);
             // The visual radio shows the effective light/dark mode while AppPreferences also
             // stores the third "system" state under app_theme. Do not let setValue() overwrite
@@ -226,6 +227,14 @@ public final class SettingsActivity extends AppCompatActivity {
                 AppPreferences.setAppTheme(requireContext(), enabled
                         ? WidgetOptions.THEME_SYSTEM
                         : (Ui.isDark(requireContext()) ? WidgetOptions.THEME_DARK : WidgetOptions.THEME_LIGHT));
+                requireActivity().recreate();
+                return true;
+            });
+            materialYou.setPersistent(false);
+            materialYou.setChecked(AppPreferences.isMaterialYouEnabled(requireContext()));
+            materialYou.setOnPreferenceChangeListener((preference, value) -> {
+                AppPreferences.setMaterialYouEnabled(requireContext(), (Boolean) value);
+                WidgetRenderer.updateAll(requireContext());
                 requireActivity().recreate();
                 return true;
             });

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -167,6 +167,7 @@ public final class SettingsTransferStore {
     private static JSONObject collectAppSettings(Context context) throws Exception {
         JSONObject json = new JSONObject();
         json.put("app_theme", AppPreferences.getAppTheme(context));
+        json.put("material_you", AppPreferences.isMaterialYouEnabled(context));
         json.put("refresh_minutes", AppPreferences.getRefreshMinutes(context));
         json.put("refresh_on_launch", AppPreferences.getRefreshOnLaunch(context));
         json.put("automatic_update_checks", UpdatePreferences.automaticChecks(context));
@@ -203,8 +204,11 @@ public final class SettingsTransferStore {
 
     private static boolean applyAppSettings(Context context, JSONObject json) throws Exception {
         String previousTheme = AppPreferences.getAppTheme(context);
+        boolean previousMaterialYou = AppPreferences.isMaterialYouEnabled(context);
         String theme = json.optString("app_theme", previousTheme);
         AppPreferences.setAppTheme(context, theme);
+        AppPreferences.setMaterialYouEnabled(context,
+                json.optBoolean("material_you", previousMaterialYou));
         AppPreferences.setRefreshMinutes(context, json.optInt("refresh_minutes",
                 AppPreferences.getRefreshMinutes(context)));
         AppPreferences.setRefreshOnLaunch(context, json.optBoolean("refresh_on_launch",
@@ -222,7 +226,8 @@ public final class SettingsTransferStore {
                     SettingsTransfer.widgetOptionsFromJson(widget,
                             AppPreferences.loadDefaultWidgetOptions(context)));
         }
-        return !previousTheme.equals(AppPreferences.getAppTheme(context));
+        return !previousTheme.equals(AppPreferences.getAppTheme(context))
+                || previousMaterialYou != AppPreferences.isMaterialYouEnabled(context);
     }
 
     private static void applyNotifications(Context context, JSONObject json) throws Exception {

--- a/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -84,7 +84,9 @@ public final class Ui {
             }
             ((AppCompatActivity) activity).getDelegate().setLocalNightMode(mode);
         }
-        activity.setTheme(R.style.AppTheme);
+        activity.setTheme(AppPreferences.isMaterialYouEnabled(activity)
+                ? R.style.AppTheme_MaterialYou
+                : R.style.AppTheme);
     }
 
     public static Page installPage(AppCompatActivity activity, String title, boolean back) {
@@ -208,11 +210,18 @@ public final class Ui {
         return z ? Color.rgb(55, 58, 64) : Color.rgb(228, 228, 228);
     }
 
+    /** Official One UI Primary (#0381FE) / dark-mode accent (#5CA9FF). */
+    public static int oneUiAccent(boolean dark) {
+        return dark ? Color.rgb(92, 169, 255) : Color.rgb(3, 129, 254);
+    }
+
     public static int accent(Context context, boolean z) {
-        if (isOneUi(context)) {
-            return z ? Color.rgb(92, 169, 255) : Color.rgb(56, 122, 255);
+        int oneUi = oneUiAccent(z);
+        if (AppPreferences.isMaterialYouEnabled(context)) {
+            // Material You system accents; fall back to One UI blues when unavailable.
+            return systemColor(context, z ? "system_accent1_200" : "system_accent1_600", oneUi);
         }
-        return systemColor(context, z ? "system_accent1_200" : "system_accent1_600", z ? Color.rgb(117, 220, 179) : Color.rgb(0, 113, 83));
+        return oneUi;
     }
 
     public static int desaturatedAccent(Context context, boolean dark) {

--- a/android/app/src/main/res/values-night-v31/styles.xml
+++ b/android/app/src/main/res/values-night-v31/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Material You dark: lighter system accent tones for contrast on dark surfaces. -->
+    <style name="AppTheme.MaterialYou" parent="AppTheme">
+        <item name="colorPrimary">@android:color/system_accent1_200</item>
+        <item name="colorPrimaryDark">@android:color/system_accent1_100</item>
+        <item name="colorControlActivated">@android:color/system_accent1_200</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Dark-mode One UI accent (matches widget blue) + official Primary dark. -->
+    <color name="oneui_primary">#5CA9FF</color>
+    <color name="oneui_primary_dark">#3E91FF</color>
     <color name="widget_setting_progress_color_control_normal">#6669696C</color>
     <color name="widget_setting_seek_bar_thumb_background_tint">#1F1F22</color>
-    <color name="widget_setting_seek_bar_thumb_tint">#66A4FF</color>
+    <color name="widget_setting_seek_bar_thumb_tint">@color/oneui_primary</color>
     <color name="widget_setting_seek_bar_tick_mark_solid_color">#77777A</color>
     <color name="widget_config_divider">#3A3A3D</color>
     <color name="oneui_bg">#010102</color>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="AppTheme" parent="OneUITheme">
-        <item name="colorPrimary">#5ca9ff</item>
+        <item name="colorPrimary">@color/oneui_primary</item>
+        <item name="colorPrimaryDark">@color/oneui_primary_dark</item>
+        <item name="colorControlActivated">@color/oneui_primary</item>
         <item name="android:fontFamily">sec</item>
         <item name="android:windowActionModeOverlay">true</item>
         <item name="android:windowLightStatusBar">false</item>
@@ -10,6 +12,8 @@
         <item name="android:statusBarColor">@color/oui_des_round_and_bgcolor</item>
         <item name="buttonCornerRadius">999dp</item>
     </style>
+
+    <style name="AppTheme.MaterialYou" parent="AppTheme" />
 
     <style name="AppThemeDark" parent="AppTheme" />
     <style name="AppThemeLight" parent="AppTheme" />

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Material You: follow Android 12+ system accent palette. -->
+    <style name="AppTheme.MaterialYou" parent="AppTheme">
+        <item name="colorPrimary">@android:color/system_accent1_600</item>
+        <item name="colorPrimaryDark">@android:color/system_accent1_700</item>
+        <item name="colorControlActivated">@android:color/system_accent1_600</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Official One UI Primary / Primary dark (Samsung design guide). -->
+    <color name="oneui_primary">#0381FE</color>
+    <color name="oneui_primary_dark">#0072DE</color>
     <color name="widget_setting_progress_color_control_normal">#66C9C9CC</color>
     <color name="widget_setting_seek_bar_thumb_background_tint">#FCFCFF</color>
-    <color name="widget_setting_seek_bar_thumb_tint">#0381FE</color>
+    <color name="widget_setting_seek_bar_thumb_tint">@color/oneui_primary</color>
     <color name="widget_setting_seek_bar_tick_mark_solid_color">#FFA6A6A9</color>
     <color name="widget_config_divider">#E4E4E6</color>
     <color name="oneui_bg">#F1F1F3</color>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Official One UI Primary (#0381FE), not the lighter SESL sample blue (#387AFF). -->
     <style name="AppTheme" parent="OneUITheme">
-        <item name="colorPrimary">#387aff</item>
+        <item name="colorPrimary">@color/oneui_primary</item>
+        <item name="colorPrimaryDark">@color/oneui_primary_dark</item>
+        <item name="colorControlActivated">@color/oneui_primary</item>
         <item name="android:fontFamily">sec</item>
         <item name="android:windowActionModeOverlay">true</item>
         <item name="android:windowBackground">@color/oui_des_round_and_bgcolor</item>
@@ -9,6 +12,9 @@
         <item name="android:statusBarColor">@color/oui_des_round_and_bgcolor</item>
         <item name="buttonCornerRadius">999dp</item>
     </style>
+
+    <!-- Same One UI blues as fallback when Material You system colors are unavailable. -->
+    <style name="AppTheme.MaterialYou" parent="AppTheme" />
 
     <style name="App.ContainedPrimaryColorButtonTheme" parent="OneUI.ContainedPrimaryColorButtonTheme">
         <item name="buttonCornerRadius">999dp</item>

--- a/android/app/src/main/res/xml/preferences_settings.xml
+++ b/android/app/src/main/res/xml/preferences_settings.xml
@@ -18,6 +18,11 @@
         <SwitchPreferenceCompat
             android:key="theme_system_ui"
             android:title="System default" />
+        <SwitchPreferenceCompat
+            android:key="material_you"
+            android:title="Material You"
+            android:summary="Use the system color palette when available. Falls back to One UI blue."
+            android:defaultValue="false" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Refresh">

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -136,6 +136,19 @@ grep -q 'SettingsTransferStore.apply' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 grep -q 'Do not share transfer files with authentication' \
   "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'material_you' \
+  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'isMaterialYouEnabled' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java"
+grep -q 'AppTheme_MaterialYou' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
+grep -q 'oneUiAccent' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
+grep -q 'oneui_primary' \
+  "$ROOT/app/src/main/res/values/colors.xml"
+grep -q '#0381FE' \
+  "$ROOT/app/src/main/res/values/colors.xml"
+grep -q 'material you preference restored' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'widgetOptionsFromJson(widget,' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
 grep -q 'requireLeadTimes' \

--- a/android/shared/src/main/java/dev/bennett/codexmeter/WearGlanceFormat.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/WearGlanceFormat.java
@@ -4,7 +4,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 public final class WearGlanceFormat {
-    public static final int ONE_UI_PRIMARY = 0xFF387AFF;
+    public static final int ONE_UI_PRIMARY = 0xFF0381FE;
     public static final int ONE_UI_ON_PRIMARY = 0xFFFFFFFF;
     public static final int ONE_UI_ON_SURFACE = 0xFFFFFFFF;
     public static final int ONE_UI_SECONDARY_TEXT = 0xB3FFFFFF;
@@ -23,7 +23,7 @@ public final class WearGlanceFormat {
      *
      * Samsung publishes One UI Watch design principles, but there is no public One UI
      * Design SDK for Wear like phone oneui-design. Wear surfaces align visually with
-     * OLED black backgrounds, high-contrast white text, Samsung-blue #387AFF accents,
+     * OLED black backgrounds, high-contrast white text, Samsung-blue #0381FE accents,
      * large round-friendly tap targets, glanceable single-job layouts, and subtle
      * dark cards (#202124).
      */

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -485,6 +485,7 @@ public final class ParserSelfTest {
                 .withPercentSymbol(false);
         org.json.JSONObject appSettings = new org.json.JSONObject()
                 .put("app_theme", WidgetOptions.THEME_DARK)
+                .put("material_you", true)
                 .put("refresh_minutes", 15)
                 .put("refresh_on_launch", false)
                 .put("automatic_update_checks", true)
@@ -530,6 +531,7 @@ public final class ParserSelfTest {
                 parsed.appSettings.getJSONObject("default_widget"));
         check(WidgetOptions.THEME_DARK.equals(restored.theme), "widget theme restored");
         check(WidgetOptions.ACCENT_BLUE.equals(restored.accent), "widget accent restored");
+        check(parsed.appSettings.getBoolean("material_you"), "material you preference restored");
         check(!restored.showPercentSymbol, "percent symbol flag restored");
         check(parsed.notifications.getInt("threshold") == 50, "notification threshold restored");
         check(SettingsTransfer.leadTimesFromJson(

--- a/android/wear/src/main/java/dev/bennett/codexmeter/WearOngoingMonitor.java
+++ b/android/wear/src/main/java/dev/bennett/codexmeter/WearOngoingMonitor.java
@@ -169,7 +169,7 @@ public final class WearOngoingMonitor {
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setCategory(NotificationCompat.CATEGORY_STATUS)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                .setColor(Color.rgb(56, 122, 255))
+                .setColor(Color.rgb(3, 129, 254))
                 .setShowWhen(false)
                 .setProgress(100, used, false)
                 .addAction(new NotificationCompat.Action.Builder(
@@ -261,7 +261,7 @@ public final class WearOngoingMonitor {
                             Icon.createWithResource(context, R.drawable.ic_notification))
                     .setProgressSegments(Collections.singletonList(
                             new Notification.ProgressStyle.Segment(100)
-                                    .setColor(Color.rgb(56, 122, 255))));
+                                    .setColor(Color.rgb(3, 129, 254))));
             return builder.setStyle(style).build();
         }
 

--- a/android/wear/src/main/res/drawable/ic_launcher.xml
+++ b/android/wear/src/main/res/drawable/ic_launcher.xml
@@ -5,7 +5,7 @@
     android:viewportWidth="48"
     android:viewportHeight="48">
     <path
-        android:fillColor="#387AFF"
+        android:fillColor="#0381FE"
         android:pathData="M24,4a20,20 0,1 0,0.1 0z" />
     <path
         android:fillColor="#FFFFFFFF"

--- a/android/wear/src/main/res/drawable/preview_tile_five_hour.xml
+++ b/android/wear/src/main/res/drawable/preview_tile_five_hour.xml
@@ -13,7 +13,7 @@
         android:fillColor="@android:color/transparent"
         android:pathData="M60,18a42,42 0,1 1,-0.1 0" />
     <path
-        android:strokeColor="#387AFF"
+        android:strokeColor="#0381FE"
         android:strokeWidth="8"
         android:strokeLineCap="round"
         android:fillColor="@android:color/transparent"

--- a/android/wear/src/main/res/drawable/preview_tile_monitor.xml
+++ b/android/wear/src/main/res/drawable/preview_tile_monitor.xml
@@ -11,7 +11,7 @@
         android:fillColor="#202124"
         android:pathData="M28,30h64a16,16 0,0 1,16 16v28a16,16 0,0 1,-16 16h-64a16,16 0,0 1,-16 -16v-28a16,16 0,0 1,16 -16z" />
     <path
-        android:fillColor="#387AFF"
+        android:fillColor="#0381FE"
         android:pathData="M34,54a8,8 0,1 1,16 0a8,8 0,1 1,-16 0" />
     <path
         android:fillColor="#FFFFFFFF"

--- a/android/wear/src/main/res/drawable/preview_tile_overview.xml
+++ b/android/wear/src/main/res/drawable/preview_tile_overview.xml
@@ -11,7 +11,7 @@
         android:fillColor="#202124"
         android:pathData="M24,28h72a16,16 0,0 1,16 16v32a16,16 0,0 1,-16 16h-72a16,16 0,0 1,-16 -16v-32a16,16 0,0 1,16 -16z" />
     <path
-        android:fillColor="#387AFF"
+        android:fillColor="#0381FE"
         android:pathData="M34,44h52v8h-52z" />
     <path
         android:fillColor="#FFFFFFFF"

--- a/android/wear/src/main/res/drawable/preview_tile_reset.xml
+++ b/android/wear/src/main/res/drawable/preview_tile_reset.xml
@@ -11,7 +11,7 @@
         android:fillColor="#202124"
         android:pathData="M30,36h60a12,12 0,0 1,12 12v24a12,12 0,0 1,-12 12h-60a12,12 0,0 1,-12 -12v-24a12,12 0,0 1,12 -12z" />
     <path
-        android:fillColor="#387AFF"
+        android:fillColor="#0381FE"
         android:pathData="M58,24h4v34h-4zM58,58h28v4h-28z" />
     <path
         android:fillColor="#FFFFFFFF"

--- a/android/wear/src/main/res/drawable/preview_tile_weekly.xml
+++ b/android/wear/src/main/res/drawable/preview_tile_weekly.xml
@@ -13,7 +13,7 @@
         android:fillColor="@android:color/transparent"
         android:pathData="M60,18a42,42 0,1 1,-0.1 0" />
     <path
-        android:strokeColor="#387AFF"
+        android:strokeColor="#0381FE"
         android:strokeWidth="8"
         android:strokeLineCap="round"
         android:fillColor="@android:color/transparent"

--- a/android/wear/src/main/res/values/colors.xml
+++ b/android/wear/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="codex_blue">#387AFF</color>
+    <color name="codex_blue">#0381FE</color>
     <color name="codex_on_blue">#FFFFFFFF</color>
     <color name="codex_background">#000000</color>
     <color name="codex_card">#202124</color>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Default accent/theme primary now uses Samsung’s official One UI Primary (`#0381FE`) instead of the lighter SESL sample blue (`#387AFF`), aligned with widget blue and the One UI design guide.
- Adds a **Material You** switch under Settings → Appearance. When enabled, app accents/`colorPrimary` follow Android system accent colors (API 31+); otherwise (and as fallback) they stay on the One UI blues.
- Preference is persisted, exported/imported with settings transfer, and triggers activity recreate + widget refresh.

## Test plan
- [x] `./run-tests.sh`
- [ ] Toggle Material You on a device (API 31+) and confirm accents track the system palette
- [ ] Confirm default (Material You off) shows deeper `#0381FE` on buttons, progress, and settings controls
- [ ] Light/dark/system appearance still works with Material You on and off
- [ ] Settings export/import preserves `material_you`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1de77b2e-4246-4c2d-a602-103cf3b22bd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1de77b2e-4246-4c2d-a602-103cf3b22bd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

