### PR TITLE
Align widget fill with One UI Background toggle and 3 opacity steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@
 ### Added
 
 - Android settings transfer: export and import selected sections (app settings, notifications, Now Bar, and ChatGPT authentication) from Settings, with explicit warnings when authentication tokens are included.
+- Widget Background toggle in customize settings so the fill can be turned off entirely, matching official One UI widgets.
+
+### Changed
+
+- Widget opacity control now uses three discrete fill strengths (56% / 88% / 100%) instead of four, aligning with current Samsung One UI widget transparency steps.
 
 ### Development
 
 - Added pure-Java coverage for transfer document parsing, section selection, and embedded authentication warnings.
+- Expanded widget-option self-tests for background-off opacity, three-step snapping, and legacy four-step migration.
 
 ## 2.3.3 — 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The app includes:
 - Responsive home-screen widgets with ring, four-dial, and battery-list layouts selected for the available size.
 - Both-window, five-hour-only, and weekly-only configurations.
 - Optional reset-credit inventory, expiration, and redemption controls.
-- Transparent through opaque backgrounds.
+- Transparent through opaque backgrounds, including a Background off toggle and three One UI-style opacity steps.
 - Samsung One UI presentation throughout the dashboard, settings, and widget configuration surfaces.
 - Samsung lock/AOD providers for both usage windows together or dedicated five-hour and weekly views.
 - High-resolution supersampled lock-screen geometry with native Android text overlays.

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
@@ -38,8 +38,10 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     private Spinner displaySpinner;
     private CardItemView displayRow;
     private SeslSeekBar opacitySlider;
+    private SwitchCompat backgroundSwitch;
     private SwitchCompat percentSymbolSwitch;
     private View opacityControl;
+    private View backgroundRow;
     private FrameLayout previewContainer;
     private Bundle widgetSize = new Bundle();
     private Spinner themeSpinner;
@@ -89,15 +91,28 @@ public final class WidgetConfigActivity extends AppCompatActivity {
 
         content.addView(Ui.separator(this, "Appearance"));
         RoundedLinearLayout appearanceCard = Ui.seslRowCard(this, this.dark);
+        this.backgroundSwitch = new SwitchCompat(this);
+        this.backgroundSwitch.setChecked(saved.opacity > 0);
+        this.backgroundRow = buildSwitchRow(getString(R.string.widget_background),
+                this.backgroundSwitch, false);
+        appearanceCard.addView(this.backgroundRow);
+        View opacityDivider = new View(this);
+        opacityDivider.setBackgroundColor(Ui.divider(this.dark));
+        LinearLayout.LayoutParams opacityDividerParams =
+                new LinearLayout.LayoutParams(-1, Ui.dp(this, 1));
+        opacityDividerParams.setMargins(Ui.dp(this, 16), 0, Ui.dp(this, 16), 0);
+        appearanceCard.addView(opacityDivider, opacityDividerParams);
         this.opacityControl = LayoutInflater.from(this).inflate(
                 R.layout.view_widget_opacity, appearanceCard, false);
+        this.opacityControl.setTag(opacityDivider);
         appearanceCard.addView(this.opacityControl);
         this.opacitySlider = this.opacityControl.findViewById(R.id.opacity_slider);
-        this.opacitySlider.setProgress(opacityIndex(saved.opacity));
+        this.opacitySlider.setProgress(WidgetOptions.opacityIndex(saved.opacity));
         this.opacitySlider.setAlpha(0.0f);
         if (this.opacitySlider.getProgressDrawable() != null) {
             this.opacitySlider.getProgressDrawable().setAlpha(0);
         }
+        applyBackgroundEnabled(this.backgroundSwitch.isChecked());
 
         this.themeSpinner = Ui.spinner(this, WidgetOptionCatalog.THEME_LABELS, this.dark);
         this.accentSpinner = Ui.spinner(this, WidgetOptionCatalog.ACCENT_LABELS, this.dark);
@@ -126,16 +141,7 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         contentCard.addView(symbolDivider, dividerParams);
         this.percentSymbolSwitch = new SwitchCompat(this);
         this.percentSymbolSwitch.setChecked(saved.showPercentSymbol);
-        LinearLayout symbolRow = new LinearLayout(this);
-        symbolRow.setGravity(Gravity.CENTER_VERTICAL);
-        symbolRow.setMinimumHeight(Ui.dp(this, 64));
-        symbolRow.setPadding(Ui.dp(this, 20), 0, Ui.dp(this, 20), 0);
-        symbolRow.addView(Ui.text(this, "Show % symbol", 18, Ui.mainText(this.dark)),
-                new LinearLayout.LayoutParams(0, -2, 1));
-        symbolRow.addView(this.percentSymbolSwitch,
-                new LinearLayout.LayoutParams(-2, -2));
-        symbolRow.setOnClickListener(view -> this.percentSymbolSwitch.toggle());
-        contentCard.addView(symbolRow);
+        contentCard.addView(buildSwitchRow("Show % symbol", this.percentSymbolSwitch, false));
         content.addView(contentCard);
 
         content.addView(Ui.separator(this, "Widget tap action"));
@@ -156,6 +162,11 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         this.accentSpinner.setOnItemSelectedListener(selectionListener);
         this.displaySpinner.setOnItemSelectedListener(selectionListener);
         this.percentSymbolSwitch.setOnCheckedChangeListener((button, checked) -> renderPreview());
+        this.backgroundSwitch.setOnCheckedChangeListener((button, checked) -> {
+            applyBackgroundEnabled(checked);
+            updateSliderVisuals();
+            renderPreview();
+        });
         this.opacitySlider.setOnSeekBarChangeListener(new SeslSeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeslSeekBar seekBar, int progress, boolean fromUser) {
@@ -197,6 +208,43 @@ public final class WidgetConfigActivity extends AppCompatActivity {
             }
         });
         return card;
+    }
+
+    private LinearLayout buildSwitchRow(String title, SwitchCompat toggle, boolean topDivider) {
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.VERTICAL);
+        if (topDivider) {
+            View divider = new View(this);
+            divider.setBackgroundColor(Ui.divider(this.dark));
+            LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 1));
+            dividerParams.setMargins(Ui.dp(this, 16), 0, Ui.dp(this, 16), 0);
+            row.addView(divider, dividerParams);
+        }
+        LinearLayout content = new LinearLayout(this);
+        content.setGravity(Gravity.CENTER_VERTICAL);
+        content.setMinimumHeight(Ui.dp(this, 64));
+        content.setPadding(Ui.dp(this, 20), 0, Ui.dp(this, 20), 0);
+        content.addView(Ui.text(this, title, 18, Ui.mainText(this.dark)),
+                new LinearLayout.LayoutParams(0, -2, 1));
+        content.addView(toggle, new LinearLayout.LayoutParams(-2, -2));
+        content.setOnClickListener(view -> toggle.toggle());
+        row.addView(content, new LinearLayout.LayoutParams(-1, -2));
+        return row;
+    }
+
+    private void applyBackgroundEnabled(boolean enabled) {
+        if (this.opacityControl == null) {
+            return;
+        }
+        int visibility = enabled ? View.VISIBLE : View.GONE;
+        this.opacityControl.setVisibility(visibility);
+        Object divider = this.opacityControl.getTag();
+        if (divider instanceof View) {
+            ((View) divider).setVisibility(visibility);
+        }
+        if (this.opacitySlider != null) {
+            this.opacitySlider.setEnabled(enabled);
+        }
     }
 
     private RadioItemView radioRow(int id, String title, boolean divider) {
@@ -332,12 +380,18 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     }
 
     private WidgetOptions currentOptions() {
+        boolean backgroundOn = this.backgroundSwitch == null || this.backgroundSwitch.isChecked();
+        int opacity = backgroundOn
+                ? WidgetOptionCatalog.OPACITY_VALUES[Math.max(0, Math.min(
+                        WidgetOptionCatalog.OPACITY_VALUES.length - 1,
+                        this.opacitySlider.getProgress()))]
+                : 0;
         return new WidgetOptions(WidgetOptions.STYLE_RINGS,
                 WidgetOptions.DENSITY_AUTO,
                 WidgetOptions.SURFACE_ONE_UI, WidgetOptions.GRAPHIC_AUTO,
                 WidgetOptionCatalog.THEME_VALUES[this.themeSpinner.getSelectedItemPosition()],
                 WidgetOptionCatalog.ACCENT_VALUES[this.accentSpinner.getSelectedItemPosition()],
-                WidgetOptionCatalog.OPACITY_VALUES[this.opacitySlider.getProgress()],
+                opacity,
                 WidgetOptions.RESET_HIDDEN,
                 WidgetOptionCatalog.DISPLAY_VALUES[this.displaySpinner.getSelectedItemPosition()],
                 WidgetOptions.METRIC_BOTH, false, false, false, false, false, false)
@@ -441,14 +495,18 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     }
 
     private void updateSliderVisuals() {
-        int[] ticks = {R.id.opacity_tick_0, R.id.opacity_tick_1,
-                R.id.opacity_tick_2, R.id.opacity_tick_3};
+        if (this.opacityControl == null || this.opacitySlider == null
+                || this.opacityControl.getVisibility() != View.VISIBLE) {
+            return;
+        }
+        int[] ticks = {R.id.opacity_tick_0, R.id.opacity_tick_1, R.id.opacity_tick_2};
         int level = Math.max(0, Math.min(ticks.length - 1, this.opacitySlider.getProgress()));
         for (int i = 0; i < ticks.length; i++) {
             this.opacityControl.findViewById(ticks[i]).setAlpha(i == level ? 0.0f : 1.0f);
         }
         View thumb = this.opacityControl.findViewById(R.id.opacity_thumb_visual);
-        android.graphics.drawable.GradientDrawable thumbBackground = new android.graphics.drawable.GradientDrawable();
+        android.graphics.drawable.GradientDrawable thumbBackground =
+                new android.graphics.drawable.GradientDrawable();
         thumbBackground.setShape(android.graphics.drawable.GradientDrawable.OVAL);
         thumbBackground.setColor(dark ? 0xFF1F1F22 : 0xFFFCFCFF);
         thumbBackground.setStroke(Ui.dp(this, 2), Ui.accent(this, dark));
@@ -458,19 +516,6 @@ public final class WidgetConfigActivity extends AppCompatActivity {
             thumb.setTranslationX(tick.getX() + (tick.getWidth() / 2.0f)
                     - (thumb.getWidth() / 2.0f));
         });
-    }
-
-    private static int opacityIndex(int opacity) {
-        int best = 0;
-        int distance = Integer.MAX_VALUE;
-        for (int i = 0; i < WidgetOptionCatalog.OPACITY_VALUES.length; i++) {
-            int candidate = Math.abs(WidgetOptionCatalog.OPACITY_VALUES[i] - opacity);
-            if (candidate < distance) {
-                best = i;
-                distance = candidate;
-            }
-        }
-        return best;
     }
 
     private void save() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java
@@ -16,8 +16,9 @@ final class WidgetOptionCatalog {
     static final String[] GRAPHIC_VALUES = {"auto", WidgetOptions.GRAPHIC_LARGE, WidgetOptions.GRAPHIC_MAX};
     static final String[] ACCENT_LABELS = {"Mint", "Blue", "Amber", "Violet", "Rose", "Cyan", "Lime", "Monochrome"};
     static final String[] ACCENT_VALUES = {WidgetOptions.ACCENT_MINT, WidgetOptions.ACCENT_BLUE, WidgetOptions.ACCENT_AMBER, WidgetOptions.ACCENT_VIOLET, WidgetOptions.ACCENT_ROSE, WidgetOptions.ACCENT_CYAN, WidgetOptions.ACCENT_LIME, WidgetOptions.ACCENT_MONO};
-    static final String[] OPACITY_LABELS = {"15%", "40%", "70%", "94%"};
-    static final int[] OPACITY_VALUES = {15, 40, 70, 94};
+    /** One UI 7-style discrete fill strengths when the widget background is enabled. */
+    static final String[] OPACITY_LABELS = {"56%", "88%", "100%"};
+    static final int[] OPACITY_VALUES = WidgetOptions.OPACITY_LEVELS;
     static final String[] RESET_LABELS = {"Absolute time", "Relative time", "Both", "Hide reset time"};
     static final String[] RESET_VALUES = {WidgetOptions.RESET_ABSOLUTE, WidgetOptions.RESET_RELATIVE, "both", WidgetOptions.RESET_HIDDEN};
     static final String[] METRIC_LABELS = {"5-hour and weekly"};

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java
@@ -42,6 +42,9 @@ public final class WidgetOptions {
     public static final String TAP_OPEN_APP = "open_app";
     public static final String TAP_REFRESH = "refresh";
     public static final String TAP_USE_RESET = "use_reset";
+    /** One UI 7-style discrete fill strengths when the widget background is enabled. */
+    public static final int[] OPACITY_LEVELS = {56, 88, 100};
+    public static final int DEFAULT_OPACITY = 88;
     public final String accent;
     public final String density;
     public final String displayMode;
@@ -90,8 +93,13 @@ public final class WidgetOptions {
         this.graphicScale = oneOf(str4, "auto", GRAPHIC_LARGE, GRAPHIC_MAX) ? str4 : "auto";
         this.theme = oneOf(str5, THEME_SYSTEM, THEME_DARK, THEME_LIGHT) ? str5 : THEME_SYSTEM;
         this.accent = validAccent(str6) ? str6 : ACCENT_MINT;
-        if (i != 0 && i != 15 && i != 40 && i != 56 && i != 70 && i != 72 && i != 88 && i != 94 && i != 100) {
-            i = 88;
+        // Accept legacy four-step and drawable-aligned values, then snap to One UI's three
+        // fill strengths (or fully off) so saved widgets migrate cleanly.
+        if (i != 0 && i != 15 && i != 40 && i != 56 && i != 70 && i != 72 && i != 88 && i != 94
+                && i != 100) {
+            i = DEFAULT_OPACITY;
+        } else if (i > 0) {
+            i = snapOpacity(i);
         }
         this.opacity = i;
         this.resetMode = oneOf(str7, RESET_ABSOLUTE, RESET_RELATIVE, "both", RESET_HIDDEN) ? str7 : RESET_ABSOLUTE;
@@ -115,7 +123,36 @@ public final class WidgetOptions {
     }
 
     public static WidgetOptions defaults() {
-        return new WidgetOptions(STYLE_RINGS, "auto", SURFACE_ONE_UI, "auto", THEME_SYSTEM, ACCENT_BLUE, 88, RESET_HIDDEN, DISPLAY_REMAINING, "both", false, false, false, false, false, false);
+        return new WidgetOptions(STYLE_RINGS, "auto", SURFACE_ONE_UI, "auto", THEME_SYSTEM, ACCENT_BLUE, DEFAULT_OPACITY, RESET_HIDDEN, DISPLAY_REMAINING, "both", false, false, false, false, false, false);
+    }
+
+    /** Nearest allowed opacity when background is on; {@code 0} stays fully off. */
+    public static int snapOpacity(int opacity) {
+        if (opacity <= 0) {
+            return 0;
+        }
+        int best = DEFAULT_OPACITY;
+        int distance = Integer.MAX_VALUE;
+        for (int value : OPACITY_LEVELS) {
+            int candidate = Math.abs(value - opacity);
+            // Prefer the stronger fill when two levels are equidistant (e.g. 94 → 100).
+            if (candidate < distance || (candidate == distance && value > best)) {
+                best = value;
+                distance = candidate;
+            }
+        }
+        return best;
+    }
+
+    /** Slider index for a stored opacity; background-off restores the medium tick. */
+    public static int opacityIndex(int opacity) {
+        int snapped = snapOpacity(opacity <= 0 ? DEFAULT_OPACITY : opacity);
+        for (int i = 0; i < OPACITY_LEVELS.length; i++) {
+            if (OPACITY_LEVELS[i] == snapped) {
+                return i;
+            }
+        }
+        return 1;
     }
 
     public boolean showsFiveHour() {

--- a/android/app/src/main/res/layout/view_widget_opacity.xml
+++ b/android/app/src/main/res/layout/view_widget_opacity.xml
@@ -59,8 +59,6 @@
                 <View android:id="@+id/opacity_tick_1" android:layout_width="@dimen/widget_setting_seek_bar_tickmark_drawable_width" android:layout_height="@dimen/widget_setting_seek_bar_tickmark_drawable_height" android:background="@drawable/widget_setting_seek_bar_tick_mark" />
                 <Space android:layout_width="0dp" android:layout_height="1dp" android:layout_weight="1" />
                 <View android:id="@+id/opacity_tick_2" android:layout_width="@dimen/widget_setting_seek_bar_tickmark_drawable_width" android:layout_height="@dimen/widget_setting_seek_bar_tickmark_drawable_height" android:background="@drawable/widget_setting_seek_bar_tick_mark" />
-                <Space android:layout_width="0dp" android:layout_height="1dp" android:layout_weight="1" />
-                <View android:id="@+id/opacity_tick_3" android:layout_width="@dimen/widget_setting_seek_bar_tickmark_drawable_width" android:layout_height="@dimen/widget_setting_seek_bar_tickmark_drawable_height" android:background="@drawable/widget_setting_seek_bar_tick_mark" />
             </LinearLayout>
 
             <View
@@ -74,10 +72,10 @@
                 android:id="@+id/opacity_slider"
                 android:layout_width="match_parent"
                 android:layout_height="32dp"
-                android:max="3"
+                android:max="2"
                 android:paddingStart="24dp"
                 android:paddingEnd="22dp"
-                android:progress="2"
+                android:progress="1"
                 android:progressDrawable="@drawable/widget_setting_seek_bar_progress_transparent"
                 android:splitTrack="false"
                 android:thumb="@drawable/widget_setting_seek_bar_thumb"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="widget_config_cancel">Cancel</string>
     <string name="widget_config_save">Save</string>
+    <string name="widget_background">Background</string>
     <string name="widget_opacity">Opacity</string>
     <string name="widget_next_reset">Time remaining until the next usage reset</string>
     <string name="widget_reset_credits">Available Codex reset credits</string>

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -324,6 +324,14 @@ grep -R -q 'app:widgetStyle="monotone"' "$ROOT/app/src/main/res/xml/samsung_lock
 grep -q 'RESET_CREDITS_CONSUME_URL' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
 grep -q 'ResetCreditActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'showResetAction' "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java"
+grep -q 'OPACITY_LEVELS = {56, 88, 100}' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java"
+grep -q 'widget_background' "$ROOT/app/src/main/res/values/strings.xml"
+grep -q 'backgroundSwitch' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
+grep -q 'android:max="2"' "$ROOT/app/src/main/res/layout/view_widget_opacity.xml"
+! grep -q 'opacity_tick_3' "$ROOT/app/src/main/res/layout/view_widget_opacity.xml"
+grep -q 'One UI widget opacity uses three levels' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'dev.oneuiproject.oneui.widget.CardItemView' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java"
 grep -q 'Ui.nativePrimaryButton' \

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -635,6 +635,8 @@ public final class ParserSelfTest {
                 WidgetOptions.RESET_BOTH, WidgetOptions.DISPLAY_USED);
         check(WidgetOptions.STYLE_BARS.equals(migrated.layout), "legacy detailed migration");
         check(WidgetOptions.DENSITY_AUTO.equals(migrated.density), "default density");
+        // 72 is equidistant from 56 and 88; prefer the stronger fill (88).
+        check(migrated.opacity == 88, "legacy 72% opacity snaps to medium fill");
         WidgetOptions safe = new WidgetOptions("invalid", "invalid", "invalid", "invalid", 13,
                 "invalid", "invalid", true, false, true);
         check(WidgetOptions.STYLE_AUTO.equals(safe.layout), "invalid style fallback");
@@ -643,6 +645,16 @@ public final class ParserSelfTest {
         check(WidgetOptions.SURFACE_MATERIAL.equals(safe.surfaceStyle), "legacy surface fallback");
         check(WidgetOptions.GRAPHIC_AUTO.equals(safe.graphicScale), "legacy graphic fallback");
         check(!safe.showUpdated && safe.showRefresh, "boolean options");
+
+        check(WidgetOptions.OPACITY_LEVELS.length == 3,
+                "One UI widget opacity uses three levels");
+        check(WidgetOptions.snapOpacity(0) == 0, "background-off stays at 0");
+        check(WidgetOptions.snapOpacity(15) == 56, "legacy 15% maps to low fill");
+        check(WidgetOptions.snapOpacity(40) == 56, "legacy 40% maps to low fill");
+        check(WidgetOptions.snapOpacity(70) == 56, "legacy 70% maps to low fill");
+        check(WidgetOptions.snapOpacity(94) == 100, "legacy 94% maps to full fill");
+        check(WidgetOptions.opacityIndex(0) == 1, "background-off restores medium slider");
+        check(WidgetOptions.opacityIndex(88) == 1, "default opacity is middle tick");
 
         WidgetOptions transparent = new WidgetOptions(WidgetOptions.STYLE_RINGS,
                 WidgetOptions.DENSITY_COMFORTABLE, WidgetOptions.SURFACE_ONE_UI,
@@ -653,6 +665,21 @@ public final class ParserSelfTest {
         check(WidgetOptions.SURFACE_ONE_UI.equals(transparent.surfaceStyle), "One UI widget style");
         check(WidgetOptions.GRAPHIC_MAX.equals(transparent.graphicScale), "maximum graphic scale");
         check(!WidgetOptions.defaults().showTitle, "widget title defaults off");
+        check(WidgetOptions.defaults().opacity == WidgetOptions.DEFAULT_OPACITY,
+                "default fill uses medium opacity");
+
+        WidgetOptions low = new WidgetOptions(WidgetOptions.STYLE_RINGS,
+                WidgetOptions.DENSITY_AUTO, WidgetOptions.SURFACE_ONE_UI,
+                WidgetOptions.GRAPHIC_AUTO, WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_BLUE,
+                56, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING,
+                "both", false, false, false, false, false, false);
+        WidgetOptions high = new WidgetOptions(WidgetOptions.STYLE_RINGS,
+                WidgetOptions.DENSITY_AUTO, WidgetOptions.SURFACE_ONE_UI,
+                WidgetOptions.GRAPHIC_AUTO, WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_BLUE,
+                100, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING,
+                "both", false, false, false, false, false, false);
+        check(low.opacity == 56, "low fill strength accepted");
+        check(high.opacity == 100, "full fill strength accepted");
     }
 
     private static void testOnboardingFlow() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Home-screen widget customize settings now match current Samsung One UI widget fill controls:

1. **Background toggle** — turn the widget fill completely off (opacity `0`), the same way official One UI widgets expose Background on/off.
2. **Three opacity steps** — replace the previous four-tick control (`15/40/70/94`) with One UI-style strengths `56% / 88% / 100%`.

Legacy saved opacities snap to the nearest of the three levels (preferring the stronger fill on ties). Turning Background back on restores the medium slider tick when the previous value was off.

## Demo

Illustrative fill states (wallpaper behind the card):

[Background off + three opacity steps](https://cursor.com/agents/bc-ce84f8b4-cc9f-4640-b7a2-8d93b98fbe28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwidget-background-demo%2Fwidget-fill-demo-collage.png)

| State | Meaning |
|-------|---------|
| Background off | No fill (`opacity = 0`) |
| 56% | Low fill |
| 88% | Medium fill (default) |
| 100% | Full fill |

## Test plan

- [x] `./run-tests.sh` — widget-option self-tests for three levels, background-off, and legacy snapping
- [x] `./build.sh` — phone + Wear release APKs built
- [x] `./lint.sh` — release lint succeeded (baseline warnings only)
- [ ] On a Galaxy device: long-press widget → Settings → toggle Background off/on and sweep the three opacity ticks; confirm live preview and saved widget match

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce84f8b4-cc9f-4640-b7a2-8d93b98fbe28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce84f8b4-cc9f-4640-b7a2-8d93b98fbe28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

