### PR TITLE
Add modular Material 3 Expressive Android design

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
@@ -22,7 +22,6 @@ import androidx.core.view.WindowInsetsCompat;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import dev.oneuiproject.oneui.widget.CardItemView;
-import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 import dev.oneuiproject.oneui.utils.EdgeToEdge;
 
 public final class AboutActivity extends AppCompatActivity {
@@ -86,7 +85,7 @@ public final class AboutActivity extends AppCompatActivity {
 
     private void buildSections(LinearLayout content) {
         content.addView(sectionTitle("Credits"));
-        RoundedLinearLayout credits = Ui.cardGroup(this, dark);
+        LinearLayout credits = Ui.cardGroup(this, dark);
         credits.addView(personRow("BenIt Buhner", "App creator and AI geek", R.drawable.benit_github_avatar, false,
                 "https://github.com/BenItBuhner"));
         credits.addView(personRow("That Josh Guy", "App and Icon designer", R.drawable.codex_profile_avatar, true,
@@ -94,7 +93,7 @@ public final class AboutActivity extends AppCompatActivity {
         content.addView(credits);
 
         content.addView(sectionTitle("Dependencies"));
-        RoundedLinearLayout dependencies = Ui.cardGroup(this, dark);
+        LinearLayout dependencies = Ui.cardGroup(this, dark);
         CardItemView oneUi = Ui.actionRow(this, "One UI Design Library",
                 "The original Android design base, preserved as the default.",
                 R.drawable.ic_oui_theme,
@@ -213,6 +212,9 @@ public final class AboutActivity extends AppCompatActivity {
     }
 
     private TextView sectionTitle(String title) {
+        if (!Ui.isOneUi(this)) {
+            return Ui.sectionTitle(this, title, dark);
+        }
         TextView label = Ui.text(this, title, 14, Ui.secondaryText(dark));
         label.setTypeface(Ui.mediumTypeface(this));
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(-1, -2);

--- a/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
@@ -35,6 +35,12 @@ public final class AboutActivity extends AppCompatActivity {
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
         dark = Ui.isDark(this);
+        if (!Ui.isOneUi(this)) {
+            Ui.Page page = Ui.installPage(this, "About", true);
+            page.content.addView(buildMaterialHero());
+            buildSections(page.content);
+            return;
+        }
         EdgeToEdge.apply(this, () -> new kotlin.Pair<>(dark, dark));
         setContentView(R.layout.activity_about);
         applySystemBarInsets();
@@ -75,6 +81,10 @@ public final class AboutActivity extends AppCompatActivity {
 
     private void build(LinearLayout content) {
         content.addView(buildAppCard());
+        buildSections(content);
+    }
+
+    private void buildSections(LinearLayout content) {
         content.addView(sectionTitle("Credits"));
         RoundedLinearLayout credits = Ui.cardGroup(this, dark);
         credits.addView(personRow("BenIt Buhner", "App creator and AI geek", R.drawable.benit_github_avatar, false,
@@ -85,7 +95,9 @@ public final class AboutActivity extends AppCompatActivity {
 
         content.addView(sectionTitle("Dependencies"));
         RoundedLinearLayout dependencies = Ui.cardGroup(this, dark);
-        CardItemView oneUi = Ui.actionRow(this, "One UI Design Library", "The library that makes this app so pretty.", R.drawable.ic_oui_theme,
+        CardItemView oneUi = Ui.actionRow(this, "One UI Design Library",
+                "The original Android design base, preserved as the default.",
+                R.drawable.ic_oui_theme,
                 view -> openUrl("https://github.com/tribalfs/oneui-design"));
         dependencies.addView(oneUi);
         CardItemView openAi = Ui.actionRow(this, "OpenAI API", "This app would be pretty useless without it.", R.drawable.ic_openai_figma,
@@ -94,6 +106,28 @@ public final class AboutActivity extends AppCompatActivity {
         openAi.setShowTopDivider(true);
         dependencies.addView(openAi);
         content.addView(dependencies);
+    }
+
+    private LinearLayout buildMaterialHero() {
+        LinearLayout hero = Ui.card(this, dark);
+        hero.setGravity(Gravity.CENTER);
+        ImageView icon = new ImageView(this);
+        icon.setImageResource(R.mipmap.ic_launcher);
+        hero.addView(icon, new LinearLayout.LayoutParams(Ui.dp(this, 72), Ui.dp(this, 72)));
+        TextView title = Ui.title(this, "Codex Meter", dark);
+        title.setGravity(Gravity.CENTER);
+        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(-1, -2);
+        titleParams.setMargins(0, Ui.dp(this, 20), 0, 0);
+        hero.addView(title, titleParams);
+        TextView subtitle = Ui.text(this,
+                getString(R.string.about_version, Ui.versionName(this))
+                        + " · Material 3 Expressive",
+                14, Ui.secondaryText(dark));
+        subtitle.setGravity(Gravity.CENTER);
+        LinearLayout.LayoutParams subtitleParams = new LinearLayout.LayoutParams(-1, -2);
+        subtitleParams.setMargins(0, Ui.dp(this, 8), 0, Ui.dp(this, 4));
+        hero.addView(subtitle, subtitleParams);
+        return hero;
     }
 
     private LinearLayout buildAppCard() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppDesignStyle.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppDesignStyle.java
@@ -1,0 +1,18 @@
+package dev.bennett.codexmeter;
+
+/** Stable persisted values for the independently selectable Android design system. */
+public final class AppDesignStyle {
+    public static final String MATERIAL_EXPRESSIVE = WidgetOptions.SURFACE_MATERIAL;
+    public static final String ONE_UI = WidgetOptions.SURFACE_ONE_UI;
+
+    private AppDesignStyle() {
+    }
+
+    public static String normalize(String value) {
+        return MATERIAL_EXPRESSIVE.equals(value) ? MATERIAL_EXPRESSIVE : ONE_UI;
+    }
+
+    public static boolean isMaterialExpressive(String value) {
+        return MATERIAL_EXPRESSIVE.equals(normalize(value));
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -217,11 +217,12 @@ public final class AppPreferences {
     }
 
     public static String getAppStyle(Context context) {
-        return WidgetOptions.SURFACE_ONE_UI;
+        return AppDesignStyle.normalize(prefs(context).getString(
+                KEY_APP_STYLE, AppDesignStyle.ONE_UI));
     }
 
     public static void setAppStyle(Context context, String str) {
-        prefs(context).edit().putString(KEY_APP_STYLE, WidgetOptions.SURFACE_ONE_UI).apply();
+        prefs(context).edit().putString(KEY_APP_STYLE, AppDesignStyle.normalize(str)).commit();
     }
 
     public static WidgetOptions loadDefaultWidgetOptions(Context context) {
@@ -264,6 +265,13 @@ public final class AppPreferences {
     }
 
     private static WidgetOptions batteryStyle(WidgetOptions options) {
+        if (WidgetOptions.SURFACE_MATERIAL.equals(options.surfaceStyle)) {
+            return new WidgetOptions(WidgetOptions.STYLE_RINGS, WidgetOptions.DENSITY_AUTO,
+                    WidgetOptions.SURFACE_MATERIAL, WidgetOptions.GRAPHIC_AUTO, options.theme,
+                    options.accent, options.opacity, WidgetOptions.RESET_HIDDEN,
+                    options.displayMode, WidgetOptions.METRIC_BOTH, false, false, false,
+                    false, false, false).withPercentSymbol(options.showPercentSymbol);
+        }
         return new WidgetOptions(WidgetOptions.STYLE_RINGS, WidgetOptions.DENSITY_AUTO,
                 WidgetOptions.SURFACE_ONE_UI, "auto", options.theme, options.accent,
                 options.opacity, WidgetOptions.RESET_HIDDEN, options.displayMode, "both",

--- a/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
@@ -14,7 +14,6 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
-import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class LockWidgetConfigActivity extends AppCompatActivity {
@@ -57,7 +56,7 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
         page.preview.addView(this.preview, new FrameLayout.LayoutParams(-1, -1));
 
         linearLayout.addView(Ui.separator(this, "Content"));
-        RoundedLinearLayout contentCard = Ui.seslCard(this, this.dark);
+        LinearLayout contentCard = Ui.seslCard(this, this.dark);
         LockWidgetOptions lockWidgetOptionsLoadLockWidgetOptions = AppPreferences.loadLockWidgetOptions(this, this.appWidgetId);
         this.metricSpinner = Ui.spinner(this, WidgetOptionCatalog.METRIC_LABELS, this.dark);
         WidgetOptionCatalog.selectString(this.metricSpinner, WidgetOptionCatalog.METRIC_VALUES, lockWidgetOptionsLoadLockWidgetOptions.metricMode);

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -208,6 +208,10 @@ public final class MainActivity extends AppCompatActivity {
             this.launchSignInRequested = true;
             intent.removeExtra("start_sign_in");
         }
+        if (intent != null && intent.getBooleanExtra("seed_demo_usage", false)) {
+            seedDemoUsage();
+            intent.removeExtra("seed_demo_usage");
+        }
         Uri data = intent == null ? null : intent.getData();
         if (data != null && "codexmeter".equals(data.getScheme()) && "auth".equals(data.getHost())) {
             if (SecureTokenStore.isSignedIn(this)) {
@@ -216,6 +220,29 @@ public final class MainActivity extends AppCompatActivity {
             }
             intent.setData(null);
         }
+    }
+
+    /** Sample allowance numbers so Material widgets/dashboard read as a real M3E surface. */
+    private void seedDemoUsage() {
+        long nowSec = System.currentTimeMillis() / 1000L;
+        UsageWindow fiveHour = new UsageWindow(27, 5L * 3600L, 2L * 3600L + 14L * 60L,
+                nowSec + 2L * 3600L + 14L * 60L);
+        UsageWindow weekly = new UsageWindow(56, 7L * 24L * 3600L, 4L * 24L * 3600L,
+                nowSec + 4L * 24L * 3600L);
+        AppPreferences.saveSnapshot(this, new UsageSnapshot("plus", true, false, fiveHour, weekly,
+                2, System.currentTimeMillis()));
+        WidgetOptions material = new WidgetOptions(WidgetOptions.STYLE_RINGS,
+                WidgetOptions.DENSITY_COMFORTABLE, WidgetOptions.SURFACE_MATERIAL,
+                WidgetOptions.GRAPHIC_LARGE, WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_APP,
+                100, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING, "both",
+                false, false, false, false, false, false);
+        AppPreferences.saveDefaultWidgetOptions(this, material);
+        int[] ids = AppWidgetManager.getInstance(this)
+                .getAppWidgetIds(new ComponentName(this, CodexUsageWidget.class));
+        for (int id : ids) {
+            AppPreferences.saveWidgetOptions(this, id, material);
+        }
+        WidgetRenderer.updateAll(this);
     }
 
     private boolean routeToOnboarding(Intent intent) {
@@ -264,9 +291,6 @@ public final class MainActivity extends AppCompatActivity {
                 this.content.addView(buildUpdateCard(update));
                 Ui.addSpacer(this.content, sectionGap);
             }
-            if (material) {
-                addMaterialHero();
-            }
             this.content.addView(buildUsageDashboard());
             Ui.addSpacer(this.content, sectionGap);
             if (!SecureTokenStore.isSignedIn(this)) {
@@ -278,28 +302,11 @@ public final class MainActivity extends AppCompatActivity {
                 Ui.addSpacer(this.content, sectionGap);
             }
             this.content.addView(buildResetCreditsCard());
+            if (material) {
+                Ui.addSpacer(this.content, sectionGap);
+                this.content.addView(buildMaterialWidgetShowcase());
+            }
         }
-    }
-
-    private void addMaterialHero() {
-        boolean signedIn = SecureTokenStore.isSignedIn(this);
-        TextView eyebrow = Ui.text(this, signedIn ? "ALLOWANCE" : "GET STARTED", 12.0f,
-                Ui.accent(this, this.dark));
-        eyebrow.setTypeface(Ui.emphasizedTypeface(this));
-        eyebrow.setLetterSpacing(0.08f);
-        LinearLayout.LayoutParams eyeParams = new LinearLayout.LayoutParams(-1, -2);
-        eyeParams.setMargins(Ui.dp(this, 8), Ui.dp(this, 4), 0, Ui.dp(this, 6));
-        this.content.addView(eyebrow, eyeParams);
-
-        TextView headline = Ui.text(this,
-                signedIn ? "What's left" : "Your Codex\nat a glance",
-                34.0f, Ui.mainText(this, this.dark));
-        headline.setTypeface(Ui.emphasizedTypeface(this));
-        headline.setLetterSpacing(-0.03f);
-        headline.setLineSpacing(0f, 0.95f);
-        LinearLayout.LayoutParams headParams = new LinearLayout.LayoutParams(-1, -2);
-        headParams.setMargins(Ui.dp(this, 4), 0, Ui.dp(this, 4), Ui.dp(this, 18));
-        this.content.addView(headline, headParams);
     }
 
     private LinearLayout buildUpdateCard(GitHubRelease release) {
@@ -335,12 +342,14 @@ public final class MainActivity extends AppCompatActivity {
         LinearLayout column = new LinearLayout(this);
         column.setOrientation(LinearLayout.VERTICAL);
         if (!Ui.isOneUi(this)) {
-            column.addView(buildMaterialMetricCard("5 hour",
-                    signedIn && snapshot != null ? snapshot.fiveHour : null, signedIn, 0));
+            // Cached snapshot stays visible offline / for Material demos without a live session.
+            UsageWindow fiveHour = snapshot != null ? snapshot.fiveHour : null;
+            UsageWindow weekly = snapshot != null ? snapshot.weekly : null;
+            column.addView(buildMaterialMetricCard("5 hour", fiveHour,
+                    signedIn || fiveHour != null, 0));
             Ui.addSpacer(column, 14);
-            // Secondary container + asymmetric corners so the pair is not twin lavender blobs.
-            column.addView(buildMaterialMetricCard("Weekly",
-                    signedIn && snapshot != null ? snapshot.weekly : null, signedIn, 1));
+            column.addView(buildMaterialMetricCard("Weekly", weekly,
+                    signedIn || weekly != null, 1));
             return column;
         }
         column.addView(buildMetricCard("5 hour", signedIn && snapshot != null ? snapshot.fiveHour : null, signedIn, false));
@@ -569,6 +578,7 @@ public final class MainActivity extends AppCompatActivity {
         LinearLayout card = Ui.expressiveCard(this, this.dark,
                 Ui.tertiaryContainer(this, this.dark), 2);
         int on = Ui.onTertiaryContainer(this, this.dark);
+        boolean showCount = signedIn || available > 0;
 
         TextView label = Ui.text(this, "RESET CREDITS", 12.0f, on);
         label.setTypeface(Ui.emphasizedTypeface(this));
@@ -576,12 +586,12 @@ public final class MainActivity extends AppCompatActivity {
         card.addView(label);
 
         LinearLayout row = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
-        TextView count = Ui.text(this, signedIn ? String.valueOf(available) : "—", 52.0f, on);
+        TextView count = Ui.text(this, showCount ? String.valueOf(available) : "—", 52.0f, on);
         count.setTypeface(Ui.emphasizedTypeface(this));
         count.setLetterSpacing(-0.04f);
         row.addView(count);
         TextView detail = Ui.text(this,
-                signedIn ? (available == 1 ? "reset\nready" : "resets\nready")
+                showCount ? (available == 1 ? "reset\nready" : "resets\nready")
                         : "Sign in to\nsee credits",
                 18.0f, on);
         detail.setTypeface(Ui.mediumTypeface(this));
@@ -600,6 +610,154 @@ public final class MainActivity extends AppCompatActivity {
                 startActivity(new Intent(this, ResetCreditActivity.class)));
         card.addView(button, new LinearLayout.LayoutParams(-1, Ui.dp(this, 64)));
         return card;
+    }
+
+    /** Live Material compact + dials widget surfaces, using the real RemoteViews layouts. */
+    private LinearLayout buildMaterialWidgetShowcase() {
+        LinearLayout section = new LinearLayout(this);
+        section.setOrientation(LinearLayout.VERTICAL);
+
+        TextView heading = Ui.text(this, "Material widgets", 22.0f, Ui.mainText(this, this.dark));
+        heading.setTypeface(Ui.emphasizedTypeface(this));
+        heading.setLetterSpacing(-0.02f);
+        section.addView(heading);
+        TextView blurb = Ui.text(this,
+                "Compact bars and dual dials — both Material 3 Expressive, both home-screen ready.",
+                14.0f, Ui.secondaryText(this, this.dark));
+        LinearLayout.LayoutParams blurbParams = new LinearLayout.LayoutParams(-1, -2);
+        blurbParams.setMargins(0, Ui.dp(this, 6), 0, Ui.dp(this, 14));
+        section.addView(blurb, blurbParams);
+
+        section.addView(materialWidgetLabel("COMPACT"));
+        section.addView(materialWidgetHost(WidgetOptions.STYLE_MINIMAL, 250, 72),
+                new LinearLayout.LayoutParams(-1, Ui.dp(this, 88)));
+        Ui.addSpacer(section, 14);
+        section.addView(materialWidgetLabel("DIALS"));
+        section.addView(materialWidgetHost(WidgetOptions.STYLE_DIALS, 250, 156),
+                new LinearLayout.LayoutParams(-1, Ui.dp(this, 168)));
+        Ui.addSpacer(section, 16);
+
+        Button add = Ui.nativePrimaryButton(this, "Add widget to home");
+        add.setOnClickListener(view -> requestPinWidget());
+        section.addView(add, new LinearLayout.LayoutParams(-1, Ui.dp(this, 64)));
+        return section;
+    }
+
+    private TextView materialWidgetLabel(String label) {
+        TextView text = Ui.text(this, label, 12.0f, Ui.accent(this, this.dark));
+        text.setTypeface(Ui.emphasizedTypeface(this));
+        text.setLetterSpacing(0.08f);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(-1, -2);
+        params.setMargins(Ui.dp(this, 4), 0, 0, Ui.dp(this, 8));
+        text.setLayoutParams(params);
+        return text;
+    }
+
+    private FrameLayout materialWidgetHost(String style, int widthDp, int heightDp) {
+        FrameLayout host = new FrameLayout(this);
+        host.setBackground(Ui.expressiveShape(Ui.materialSurface(this, this.dark),
+                Ui.expressiveRadii(this, style.equals(WidgetOptions.STYLE_DIALS) ? 1 : 0)));
+        host.setClipToOutline(true);
+        // Inflate the real Material widget layouts (not RemoteViews.apply — AppCompat
+        // ImageViews reject setImageResource from RemoteViews inside activities).
+        int layout = WidgetOptions.STYLE_DIALS.equals(style)
+                ? R.layout.widget_material_dials : R.layout.widget_material_compact;
+        View widget = getLayoutInflater().inflate(layout, host, false);
+        bindMaterialWidgetShowcase(widget, style);
+        host.addView(widget, new FrameLayout.LayoutParams(-1, -1));
+        return host;
+    }
+
+    private void bindMaterialWidgetShowcase(View root, String style) {
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
+        int five = snapshot != null && snapshot.fiveHour != null
+                ? snapshot.fiveHour.remainingPercent() : 73;
+        int week = snapshot != null && snapshot.weekly != null
+                ? snapshot.weekly.remainingPercent() : 44;
+        boolean dark = this.dark;
+        int onSurface = Ui.materialOnSurface(this, dark);
+        int accent = Ui.materialAccent(this, dark);
+        if (WidgetOptions.STYLE_DIALS.equals(style)) {
+            ImageView primary = root.findViewById(R.id.primary_graphic);
+            ImageView secondary = root.findViewById(R.id.secondary_graphic);
+            if (primary != null) {
+                primary.setImageBitmap(WidgetGraphics.expressiveDial(five, accent,
+                        Color.argb(dark ? 74 : 48, Color.red(onSurface), Color.green(onSurface),
+                                Color.blue(onSurface)),
+                        onSurface, "left", 1.1f));
+            }
+            if (secondary != null) {
+                secondary.setImageBitmap(WidgetGraphics.expressiveDial(week, accent,
+                        Color.argb(dark ? 74 : 48, Color.red(onSurface), Color.green(onSurface),
+                                Color.blue(onSurface)),
+                        onSurface, "left", 1.1f));
+            }
+            TextView primaryLabel = root.findViewById(R.id.primary_label);
+            TextView secondaryLabel = root.findViewById(R.id.secondary_label);
+            if (primaryLabel != null) {
+                primaryLabel.setVisibility(View.VISIBLE);
+                primaryLabel.setText("5H");
+                primaryLabel.setTextColor(Ui.onPrimaryContainer(this, dark));
+                primaryLabel.getBackground().setTint(Ui.primaryContainer(this, dark));
+            }
+            if (secondaryLabel != null) {
+                secondaryLabel.setVisibility(View.VISIBLE);
+                secondaryLabel.setText("WK");
+                secondaryLabel.setTextColor(Ui.onSecondaryContainer(this, dark));
+                secondaryLabel.getBackground().setTint(Ui.secondaryContainer(this, dark));
+            }
+            return;
+        }
+        TextView primaryLabel = root.findViewById(R.id.primary_label);
+        TextView secondaryLabel = root.findViewById(R.id.secondary_label);
+        TextView primaryPercent = root.findViewById(R.id.primary_percent);
+        TextView secondaryPercent = root.findViewById(R.id.secondary_percent);
+        ImageView primaryProgress = root.findViewById(R.id.primary_progress);
+        ImageView secondaryProgress = root.findViewById(R.id.secondary_progress);
+        ImageView primaryTrack = root.findViewById(R.id.primary_track);
+        ImageView secondaryTrack = root.findViewById(R.id.secondary_track);
+        if (primaryLabel != null) {
+            primaryLabel.setText("5H");
+            primaryLabel.setTextColor(Ui.onPrimaryContainer(this, dark));
+            if (primaryLabel.getBackground() != null) {
+                primaryLabel.getBackground().mutate().setTint(Ui.primaryContainer(this, dark));
+            }
+        }
+        if (secondaryLabel != null) {
+            secondaryLabel.setText("WK");
+            secondaryLabel.setTextColor(Ui.onSecondaryContainer(this, dark));
+            if (secondaryLabel.getBackground() != null) {
+                secondaryLabel.getBackground().mutate().setTint(Ui.secondaryContainer(this, dark));
+            }
+        }
+        if (primaryPercent != null) {
+            primaryPercent.setText(five + "%");
+            primaryPercent.setTextColor(onSurface);
+            primaryPercent.setTypeface(Ui.emphasizedTypeface(this));
+        }
+        if (secondaryPercent != null) {
+            secondaryPercent.setText(week + "%");
+            secondaryPercent.setTextColor(onSurface);
+            secondaryPercent.setTypeface(Ui.emphasizedTypeface(this));
+        }
+        if (primaryTrack != null) {
+            primaryTrack.setImageResource(dark
+                    ? R.drawable.progress_track_material_dark : R.drawable.progress_track_material);
+        }
+        if (secondaryTrack != null) {
+            secondaryTrack.setImageResource(dark
+                    ? R.drawable.progress_track_material_dark : R.drawable.progress_track_material);
+        }
+        if (primaryProgress != null) {
+            primaryProgress.setImageResource(R.drawable.progress_mint);
+            primaryProgress.setColorFilter(accent);
+            primaryProgress.setImageLevel(Math.max(0, five) * 100);
+        }
+        if (secondaryProgress != null) {
+            secondaryProgress.setImageResource(R.drawable.progress_mint);
+            secondaryProgress.setColorFilter(accent);
+            secondaryProgress.setImageLevel(Math.max(0, week) * 100);
+        }
     }
 
     private LinearLayout buildWidgetCard() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -41,6 +41,7 @@ public final class MainActivity extends AppCompatActivity {
     private SwipeRefreshLayout swipeRefresh;
     private boolean dark;
     private boolean receiverRegistered;
+    private boolean demoUsageVisible;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private String lastLaunchedAuthUrl = "";
     private boolean launchSignInRequested;
@@ -208,6 +209,7 @@ public final class MainActivity extends AppCompatActivity {
             intent.removeExtra("start_sign_in");
         }
         if (intent != null && intent.getBooleanExtra("seed_demo_usage", false)) {
+            this.demoUsageVisible = true;
             seedDemoUsage(intent.getStringExtra("widget_surface"));
             intent.removeExtra("seed_demo_usage");
             intent.removeExtra("widget_surface");
@@ -346,6 +348,7 @@ public final class MainActivity extends AppCompatActivity {
     private LinearLayout buildUsageDashboard() {
         UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
         boolean signedIn = SecureTokenStore.isSignedIn(this);
+        boolean canShowUsage = signedIn || this.demoUsageVisible;
         LinearLayout column = new LinearLayout(this);
         column.setOrientation(LinearLayout.VERTICAL);
         if (!Ui.isOneUi(this)) {
@@ -359,9 +362,11 @@ public final class MainActivity extends AppCompatActivity {
                     signedIn || weekly != null, 1));
             return column;
         }
-        column.addView(buildMetricCard("5 hour", signedIn && snapshot != null ? snapshot.fiveHour : null, signedIn, false));
+        column.addView(buildMetricCard("5 hour",
+                canShowUsage && snapshot != null ? snapshot.fiveHour : null, canShowUsage, false));
         Ui.addSpacer(column, 20);
-        column.addView(buildMetricCard("Weekly", signedIn && snapshot != null ? snapshot.weekly : null, signedIn, true));
+        column.addView(buildMetricCard("Weekly",
+                canShowUsage && snapshot != null ? snapshot.weekly : null, canShowUsage, true));
         return column;
     }
 
@@ -550,6 +555,7 @@ public final class MainActivity extends AppCompatActivity {
 
     private LinearLayout buildResetCreditsCard() {
         boolean zIsSignedIn = SecureTokenStore.isSignedIn(this);
+        boolean showDemoData = zIsSignedIn || this.demoUsageVisible;
         ResetCreditsSnapshot resetCreditsSnapshotLoadResetCredits = AppPreferences.loadResetCredits(this);
         int i = resetCreditsSnapshotLoadResetCredits == null ? 0 : resetCreditsSnapshotLoadResetCredits.availableCount;
         if (!Ui.isOneUi(this)) {
@@ -559,10 +565,12 @@ public final class MainActivity extends AppCompatActivity {
         linearLayoutCard.setPadding(Ui.dp(this, 10.0f), Ui.dp(this, 10.0f), Ui.dp(this, 10.0f), Ui.dp(this, 10.0f));
 
         LinearLayout countRow = Ui.horizontal(this, Gravity.CENTER);
-        TextView count = Ui.text(this, zIsSignedIn ? String.valueOf(i) : "—", 30.0f, Ui.mainText(this.dark));
+        TextView count = Ui.text(this, showDemoData ? String.valueOf(i) : "—", 30.0f,
+                Ui.mainText(this.dark));
         count.setTypeface(Ui.mediumTypeface(this));
         countRow.addView(count);
-        TextView label = Ui.text(this, zIsSignedIn ? "Resets available" : "Sign in to view resets", 18.0f, Ui.mainText(this.dark));
+        TextView label = Ui.text(this, showDemoData
+                ? "Resets available" : "Sign in to view resets", 18.0f, Ui.mainText(this.dark));
         label.setTypeface(Ui.mediumTypeface(this));
         LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(-2, -2);
         labelParams.setMargins(Ui.dp(this, 18.0f), 0, 0, 0);

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -21,7 +21,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
-import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -209,8 +208,9 @@ public final class MainActivity extends AppCompatActivity {
             intent.removeExtra("start_sign_in");
         }
         if (intent != null && intent.getBooleanExtra("seed_demo_usage", false)) {
-            seedDemoUsage();
+            seedDemoUsage(intent.getStringExtra("widget_surface"));
             intent.removeExtra("seed_demo_usage");
+            intent.removeExtra("widget_surface");
         }
         Uri data = intent == null ? null : intent.getData();
         if (data != null && "codexmeter".equals(data.getScheme()) && "auth".equals(data.getHost())) {
@@ -222,8 +222,11 @@ public final class MainActivity extends AppCompatActivity {
         }
     }
 
-    /** Sample allowance numbers so Material widgets/dashboard read as a real M3E surface. */
-    private void seedDemoUsage() {
+    /**
+     * Sample allowance numbers for demos. Optional {@code widgetSurface} is
+     * {@link WidgetOptions#SURFACE_ONE_UI} or {@link WidgetOptions#SURFACE_MATERIAL}.
+     */
+    private void seedDemoUsage(String widgetSurface) {
         long nowSec = System.currentTimeMillis() / 1000L;
         UsageWindow fiveHour = new UsageWindow(27, 5L * 3600L, 2L * 3600L + 14L * 60L,
                 nowSec + 2L * 3600L + 14L * 60L);
@@ -231,16 +234,20 @@ public final class MainActivity extends AppCompatActivity {
                 nowSec + 4L * 24L * 3600L);
         AppPreferences.saveSnapshot(this, new UsageSnapshot("plus", true, false, fiveHour, weekly,
                 2, System.currentTimeMillis()));
-        WidgetOptions material = new WidgetOptions(WidgetOptions.STYLE_RINGS,
-                WidgetOptions.DENSITY_COMFORTABLE, WidgetOptions.SURFACE_MATERIAL,
-                WidgetOptions.GRAPHIC_LARGE, WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_APP,
-                100, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING, "both",
+        String surface = WidgetOptions.SURFACE_MATERIAL.equals(widgetSurface)
+                ? WidgetOptions.SURFACE_MATERIAL : WidgetOptions.SURFACE_ONE_UI;
+        String accent = WidgetOptions.SURFACE_MATERIAL.equals(surface)
+                ? WidgetOptions.ACCENT_APP : WidgetOptions.ACCENT_BLUE;
+        WidgetOptions options = new WidgetOptions(WidgetOptions.STYLE_RINGS,
+                WidgetOptions.DENSITY_COMFORTABLE, surface,
+                WidgetOptions.GRAPHIC_LARGE, WidgetOptions.THEME_SYSTEM, accent,
+                88, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING, "both",
                 false, false, false, false, false, false);
-        AppPreferences.saveDefaultWidgetOptions(this, material);
+        AppPreferences.saveDefaultWidgetOptions(this, options);
         int[] ids = AppWidgetManager.getInstance(this)
                 .getAppWidgetIds(new ComponentName(this, CodexUsageWidget.class));
         for (int id : ids) {
-            AppPreferences.saveWidgetOptions(this, id, material);
+            AppPreferences.saveWidgetOptions(this, id, options);
         }
         WidgetRenderer.updateAll(this);
     }
@@ -302,10 +309,6 @@ public final class MainActivity extends AppCompatActivity {
                 Ui.addSpacer(this.content, sectionGap);
             }
             this.content.addView(buildResetCreditsCard());
-            if (material) {
-                Ui.addSpacer(this.content, sectionGap);
-                this.content.addView(buildMaterialWidgetShowcase());
-            }
         }
     }
 
@@ -610,154 +613,6 @@ public final class MainActivity extends AppCompatActivity {
                 startActivity(new Intent(this, ResetCreditActivity.class)));
         card.addView(button, new LinearLayout.LayoutParams(-1, Ui.dp(this, 64)));
         return card;
-    }
-
-    /** Live Material compact + dials widget surfaces, using the real RemoteViews layouts. */
-    private LinearLayout buildMaterialWidgetShowcase() {
-        LinearLayout section = new LinearLayout(this);
-        section.setOrientation(LinearLayout.VERTICAL);
-
-        TextView heading = Ui.text(this, "Material widgets", 22.0f, Ui.mainText(this, this.dark));
-        heading.setTypeface(Ui.emphasizedTypeface(this));
-        heading.setLetterSpacing(-0.02f);
-        section.addView(heading);
-        TextView blurb = Ui.text(this,
-                "Compact bars and dual dials — both Material 3 Expressive, both home-screen ready.",
-                14.0f, Ui.secondaryText(this, this.dark));
-        LinearLayout.LayoutParams blurbParams = new LinearLayout.LayoutParams(-1, -2);
-        blurbParams.setMargins(0, Ui.dp(this, 6), 0, Ui.dp(this, 14));
-        section.addView(blurb, blurbParams);
-
-        section.addView(materialWidgetLabel("COMPACT"));
-        section.addView(materialWidgetHost(WidgetOptions.STYLE_MINIMAL, 250, 72),
-                new LinearLayout.LayoutParams(-1, Ui.dp(this, 88)));
-        Ui.addSpacer(section, 14);
-        section.addView(materialWidgetLabel("DIALS"));
-        section.addView(materialWidgetHost(WidgetOptions.STYLE_DIALS, 250, 156),
-                new LinearLayout.LayoutParams(-1, Ui.dp(this, 168)));
-        Ui.addSpacer(section, 16);
-
-        Button add = Ui.nativePrimaryButton(this, "Add widget to home");
-        add.setOnClickListener(view -> requestPinWidget());
-        section.addView(add, new LinearLayout.LayoutParams(-1, Ui.dp(this, 64)));
-        return section;
-    }
-
-    private TextView materialWidgetLabel(String label) {
-        TextView text = Ui.text(this, label, 12.0f, Ui.accent(this, this.dark));
-        text.setTypeface(Ui.emphasizedTypeface(this));
-        text.setLetterSpacing(0.08f);
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(-1, -2);
-        params.setMargins(Ui.dp(this, 4), 0, 0, Ui.dp(this, 8));
-        text.setLayoutParams(params);
-        return text;
-    }
-
-    private FrameLayout materialWidgetHost(String style, int widthDp, int heightDp) {
-        FrameLayout host = new FrameLayout(this);
-        host.setBackground(Ui.expressiveShape(Ui.materialSurface(this, this.dark),
-                Ui.expressiveRadii(this, style.equals(WidgetOptions.STYLE_DIALS) ? 1 : 0)));
-        host.setClipToOutline(true);
-        // Inflate the real Material widget layouts (not RemoteViews.apply — AppCompat
-        // ImageViews reject setImageResource from RemoteViews inside activities).
-        int layout = WidgetOptions.STYLE_DIALS.equals(style)
-                ? R.layout.widget_material_dials : R.layout.widget_material_compact;
-        View widget = getLayoutInflater().inflate(layout, host, false);
-        bindMaterialWidgetShowcase(widget, style);
-        host.addView(widget, new FrameLayout.LayoutParams(-1, -1));
-        return host;
-    }
-
-    private void bindMaterialWidgetShowcase(View root, String style) {
-        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
-        int five = snapshot != null && snapshot.fiveHour != null
-                ? snapshot.fiveHour.remainingPercent() : 73;
-        int week = snapshot != null && snapshot.weekly != null
-                ? snapshot.weekly.remainingPercent() : 44;
-        boolean dark = this.dark;
-        int onSurface = Ui.materialOnSurface(this, dark);
-        int accent = Ui.materialAccent(this, dark);
-        if (WidgetOptions.STYLE_DIALS.equals(style)) {
-            ImageView primary = root.findViewById(R.id.primary_graphic);
-            ImageView secondary = root.findViewById(R.id.secondary_graphic);
-            if (primary != null) {
-                primary.setImageBitmap(WidgetGraphics.expressiveDial(five, accent,
-                        Color.argb(dark ? 74 : 48, Color.red(onSurface), Color.green(onSurface),
-                                Color.blue(onSurface)),
-                        onSurface, "left", 1.1f));
-            }
-            if (secondary != null) {
-                secondary.setImageBitmap(WidgetGraphics.expressiveDial(week, accent,
-                        Color.argb(dark ? 74 : 48, Color.red(onSurface), Color.green(onSurface),
-                                Color.blue(onSurface)),
-                        onSurface, "left", 1.1f));
-            }
-            TextView primaryLabel = root.findViewById(R.id.primary_label);
-            TextView secondaryLabel = root.findViewById(R.id.secondary_label);
-            if (primaryLabel != null) {
-                primaryLabel.setVisibility(View.VISIBLE);
-                primaryLabel.setText("5H");
-                primaryLabel.setTextColor(Ui.onPrimaryContainer(this, dark));
-                primaryLabel.getBackground().setTint(Ui.primaryContainer(this, dark));
-            }
-            if (secondaryLabel != null) {
-                secondaryLabel.setVisibility(View.VISIBLE);
-                secondaryLabel.setText("WK");
-                secondaryLabel.setTextColor(Ui.onSecondaryContainer(this, dark));
-                secondaryLabel.getBackground().setTint(Ui.secondaryContainer(this, dark));
-            }
-            return;
-        }
-        TextView primaryLabel = root.findViewById(R.id.primary_label);
-        TextView secondaryLabel = root.findViewById(R.id.secondary_label);
-        TextView primaryPercent = root.findViewById(R.id.primary_percent);
-        TextView secondaryPercent = root.findViewById(R.id.secondary_percent);
-        ImageView primaryProgress = root.findViewById(R.id.primary_progress);
-        ImageView secondaryProgress = root.findViewById(R.id.secondary_progress);
-        ImageView primaryTrack = root.findViewById(R.id.primary_track);
-        ImageView secondaryTrack = root.findViewById(R.id.secondary_track);
-        if (primaryLabel != null) {
-            primaryLabel.setText("5H");
-            primaryLabel.setTextColor(Ui.onPrimaryContainer(this, dark));
-            if (primaryLabel.getBackground() != null) {
-                primaryLabel.getBackground().mutate().setTint(Ui.primaryContainer(this, dark));
-            }
-        }
-        if (secondaryLabel != null) {
-            secondaryLabel.setText("WK");
-            secondaryLabel.setTextColor(Ui.onSecondaryContainer(this, dark));
-            if (secondaryLabel.getBackground() != null) {
-                secondaryLabel.getBackground().mutate().setTint(Ui.secondaryContainer(this, dark));
-            }
-        }
-        if (primaryPercent != null) {
-            primaryPercent.setText(five + "%");
-            primaryPercent.setTextColor(onSurface);
-            primaryPercent.setTypeface(Ui.emphasizedTypeface(this));
-        }
-        if (secondaryPercent != null) {
-            secondaryPercent.setText(week + "%");
-            secondaryPercent.setTextColor(onSurface);
-            secondaryPercent.setTypeface(Ui.emphasizedTypeface(this));
-        }
-        if (primaryTrack != null) {
-            primaryTrack.setImageResource(dark
-                    ? R.drawable.progress_track_material_dark : R.drawable.progress_track_material);
-        }
-        if (secondaryTrack != null) {
-            secondaryTrack.setImageResource(dark
-                    ? R.drawable.progress_track_material_dark : R.drawable.progress_track_material);
-        }
-        if (primaryProgress != null) {
-            primaryProgress.setImageResource(R.drawable.progress_mint);
-            primaryProgress.setColorFilter(accent);
-            primaryProgress.setImageLevel(Math.max(0, five) * 100);
-        }
-        if (secondaryProgress != null) {
-            secondaryProgress.setImageResource(R.drawable.progress_mint);
-            secondaryProgress.setColorFilter(accent);
-            secondaryProgress.setImageLevel(Math.max(0, week) * 100);
-        }
     }
 
     private LinearLayout buildWidgetCard() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -9,6 +9,10 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.graphics.Color;
+import android.graphics.drawable.ClipDrawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.LayerDrawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -250,22 +254,49 @@ public final class MainActivity extends AppCompatActivity {
     public void rebuild() {
         if (this.content != null) {
             this.content.removeAllViews();
+            boolean material = !Ui.isOneUi(this);
+            int sectionGap = material ? 16 : 20;
             GitHubRelease update = UpdatePreferences.availableUpdate(this);
             if (update != null) {
                 this.content.addView(buildUpdateCard(update));
-                Ui.addSpacer(this.content, 20);
+                Ui.addSpacer(this.content, sectionGap);
+            }
+            if (material) {
+                addMaterialHero();
             }
             this.content.addView(buildUsageDashboard());
-            Ui.addSpacer(this.content, 20);
+            Ui.addSpacer(this.content, sectionGap);
             if (!SecureTokenStore.isSignedIn(this)) {
                 Button signIn = Ui.nativePrimaryButton(this,
                         AppPreferences.isOAuthPending(this) ? "Continue sign-in" : "Sign in with ChatGPT");
                 signIn.setOnClickListener(view -> startOrContinueSignIn());
-                this.content.addView(signIn, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
-                Ui.addSpacer(this.content, 20);
+                this.content.addView(signIn, new LinearLayout.LayoutParams(-1,
+                        Ui.dp(this, material ? 64 : 60)));
+                Ui.addSpacer(this.content, sectionGap);
             }
             this.content.addView(buildResetCreditsCard());
         }
+    }
+
+    private void addMaterialHero() {
+        boolean signedIn = SecureTokenStore.isSignedIn(this);
+        TextView eyebrow = Ui.text(this, signedIn ? "ALLOWANCE" : "GET STARTED", 12.0f,
+                Ui.accent(this, this.dark));
+        eyebrow.setTypeface(Ui.emphasizedTypeface(this));
+        eyebrow.setLetterSpacing(0.08f);
+        LinearLayout.LayoutParams eyeParams = new LinearLayout.LayoutParams(-1, -2);
+        eyeParams.setMargins(Ui.dp(this, 8), Ui.dp(this, 4), 0, Ui.dp(this, 6));
+        this.content.addView(eyebrow, eyeParams);
+
+        TextView headline = Ui.text(this,
+                signedIn ? "What's left" : "Your Codex\nat a glance",
+                34.0f, Ui.mainText(this, this.dark));
+        headline.setTypeface(Ui.emphasizedTypeface(this));
+        headline.setLetterSpacing(-0.03f);
+        headline.setLineSpacing(0f, 0.95f);
+        LinearLayout.LayoutParams headParams = new LinearLayout.LayoutParams(-1, -2);
+        headParams.setMargins(Ui.dp(this, 4), 0, Ui.dp(this, 4), Ui.dp(this, 18));
+        this.content.addView(headline, headParams);
     }
 
     private LinearLayout buildUpdateCard(GitHubRelease release) {
@@ -300,6 +331,14 @@ public final class MainActivity extends AppCompatActivity {
         boolean signedIn = SecureTokenStore.isSignedIn(this);
         LinearLayout column = new LinearLayout(this);
         column.setOrientation(LinearLayout.VERTICAL);
+        if (!Ui.isOneUi(this)) {
+            column.addView(buildMaterialMetricCard("5 hour",
+                    signedIn && snapshot != null ? snapshot.fiveHour : null, signedIn, 0));
+            Ui.addSpacer(column, 14);
+            column.addView(buildMaterialMetricCard("Weekly",
+                    signedIn && snapshot != null ? snapshot.weekly : null, signedIn, 1));
+            return column;
+        }
         column.addView(buildMetricCard("5 hour", signedIn && snapshot != null ? snapshot.fiveHour : null, signedIn, false));
         Ui.addSpacer(column, 20);
         column.addView(buildMetricCard("Weekly", signedIn && snapshot != null ? snapshot.weekly : null, signedIn, true));
@@ -318,6 +357,72 @@ public final class MainActivity extends AppCompatActivity {
                 "Weekly".equals(label) ? R.drawable.ic_oui_calendar_week : R.drawable.ic_oui_time,
                 invertedWave);
         card.addView(wave, new LinearLayout.LayoutParams(-1, Ui.dp(this, 103.0f)));
+        return card;
+    }
+
+    /**
+     * Material 3 Expressive metric card — primary/secondary containers, display % type,
+     * fat progress, asymmetric corners. Intentionally not the One UI wave treatment.
+     */
+    private LinearLayout buildMaterialMetricCard(String label, UsageWindow window, boolean signedIn,
+            int tone) {
+        int fill = tone == 0
+                ? Ui.primaryContainer(this, this.dark)
+                : Ui.secondaryContainer(this, this.dark);
+        int onFill = tone == 0
+                ? Ui.onPrimaryContainer(this, this.dark)
+                : Ui.onSecondaryContainer(this, this.dark);
+        int mutedOn = Color.argb(178, Color.red(onFill), Color.green(onFill), Color.blue(onFill));
+        LinearLayout card = Ui.expressiveCard(this, this.dark, fill, tone);
+        card.setMinimumHeight(Ui.dp(this, 168.0f));
+
+        LinearLayout header = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
+        TextView title = Ui.text(this, label, 16.0f, onFill);
+        title.setTypeface(Ui.emphasizedTypeface(this));
+        title.setLetterSpacing(0.01f);
+        header.addView(title, new LinearLayout.LayoutParams(0, -2, 1.0f));
+        ImageView icon = new ImageView(this);
+        icon.setImageResource("Weekly".equals(label)
+                ? R.drawable.ic_oui_calendar_week : R.drawable.ic_oui_time);
+        icon.setColorFilter(onFill);
+        header.addView(icon, new LinearLayout.LayoutParams(Ui.dp(this, 28), Ui.dp(this, 28)));
+        card.addView(header);
+
+        int percent = window == null ? 0 : window.remainingPercent();
+        TextView giant = Ui.text(this, percent + "%", 56.0f, onFill);
+        giant.setTypeface(Ui.emphasizedTypeface(this));
+        giant.setLetterSpacing(-0.04f);
+        giant.setIncludeFontPadding(false);
+        LinearLayout.LayoutParams giantParams = new LinearLayout.LayoutParams(-1, -2);
+        giantParams.setMargins(0, Ui.dp(this, 10), 0, Ui.dp(this, 14));
+        card.addView(giant, giantParams);
+
+        ProgressBar bar = Ui.progress(this, this.dark);
+        int pill = Ui.dp(this, 999);
+        GradientDrawable track = new GradientDrawable();
+        track.setColor(Color.argb(this.dark ? 60 : 40, Color.red(onFill), Color.green(onFill),
+                Color.blue(onFill)));
+        track.setCornerRadius(pill);
+        GradientDrawable fillBar = new GradientDrawable();
+        fillBar.setColor(Ui.accent(this, this.dark));
+        fillBar.setCornerRadius(pill);
+        ClipDrawable clip = new ClipDrawable(fillBar, Gravity.START, ClipDrawable.HORIZONTAL);
+        LayerDrawable layer = new LayerDrawable(new android.graphics.drawable.Drawable[]{track, clip});
+        layer.setId(0, android.R.id.background);
+        layer.setId(1, android.R.id.progress);
+        bar.setProgressDrawable(layer);
+        bar.setProgress(percent);
+        card.addView(bar);
+
+        String reset = window == null
+                ? (signedIn ? "Waiting for live usage" : "Sign in to load remaining allowance")
+                : UsageFormat.reset(this, window, WidgetOptions.RESET_RELATIVE,
+                        System.currentTimeMillis());
+        TextView resetView = Ui.text(this, reset, 14.0f, mutedOn);
+        resetView.setTypeface(Ui.mediumTypeface(this));
+        LinearLayout.LayoutParams resetParams = new LinearLayout.LayoutParams(-1, -2);
+        resetParams.setMargins(0, Ui.dp(this, 12), 0, 0);
+        card.addView(resetView, resetParams);
         return card;
     }
 
@@ -418,11 +523,14 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     private LinearLayout buildResetCreditsCard() {
-        LinearLayout linearLayoutCard = Ui.card(this, this.dark);
-        linearLayoutCard.setPadding(Ui.dp(this, 10.0f), Ui.dp(this, 10.0f), Ui.dp(this, 10.0f), Ui.dp(this, 10.0f));
         boolean zIsSignedIn = SecureTokenStore.isSignedIn(this);
         ResetCreditsSnapshot resetCreditsSnapshotLoadResetCredits = AppPreferences.loadResetCredits(this);
         int i = resetCreditsSnapshotLoadResetCredits == null ? 0 : resetCreditsSnapshotLoadResetCredits.availableCount;
+        if (!Ui.isOneUi(this)) {
+            return buildMaterialResetCreditsCard(zIsSignedIn, i);
+        }
+        LinearLayout linearLayoutCard = Ui.card(this, this.dark);
+        linearLayoutCard.setPadding(Ui.dp(this, 10.0f), Ui.dp(this, 10.0f), Ui.dp(this, 10.0f), Ui.dp(this, 10.0f));
 
         LinearLayout countRow = Ui.horizontal(this, Gravity.CENTER);
         TextView count = Ui.text(this, zIsSignedIn ? String.valueOf(i) : "—", 30.0f, Ui.mainText(this.dark));
@@ -445,6 +553,43 @@ public final class MainActivity extends AppCompatActivity {
         });
         linearLayoutCard.addView(button, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60.0f)));
         return linearLayoutCard;
+    }
+
+    private LinearLayout buildMaterialResetCreditsCard(boolean signedIn, int available) {
+        LinearLayout card = Ui.expressiveCard(this, this.dark,
+                Ui.tertiaryContainer(this, this.dark), 2);
+        int on = Ui.onTertiaryContainer(this, this.dark);
+
+        TextView label = Ui.text(this, "RESET CREDITS", 12.0f, on);
+        label.setTypeface(Ui.emphasizedTypeface(this));
+        label.setLetterSpacing(0.08f);
+        card.addView(label);
+
+        LinearLayout row = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
+        TextView count = Ui.text(this, signedIn ? String.valueOf(available) : "—", 52.0f, on);
+        count.setTypeface(Ui.emphasizedTypeface(this));
+        count.setLetterSpacing(-0.04f);
+        row.addView(count);
+        TextView detail = Ui.text(this,
+                signedIn ? (available == 1 ? "reset\nready" : "resets\nready")
+                        : "Sign in to\nsee credits",
+                18.0f, on);
+        detail.setTypeface(Ui.mediumTypeface(this));
+        detail.setLineSpacing(0f, 0.95f);
+        LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(0, -2, 1.0f);
+        detailParams.setMargins(Ui.dp(this, 16), 0, 0, 0);
+        row.addView(detail, detailParams);
+        LinearLayout.LayoutParams rowParams = new LinearLayout.LayoutParams(-1, -2);
+        rowParams.setMargins(0, Ui.dp(this, 8), 0, Ui.dp(this, 16));
+        card.addView(row, rowParams);
+
+        Button button = Ui.nativePrimaryButton(this,
+                available > 0 ? "Use 1 reset" : "No resets available");
+        button.setEnabled(signedIn && available > 0);
+        button.setOnClickListener(view ->
+                startActivity(new Intent(this, ResetCreditActivity.class)));
+        card.addView(button, new LinearLayout.LayoutParams(-1, Ui.dp(this, 64)));
+        return card;
     }
 
     private LinearLayout buildWidgetCard() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -212,6 +212,10 @@ public final class MainActivity extends AppCompatActivity {
             intent.removeExtra("seed_demo_usage");
             intent.removeExtra("widget_surface");
         }
+        if (intent != null && intent.getBooleanExtra("pin_widget", false)) {
+            intent.removeExtra("pin_widget");
+            requestPinWidget();
+        }
         Uri data = intent == null ? null : intent.getData();
         if (data != null && "codexmeter".equals(data.getScheme()) && "auth".equals(data.getHost())) {
             if (SecureTokenStore.isSignedIn(this)) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -399,9 +399,9 @@ public final class MainActivity extends AppCompatActivity {
         card.addView(header);
 
         int percent = window == null ? 0 : window.remainingPercent();
-        TextView giant = Ui.text(this, percent + "%", 56.0f, onFill);
+        TextView giant = Ui.text(this, percent + "%", 64.0f, onFill);
         giant.setTypeface(Ui.emphasizedTypeface(this));
-        giant.setLetterSpacing(-0.04f);
+        giant.setLetterSpacing(-0.045f);
         giant.setIncludeFontPadding(false);
         LinearLayout.LayoutParams giantParams = new LinearLayout.LayoutParams(-1, -2);
         giantParams.setMargins(0, Ui.dp(this, 10), 0, Ui.dp(this, 14));

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -32,6 +32,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 /* JADX INFO: loaded from: classes.dex */
 public final class MainActivity extends AppCompatActivity {
     private static final int MENU_SETTINGS = 8101;
+    private String appliedStyle;
     private String appliedTheme;
     private LinearLayout content;
     private SwipeRefreshLayout swipeRefresh;
@@ -76,6 +77,7 @@ public final class MainActivity extends AppCompatActivity {
     @Override // android.app.Activity
     protected void onCreate(Bundle bundle) {
         this.appliedTheme = AppPreferences.getAppTheme(this);
+        this.appliedStyle = AppPreferences.getAppStyle(this);
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
         if (routeToOnboarding(getIntent())) {
@@ -129,8 +131,10 @@ public final class MainActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         String appTheme = AppPreferences.getAppTheme(this);
+        String appStyle = AppPreferences.getAppStyle(this);
         boolean zIsDark = Ui.isDark(this);
-        if (!appTheme.equals(this.appliedTheme) || zIsDark != this.dark) {
+        if (!appTheme.equals(this.appliedTheme) || !appStyle.equals(this.appliedStyle)
+                || zIsDark != this.dark) {
             recreate();
         } else {
             handleLaunchIntent(getIntent());

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -105,9 +105,12 @@ public final class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        menu.add(Menu.NONE, MENU_SETTINGS, 0, "Settings")
+        MenuItem settings = menu.add(Menu.NONE, MENU_SETTINGS, 0, "Settings")
                 .setIcon(R.drawable.ic_oui_settings_outline)
-                .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+                .setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        if (!Ui.isOneUi(this) && settings.getIcon() != null) {
+            settings.getIcon().mutate().setTint(Ui.mainText(this, this.dark));
+        }
         return true;
     }
 
@@ -335,6 +338,7 @@ public final class MainActivity extends AppCompatActivity {
             column.addView(buildMaterialMetricCard("5 hour",
                     signedIn && snapshot != null ? snapshot.fiveHour : null, signedIn, 0));
             Ui.addSpacer(column, 14);
+            // Secondary container + asymmetric corners so the pair is not twin lavender blobs.
             column.addView(buildMaterialMetricCard("Weekly",
                     signedIn && snapshot != null ? snapshot.weekly : null, signedIn, 1));
             return column;
@@ -366,12 +370,18 @@ public final class MainActivity extends AppCompatActivity {
      */
     private LinearLayout buildMaterialMetricCard(String label, UsageWindow window, boolean signedIn,
             int tone) {
-        int fill = tone == 0
-                ? Ui.primaryContainer(this, this.dark)
-                : Ui.secondaryContainer(this, this.dark);
-        int onFill = tone == 0
-                ? Ui.onPrimaryContainer(this, this.dark)
-                : Ui.onSecondaryContainer(this, this.dark);
+        int fill;
+        int onFill;
+        if (tone == 0) {
+            fill = Ui.primaryContainer(this, this.dark);
+            onFill = Ui.onPrimaryContainer(this, this.dark);
+        } else if (tone == 2) {
+            fill = Ui.tertiaryContainer(this, this.dark);
+            onFill = Ui.onTertiaryContainer(this, this.dark);
+        } else {
+            fill = Ui.secondaryContainer(this, this.dark);
+            onFill = Ui.onSecondaryContainer(this, this.dark);
+        }
         int mutedOn = Color.argb(178, Color.red(onFill), Color.green(onFill), Color.blue(onFill));
         LinearLayout card = Ui.expressiveCard(this, this.dark, fill, tone);
         card.setMinimumHeight(Ui.dp(this, 168.0f));

--- a/android/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -207,18 +207,18 @@ public final class OnboardingActivity extends AppCompatActivity {
         RoundedLinearLayout card = Ui.seslCard(this, this.dark);
         TextView title = Ui.text(this, Ui.isOneUi(this)
                         ? "Built to feel at home on Galaxy"
-                        : "Built for Material You",
+                        : "Built for Material 3 Expressive",
                 18.0f,
-                Ui.mainText(this.dark));
-        title.setTypeface(Ui.mediumTypeface(this));
+                Ui.mainText(this, this.dark));
+        title.setTypeface(Ui.isOneUi(this) ? Ui.mediumTypeface(this) : Ui.emphasizedTypeface(this));
         card.addView(title);
         TextView body = Ui.text(this,
                 Ui.isOneUi(this)
                         ? "Reachable layouts, responsive cards, system theming, and Samsung "
                             + "lock-screen widgets use the app’s native One UI components."
-                        : "Dynamic color, expressive shapes, responsive cards, and Material "
-                            + "widgets make Codex Meter feel at home on stock Android.",
-                15.0f, Ui.secondaryText(this.dark));
+                        : "Bold type, dynamic color containers, fat shapes, and Material You "
+                            + "widgets make Codex Meter feel like a stock Google app.",
+                15.0f, Ui.secondaryText(this, this.dark));
         LinearLayout.LayoutParams bodyParams = new LinearLayout.LayoutParams(-1, -2);
         bodyParams.setMargins(0, Ui.dp(this, 10), 0, 0);
         card.addView(body, bodyParams);

--- a/android/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -165,8 +165,8 @@ public final class OnboardingActivity extends AppCompatActivity {
     private void render() {
         if (this.content == null) return;
         this.content.removeAllViews();
-        this.page.toolbar.setTitle("Codex Meter");
-        this.page.toolbar.setShowNavigationButtonAsBack(this.step > OnboardingFlow.STEP_WELCOME);
+        this.page.setTitle("Codex Meter");
+        this.page.setShowNavigationButtonAsBack(this.step > OnboardingFlow.STEP_WELCOME);
 
         addProgress();
         if (this.step == OnboardingFlow.STEP_WELCOME) {
@@ -201,17 +201,23 @@ public final class OnboardingActivity extends AppCompatActivity {
     private void buildWelcome() {
         addIntro("Meet Codex Meter",
                 "Your ChatGPT Codex allowance, reset timing, and available reset credits in one "
-                        + "quick One UI view.",
+                        + "quick " + designName() + " view.",
                 R.drawable.ic_oui_battery);
 
         RoundedLinearLayout card = Ui.seslCard(this, this.dark);
-        TextView title = Ui.text(this, "Built to feel at home on Galaxy", 18.0f,
+        TextView title = Ui.text(this, Ui.isOneUi(this)
+                        ? "Built to feel at home on Galaxy"
+                        : "Built for Material You",
+                18.0f,
                 Ui.mainText(this.dark));
         title.setTypeface(Ui.mediumTypeface(this));
         card.addView(title);
         TextView body = Ui.text(this,
-                "Reachable layouts, responsive cards, system theming, and Samsung lock-screen "
-                        + "widgets all use the app’s native One UI components.",
+                Ui.isOneUi(this)
+                        ? "Reachable layouts, responsive cards, system theming, and Samsung "
+                            + "lock-screen widgets use the app’s native One UI components."
+                        : "Dynamic color, expressive shapes, responsive cards, and Material "
+                            + "widgets make Codex Meter feel at home on stock Android.",
                 15.0f, Ui.secondaryText(this.dark));
         LinearLayout.LayoutParams bodyParams = new LinearLayout.LayoutParams(-1, -2);
         bodyParams.setMargins(0, Ui.dp(this, 10), 0, 0);
@@ -233,7 +239,8 @@ public final class OnboardingActivity extends AppCompatActivity {
                 R.drawable.ic_oui_calendar_week, null);
         limits.setShowBottomDivider(true);
         features.addView(limits);
-        CardItemView widgets = Ui.actionRow(this, "Native One UI widgets",
+        CardItemView widgets = Ui.actionRow(this, Ui.isOneUi(this)
+                        ? "Native One UI widgets" : "Material You widgets",
                 "At-a-glance usage on your home and lock screens",
                 R.drawable.ic_oui_add_home, null);
         widgets.setShowBottomDivider(true);
@@ -418,5 +425,9 @@ public final class OnboardingActivity extends AppCompatActivity {
             return exception.getClass().getSimpleName();
         }
         return message.length() > 180 ? message.substring(0, 180) : message;
+    }
+
+    private String designName() {
+        return Ui.isOneUi(this) ? "One UI" : "Material 3 Expressive";
     }
 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -21,7 +21,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.widget.NestedScrollView;
 
 import dev.oneuiproject.oneui.widget.CardItemView;
-import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 
 /** First-run setup built from the same One UI Design Library primitives as the app. */
 public final class OnboardingActivity extends AppCompatActivity {
@@ -193,7 +192,8 @@ public final class OnboardingActivity extends AppCompatActivity {
 
         ProgressBar progress = Ui.progress(this, this.dark);
         progress.setProgress((this.step + 1) * 100 / OnboardingFlow.STEP_COUNT);
-        LinearLayout.LayoutParams progressParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 5));
+        LinearLayout.LayoutParams progressParams = new LinearLayout.LayoutParams(-1,
+                Ui.dp(this, Ui.isOneUi(this) ? 5 : 12));
         progressParams.setMargins(Ui.dp(this, 14), 0, Ui.dp(this, 14), Ui.dp(this, 26));
         this.content.addView(progress, progressParams);
     }
@@ -204,7 +204,7 @@ public final class OnboardingActivity extends AppCompatActivity {
                         + "quick " + designName() + " view.",
                 R.drawable.ic_oui_battery);
 
-        RoundedLinearLayout card = Ui.seslCard(this, this.dark);
+        LinearLayout card = Ui.seslCard(this, this.dark);
         TextView title = Ui.text(this, Ui.isOneUi(this)
                         ? "Built to feel at home on Galaxy"
                         : "Built for Material 3 Expressive",
@@ -233,7 +233,7 @@ public final class OnboardingActivity extends AppCompatActivity {
                 R.drawable.ic_oui_time);
 
         this.content.addView(Ui.separator(this, "What you get"));
-        RoundedLinearLayout features = Ui.seslRowCard(this, this.dark);
+        LinearLayout features = Ui.seslRowCard(this, this.dark);
         CardItemView limits = Ui.actionRow(this, "Live Codex limits",
                 "Five-hour and weekly allowance with reset timing",
                 R.drawable.ic_oui_calendar_week, null);
@@ -259,7 +259,7 @@ public final class OnboardingActivity extends AppCompatActivity {
                 R.drawable.ic_oui_samsung_account);
 
         this.content.addView(Ui.separator(this, "Private by design"));
-        RoundedLinearLayout privacy = Ui.seslRowCard(this, this.dark);
+        LinearLayout privacy = Ui.seslRowCard(this, this.dark);
         CardItemView encrypted = Ui.actionRow(this, "Encrypted on this device",
                 "Session tokens are protected by Android Keystore",
                 R.drawable.ic_oui_privacy, null);
@@ -271,7 +271,7 @@ public final class OnboardingActivity extends AppCompatActivity {
         this.content.addView(privacy);
 
         if (!this.authMessage.isEmpty()) {
-            RoundedLinearLayout status = Ui.seslCard(this, this.dark);
+            LinearLayout status = Ui.seslCard(this, this.dark);
             TextView message = Ui.text(this, this.authMessage, 14.0f,
                     Ui.secondaryText(this.dark));
             status.addView(message);
@@ -300,7 +300,7 @@ public final class OnboardingActivity extends AppCompatActivity {
                         : "You can connect ChatGPT later from the Codex Meter dashboard.",
                 signedIn ? R.drawable.ic_oui_samsung_account : R.drawable.ic_oui_info_outline);
 
-        RoundedLinearLayout account = Ui.seslRowCard(this, this.dark);
+        LinearLayout account = Ui.seslRowCard(this, this.dark);
         AuthTokens tokens = SecureTokenStore.load(this);
         account.addView(Ui.actionRow(this,
                 signedIn ? "ChatGPT connected" : "Continue without an account",
@@ -314,7 +314,7 @@ public final class OnboardingActivity extends AppCompatActivity {
     }
 
     private void addIntro(String titleText, String bodyText, int iconResource) {
-        RoundedLinearLayout hero = Ui.seslCard(this, this.dark);
+        LinearLayout hero = Ui.seslCard(this, this.dark);
         ImageView icon = new ImageView(this);
         icon.setImageResource(iconResource);
         icon.setColorFilter(Ui.accent(this, this.dark));

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -138,8 +138,14 @@ public final class SettingsActivity extends AppCompatActivity {
             boolean dark = Ui.isDark(requireContext());
             LayoutPreference preference = findPreference("account_card");
             LinearLayout card = preference.findViewById(R.id.settings_account_card);
-            card.setBackground(Ui.card(requireContext(), dark).getBackground());
-            card.setClipToOutline(Ui.isOneUi(requireContext()));
+            boolean oneUi = Ui.isOneUi(requireContext());
+            if (oneUi) {
+                card.setBackground(Ui.card(requireContext(), dark).getBackground());
+            } else {
+                // The preference host already supplies the Material surface container.
+                card.setBackgroundColor(0);
+            }
+            card.setClipToOutline(oneUi);
             ImageView avatar = preference.findViewById(R.id.settings_account_avatar);
             GradientDrawable avatarBackground = new GradientDrawable();
             avatarBackground.setShape(GradientDrawable.OVAL);

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -30,7 +30,6 @@ import dev.bennett.codexmeter.wear.PhoneWearSync;
 import dev.oneuiproject.oneui.layout.ToolbarLayout;
 import dev.oneuiproject.oneui.preference.HorizontalRadioPreference;
 import dev.oneuiproject.oneui.preference.LayoutPreference;
-import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 import dev.oneuiproject.oneui.widget.CardItemView;
 import java.math.BigDecimal;
 import java.text.DecimalFormatSymbols;
@@ -138,8 +137,9 @@ public final class SettingsActivity extends AppCompatActivity {
         private void bindAccount() {
             boolean dark = Ui.isDark(requireContext());
             LayoutPreference preference = findPreference("account_card");
-            RoundedLinearLayout card = preference.findViewById(R.id.settings_account_card);
+            LinearLayout card = preference.findViewById(R.id.settings_account_card);
             card.setBackground(Ui.card(requireContext(), dark).getBackground());
+            card.setClipToOutline(Ui.isOneUi(requireContext()));
             ImageView avatar = preference.findViewById(R.id.settings_account_avatar);
             GradientDrawable avatarBackground = new GradientDrawable();
             avatarBackground.setShape(GradientDrawable.OVAL);
@@ -152,11 +152,16 @@ public final class SettingsActivity extends AppCompatActivity {
             TextView title = preference.findViewById(R.id.settings_account_title);
             TextView summary = preference.findViewById(R.id.settings_account_summary);
             TextView plan = preference.findViewById(R.id.settings_account_plan);
+            title.setTypeface(Ui.mediumTypeface(requireContext()));
+            summary.setTypeface(Ui.regularTypeface(requireContext()));
+            plan.setTypeface(Ui.emphasizedTypeface(requireContext()));
             CardItemView action = preference.findViewById(R.id.settings_account_action);
             title.setTextColor(Ui.mainText(dark));
             summary.setTextColor(Ui.secondaryText(dark));
             plan.setTextColor(Ui.mainText(dark));
             plan.setBackground(Ui.pillBackground(requireContext(), dark));
+            preference.<View>findViewById(R.id.settings_account_divider)
+                    .setBackgroundColor(Ui.divider(dark));
 
             AuthTokens tokens = SecureTokenStore.load(requireContext());
             UsageSnapshot snapshot = AppPreferences.loadSnapshot(requireContext());

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -21,6 +21,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
@@ -46,10 +47,18 @@ public final class SettingsActivity extends AppCompatActivity {
     protected void onCreate(Bundle bundle) {
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
-        AppPreferences.setAppStyle(this, WidgetOptions.SURFACE_ONE_UI);
-        setContentView(R.layout.activity_settings);
-        ToolbarLayout toolbar = findViewById(R.id.settings_toolbar_layout);
-        Ui.configureReachToolbar(toolbar, "Settings", true);
+        if (Ui.isOneUi(this)) {
+            setContentView(R.layout.activity_settings);
+            ToolbarLayout toolbar = findViewById(R.id.settings_toolbar_layout);
+            Ui.configureReachToolbar(toolbar, "Settings", true);
+        } else {
+            setContentView(R.layout.activity_material_settings);
+            View root = findViewById(R.id.material_settings_root);
+            Ui.styleMaterialRoot(this, root);
+            Ui.configureMaterialToolbar(this, (Toolbar) findViewById(R.id.material_toolbar),
+                    "Settings", true);
+            Ui.configureSystemBars(this, root, Ui.isDark(this));
+        }
         if (bundle == null) {
             getSupportFragmentManager().beginTransaction()
                     .replace(R.id.settings_fragment, new SettingsFragment())
@@ -200,6 +209,16 @@ public final class SettingsActivity extends AppCompatActivity {
         }
 
         private void bindAppearance() {
+            ListPreference style = findPreference("app_surface_style");
+            style.setPersistent(false);
+            style.setValue(AppPreferences.getAppStyle(requireContext()));
+            style.setSummaryProvider(ListPreference.SimpleSummaryProvider.getInstance());
+            style.setOnPreferenceChangeListener((preference, value) -> {
+                AppPreferences.setAppStyle(requireContext(), String.valueOf(value));
+                requireActivity().recreate();
+                return true;
+            });
+
             String selected = AppPreferences.getAppTheme(requireContext());
             boolean useSystem = WidgetOptions.THEME_SYSTEM.equals(selected);
             HorizontalRadioPreference theme = findPreference("app_theme");

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -167,6 +167,7 @@ public final class SettingsTransferStore {
     private static JSONObject collectAppSettings(Context context) throws Exception {
         JSONObject json = new JSONObject();
         json.put("app_theme", AppPreferences.getAppTheme(context));
+        json.put("app_style", AppPreferences.getAppStyle(context));
         json.put("refresh_minutes", AppPreferences.getRefreshMinutes(context));
         json.put("refresh_on_launch", AppPreferences.getRefreshOnLaunch(context));
         json.put("automatic_update_checks", UpdatePreferences.automaticChecks(context));
@@ -203,8 +204,10 @@ public final class SettingsTransferStore {
 
     private static boolean applyAppSettings(Context context, JSONObject json) throws Exception {
         String previousTheme = AppPreferences.getAppTheme(context);
+        String previousStyle = AppPreferences.getAppStyle(context);
         String theme = json.optString("app_theme", previousTheme);
         AppPreferences.setAppTheme(context, theme);
+        AppPreferences.setAppStyle(context, json.optString("app_style", previousStyle));
         AppPreferences.setRefreshMinutes(context, json.optInt("refresh_minutes",
                 AppPreferences.getRefreshMinutes(context)));
         AppPreferences.setRefreshOnLaunch(context, json.optBoolean("refresh_on_launch",
@@ -222,7 +225,8 @@ public final class SettingsTransferStore {
                     SettingsTransfer.widgetOptionsFromJson(widget,
                             AppPreferences.loadDefaultWidgetOptions(context)));
         }
-        return !previousTheme.equals(AppPreferences.getAppTheme(context));
+        return !previousTheme.equals(AppPreferences.getAppTheme(context))
+                || !previousStyle.equals(AppPreferences.getAppStyle(context));
     }
 
     private static void applyNotifications(Context context, JSONObject json) throws Exception {

--- a/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -70,7 +70,8 @@ public final class Ui {
             if (toolbar != null) {
                 toolbar.setShowNavigationButtonAsBack(show);
             } else if (materialToolbar != null) {
-                materialToolbar.setNavigationIcon(show ? R.drawable.ic_oui_back : 0);
+                materialToolbar.setNavigationIcon(show
+                        ? activity.getDrawable(R.drawable.ic_oui_back) : null);
                 if (materialToolbar.getNavigationIcon() != null) {
                     materialToolbar.getNavigationIcon().setTint(mainText(isDark(activity)));
                 }
@@ -664,7 +665,7 @@ public final class Ui {
         toolbar.setTitleTextColor(mainText(dark));
         toolbar.setSubtitleTextColor(secondaryText(dark));
         toolbar.setBackgroundColor(background(activity, dark));
-        toolbar.setNavigationIcon(back ? R.drawable.ic_oui_back : 0);
+        toolbar.setNavigationIcon(back ? activity.getDrawable(R.drawable.ic_oui_back) : null);
         if (toolbar.getNavigationIcon() != null) {
             toolbar.getNavigationIcon().setTint(mainText(dark));
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -34,6 +34,7 @@ import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.AppCompatCheckBox;
 import androidx.appcompat.widget.AppCompatSpinner;
 import androidx.appcompat.widget.SeslProgressBar;
+import androidx.appcompat.widget.Toolbar;
 import dev.oneuiproject.oneui.layout.ToolbarLayout;
 import dev.oneuiproject.oneui.ktx.ActivityKt;
 import dev.oneuiproject.oneui.popover.PopOverOptions;
@@ -45,24 +46,52 @@ import dev.oneuiproject.oneui.widget.Separator;
 public final class Ui {
     public static final class Page {
         public final ToolbarLayout toolbar;
+        public final Toolbar materialToolbar;
         public final LinearLayout content;
+        private final AppCompatActivity activity;
 
-        private Page(ToolbarLayout toolbar, LinearLayout content) {
+        private Page(AppCompatActivity activity, ToolbarLayout toolbar, Toolbar materialToolbar,
+                LinearLayout content) {
+            this.activity = activity;
             this.toolbar = toolbar;
+            this.materialToolbar = materialToolbar;
             this.content = content;
+        }
+
+        public void setTitle(String title) {
+            if (toolbar != null) {
+                toolbar.setTitle(title);
+            } else if (materialToolbar != null) {
+                materialToolbar.setTitle(title);
+            }
+        }
+
+        public void setShowNavigationButtonAsBack(boolean show) {
+            if (toolbar != null) {
+                toolbar.setShowNavigationButtonAsBack(show);
+            } else if (materialToolbar != null) {
+                materialToolbar.setNavigationIcon(show ? R.drawable.ic_oui_back : 0);
+                if (materialToolbar.getNavigationIcon() != null) {
+                    materialToolbar.getNavigationIcon().setTint(mainText(isDark(activity)));
+                }
+                materialToolbar.setNavigationOnClickListener(show ? view ->
+                        activity.getOnBackPressedDispatcher().onBackPressed() : null);
+            }
         }
     }
 
     public static final class ConfigPage {
         public final ToolbarLayout toolbar;
+        public final Toolbar materialToolbar;
         public final LinearLayout content;
         public final FrameLayout preview;
         public final TextView cancel;
         public final TextView save;
 
-        private ConfigPage(ToolbarLayout toolbar, LinearLayout content, FrameLayout preview,
-                TextView cancel, TextView save) {
+        private ConfigPage(ToolbarLayout toolbar, Toolbar materialToolbar, LinearLayout content,
+                FrameLayout preview, TextView cancel, TextView save) {
             this.toolbar = toolbar;
+            this.materialToolbar = materialToolbar;
             this.content = content;
             this.preview = preview;
             this.cancel = cancel;
@@ -84,17 +113,27 @@ public final class Ui {
             }
             ((AppCompatActivity) activity).getDelegate().setLocalNightMode(mode);
         }
-        activity.setTheme(R.style.AppTheme);
+        activity.setTheme(isOneUi(activity) ? R.style.AppTheme : R.style.AppThemeMaterial);
     }
 
     public static Page installPage(AppCompatActivity activity, String title, boolean back) {
         ViewGroup parent = activity.findViewById(android.R.id.content);
-        View root = LayoutInflater.from(activity).inflate(R.layout.activity_oneui_dashboard, parent, false);
-        ToolbarLayout toolbar = root.findViewById(R.id.toolbar_layout);
+        boolean oneUi = isOneUi(activity);
+        View root = LayoutInflater.from(activity).inflate(oneUi
+                ? R.layout.activity_oneui_dashboard : R.layout.activity_material_dashboard,
+                parent, false);
+        ToolbarLayout toolbar = oneUi ? root.findViewById(R.id.toolbar_layout) : null;
+        Toolbar materialToolbar = oneUi ? null : root.findViewById(R.id.material_toolbar);
         LinearLayout content = root.findViewById(R.id.dashboard_content);
-        configureReachToolbar(toolbar, title, back);
+        if (oneUi) {
+            configureReachToolbar(toolbar, title, back);
+        } else {
+            configureMaterialToolbar(activity, materialToolbar, title, back);
+            styleMaterialRoot(activity, root);
+        }
         activity.setContentView(root);
-        return new Page(toolbar, content);
+        configureSystemBars(activity, root, isDark(activity));
+        return new Page(activity, toolbar, materialToolbar, content);
     }
 
     public static void configureReachToolbar(ToolbarLayout toolbar, String title, boolean back) {
@@ -111,7 +150,7 @@ public final class Ui {
         boolean largeOneUiDevice = Build.MANUFACTURER != null
                 && "samsung".equalsIgnoreCase(Build.MANUFACTURER)
                 && activity.getResources().getConfiguration().smallestScreenWidthDp >= 600;
-        if (largeOneUiDevice) {
+        if (largeOneUiDevice && isOneUi(activity)) {
             ActivityKt.startPopOverActivity(
                     activity,
                     intent,
@@ -131,17 +170,29 @@ public final class Ui {
 
     public static ConfigPage installConfigPage(AppCompatActivity activity, String title) {
         ViewGroup parent = activity.findViewById(android.R.id.content);
-        View root = LayoutInflater.from(activity).inflate(R.layout.activity_widget_settings, parent, false);
-        ToolbarLayout toolbar = root.findViewById(R.id.widget_settings_root);
+        boolean oneUi = isOneUi(activity);
+        View root = LayoutInflater.from(activity).inflate(oneUi
+                ? R.layout.activity_widget_settings : R.layout.activity_material_widget_settings,
+                parent, false);
+        ToolbarLayout toolbar = oneUi ? root.findViewById(R.id.widget_settings_root) : null;
+        Toolbar materialToolbar = oneUi ? null : root.findViewById(R.id.material_toolbar);
         LinearLayout content = root.findViewById(R.id.widget_settings_content);
         FrameLayout preview = root.findViewById(R.id.widget_preview_container);
         TextView cancel = root.findViewById(R.id.config_cancel);
         TextView save = root.findViewById(R.id.config_save);
-        toolbar.setTitle(title);
-        toolbar.setShowNavigationButtonAsBack(true);
+        if (oneUi) {
+            toolbar.setTitle(title);
+            toolbar.setShowNavigationButtonAsBack(true);
+        } else {
+            configureMaterialToolbar(activity, materialToolbar, title, true);
+            styleMaterialRoot(activity, root);
+            cancel.setTextColor(mainText(isDark(activity)));
+            save.setTextColor(onAccent(activity, isDark(activity)));
+            save.setBackground(shape(accent(activity, isDark(activity)), dp(activity, 999)));
+        }
         activity.setContentView(root);
         configureSystemBars(activity, root, isDark(activity));
-        return new ConfigPage(toolbar, content, preview, cancel, save);
+        return new ConfigPage(toolbar, materialToolbar, content, preview, cancel, save);
     }
 
     public static boolean isDark(Context context) {
@@ -153,7 +204,7 @@ public final class Ui {
     }
 
     public static boolean isOneUi(Context context) {
-        return true;
+        return !AppDesignStyle.isMaterialExpressive(AppPreferences.getAppStyle(context));
     }
 
     public static int pageHorizontalPadding(Context context) {
@@ -290,7 +341,8 @@ public final class Ui {
         int i = zIsOneUi ? 22 : 20;
         int i2 = zIsOneUi ? 20 : 19;
         linearLayout.setPadding(dp(context, i), dp(context, i2), dp(context, i), dp(context, i2));
-        linearLayout.setBackground(shape(cardColor(context, z), dp(context, 28.0f)));
+        linearLayout.setBackground(shape(cardColor(context, z),
+                dp(context, zIsOneUi ? 28.0f : 32.0f)));
         linearLayout.setElevation(0.0f);
         linearLayout.setClipToOutline(true);
         linearLayout.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
@@ -301,7 +353,8 @@ public final class Ui {
         RoundedLinearLayout card = new RoundedLinearLayout(context);
         card.setOrientation(LinearLayout.VERTICAL);
         card.setPadding(dp(context, 18.0f), dp(context, 14.0f), dp(context, 18.0f), dp(context, 14.0f));
-        card.setBackground(shape(cardColor(context, dark), dp(context, 28.0f)));
+        card.setBackground(shape(cardColor(context, dark),
+                dp(context, isOneUi(context) ? 28.0f : 32.0f)));
         card.setClipToOutline(true);
         card.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return card;
@@ -310,7 +363,8 @@ public final class Ui {
     public static RoundedLinearLayout cardGroup(Context context, boolean dark) {
         RoundedLinearLayout group = new RoundedLinearLayout(context);
         group.setOrientation(LinearLayout.VERTICAL);
-        group.setBackground(shape(cardColor(context, dark), dp(context, 28.0f)));
+        group.setBackground(shape(cardColor(context, dark),
+                dp(context, isOneUi(context) ? 28.0f : 32.0f)));
         group.setClipToOutline(true);
         group.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return group;
@@ -319,7 +373,8 @@ public final class Ui {
     public static RoundedLinearLayout seslRowCard(Context context, boolean dark) {
         RoundedLinearLayout card = new RoundedLinearLayout(context);
         card.setOrientation(LinearLayout.VERTICAL);
-        card.setBackground(shape(cardColor(context, dark), dp(context, 28.0f)));
+        card.setBackground(shape(cardColor(context, dark),
+                dp(context, isOneUi(context) ? 28.0f : 32.0f)));
         card.setClipToOutline(true);
         card.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return card;
@@ -368,6 +423,9 @@ public final class Ui {
     }
 
     public static Button nativePrimaryButton(Context context, String text) {
+        if (!isOneUi(context)) {
+            return button(context, text, true, isDark(context));
+        }
         Button button = (Button) LayoutInflater.from(context).inflate(R.layout.view_oneui_primary_button, null, false);
         button.setText(text);
         boolean dark = isDark(context);
@@ -592,6 +650,53 @@ public final class Ui {
             i = 8464;
         }
         window.getDecorView().setSystemUiVisibility(i);
+    }
+
+    public static void configureMaterialToolbar(AppCompatActivity activity, Toolbar toolbar,
+            String title, boolean back) {
+        if (toolbar == null) {
+            return;
+        }
+        boolean dark = isDark(activity);
+        toolbar.setTitle(title);
+        toolbar.setTitleTextColor(mainText(dark));
+        toolbar.setSubtitleTextColor(secondaryText(dark));
+        toolbar.setBackgroundColor(background(activity, dark));
+        toolbar.setNavigationIcon(back ? R.drawable.ic_oui_back : 0);
+        if (toolbar.getNavigationIcon() != null) {
+            toolbar.getNavigationIcon().setTint(mainText(dark));
+        }
+        toolbar.setNavigationOnClickListener(back ? view ->
+                activity.getOnBackPressedDispatcher().onBackPressed() : null);
+        activity.setSupportActionBar(toolbar);
+        if (activity.getSupportActionBar() != null) {
+            activity.getSupportActionBar().setDisplayShowTitleEnabled(true);
+            activity.getSupportActionBar().setDisplayHomeAsUpEnabled(false);
+        }
+    }
+
+    public static void styleMaterialRoot(Context context, View root) {
+        boolean dark = isDark(context);
+        root.setBackgroundColor(background(context, dark));
+        View content = root.findViewById(R.id.dashboard_content);
+        if (content != null) {
+            content.setBackgroundColor(background(context, dark));
+        }
+    }
+
+    public static int materialAccent(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_accent1_200" : "system_accent1_600",
+                dark ? Color.rgb(210, 188, 255) : Color.rgb(103, 80, 164));
+    }
+
+    public static int materialSurface(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_neutral2_800" : "system_neutral2_50",
+                dark ? Color.rgb(33, 31, 38) : Color.rgb(245, 242, 250));
+    }
+
+    public static int materialOnSurface(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_neutral1_50" : "system_neutral1_900",
+                dark ? Color.rgb(232, 225, 229) : Color.rgb(29, 27, 32));
     }
 
     public static LinearLayout horizontal(Context context, int i) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -779,9 +779,10 @@ public final class Ui {
         }
         boolean dark = isDark(activity);
         toolbar.setTitle(title);
+        toolbar.setTitleTextAppearance(activity, R.style.MaterialToolbarTitle);
+        // Appearance can clobber color — stamp on-surface after.
         toolbar.setTitleTextColor(mainText(activity, dark));
         toolbar.setSubtitleTextColor(secondaryText(activity, dark));
-        toolbar.setTitleTextAppearance(activity, R.style.MaterialToolbarTitle);
         toolbar.setBackgroundColor(background(activity, dark));
         toolbar.setNavigationIcon(back ? activity.getDrawable(R.drawable.ic_oui_back) : null);
         if (toolbar.getNavigationIcon() != null) {
@@ -867,14 +868,15 @@ public final class Ui {
      * tone 0 = XL uniform, 1 = left-heavy, 2 = right-heavy.
      */
     public static float[] expressiveRadii(Context context, int tone) {
-        float xl = dp(context, 40.0f);
-        float lg = dp(context, 28.0f);
-        float md = dp(context, 16.0f);
+        // extraLargeIncreased-ish + hard asymmetry so shapes read as intentional M3E, not 28dp mush.
+        float xl = dp(context, 48.0f);
+        float lg = dp(context, 24.0f);
+        float sm = dp(context, 12.0f);
         if (tone == 1) {
-            return new float[]{xl, xl, lg, lg, xl, xl, md, md};
+            return new float[]{xl, xl, sm, sm, xl, xl, lg, lg};
         }
         if (tone == 2) {
-            return new float[]{lg, lg, xl, xl, md, md, xl, xl};
+            return new float[]{sm, sm, xl, xl, lg, lg, xl, xl};
         }
         return new float[]{xl, xl, xl, xl, xl, xl, xl, xl};
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -132,7 +132,9 @@ public final class Ui {
             styleMaterialRoot(activity, root);
         }
         activity.setContentView(root);
-        configureSystemBars(activity, root, isDark(activity));
+        if (!oneUi) {
+            configureSystemBars(activity, root, isDark(activity));
+        }
         return new Page(activity, toolbar, materialToolbar, content);
     }
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -7,8 +7,10 @@ import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Insets;
 import android.graphics.Typeface;
+import android.graphics.drawable.ClipDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.LayerDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
 import android.view.Gravity;
@@ -73,7 +75,7 @@ public final class Ui {
                 materialToolbar.setNavigationIcon(show
                         ? activity.getDrawable(R.drawable.ic_oui_back) : null);
                 if (materialToolbar.getNavigationIcon() != null) {
-                    materialToolbar.getNavigationIcon().setTint(mainText(isDark(activity)));
+                    materialToolbar.getNavigationIcon().setTint(mainText(activity, isDark(activity)));
                 }
                 materialToolbar.setNavigationOnClickListener(show ? view ->
                         activity.getOnBackPressedDispatcher().onBackPressed() : null);
@@ -189,9 +191,14 @@ public final class Ui {
         } else {
             configureMaterialToolbar(activity, materialToolbar, title, true);
             styleMaterialRoot(activity, root);
-            cancel.setTextColor(mainText(isDark(activity)));
-            save.setTextColor(onAccent(activity, isDark(activity)));
-            save.setBackground(shape(accent(activity, isDark(activity)), dp(activity, 999)));
+            boolean dark = isDark(activity);
+            cancel.setTextColor(mainText(activity, dark));
+            cancel.setTypeface(emphasizedTypeface(activity));
+            save.setTextColor(onAccent(activity, dark));
+            save.setTypeface(emphasizedTypeface(activity));
+            save.setTextSize(16f);
+            save.setPadding(dp(activity, 20), dp(activity, 10), dp(activity, 20), dp(activity, 10));
+            save.setBackground(shape(accent(activity, dark), dp(activity, 999)));
         }
         activity.setContentView(root);
         configureSystemBars(activity, root, isDark(activity));
@@ -211,7 +218,7 @@ public final class Ui {
     }
 
     public static int pageHorizontalPadding(Context context) {
-        return dp(context, isOneUi(context) ? 24.0f : 20.0f);
+        return dp(context, isOneUi(context) ? 24.0f : 16.0f);
     }
 
     public static int pageTopPadding(Context context) {
@@ -222,16 +229,20 @@ public final class Ui {
         if (isOneUi(context)) {
             return z ? Color.rgb(5, 6, 8) : Color.rgb(241, 241, 243);
         }
-        return systemColor(context, z ? "system_neutral1_900" : "system_neutral1_10", z ? Color.rgb(18, 18, 22) : Color.rgb(249, 247, 251));
+        // M3 surface — keep the canvas calm so containers can scream.
+        return systemColor(context, z ? "system_neutral1_900" : "system_neutral1_10",
+                z ? Color.rgb(20, 18, 24) : Color.rgb(254, 247, 255));
     }
 
     public static int background(boolean z) {
-        return z ? Color.rgb(18, 18, 22) : Color.rgb(249, 247, 251);
+        return z ? Color.rgb(20, 18, 24) : Color.rgb(254, 247, 255);
     }
 
     public static int cardColor(Context context, boolean z) {
         if (!isOneUi(context)) {
-            return systemColor(context, z ? "system_neutral1_800" : "system_neutral1_50", z ? Color.rgb(31, 30, 36) : Color.rgb(242, 239, 246));
+            // surface-container-high — stronger lift than plain surface
+            return systemColor(context, z ? "system_neutral1_800" : "system_neutral1_100",
+                    z ? Color.rgb(36, 34, 40) : Color.rgb(245, 235, 247));
         }
         if (z) {
             return Color.rgb(22, 24, 28);
@@ -240,22 +251,38 @@ public final class Ui {
     }
 
     public static int card(boolean z) {
-        return z ? Color.rgb(31, 30, 36) : Color.rgb(242, 239, 246);
+        return z ? Color.rgb(36, 34, 40) : Color.rgb(245, 235, 247);
     }
 
     public static int controlSurface(Context context, boolean z) {
         if (isOneUi(context)) {
             return z ? Color.rgb(42, 44, 50) : Color.rgb(238, 238, 241);
         }
-        return systemColor(context, z ? "system_neutral1_700" : "system_neutral1_100", z ? Color.rgb(46, 44, 52) : Color.rgb(232, 228, 236));
+        return systemColor(context, z ? "system_neutral1_700" : "system_neutral2_100",
+                z ? Color.rgb(54, 50, 60) : Color.rgb(236, 230, 240));
     }
 
     public static int mainText(boolean z) {
         return z ? Color.rgb(248, 248, 250) : Color.BLACK;
     }
 
+    public static int mainText(Context context, boolean z) {
+        if (isOneUi(context)) {
+            return mainText(z);
+        }
+        return materialOnSurface(context, z);
+    }
+
     public static int secondaryText(boolean z) {
         return z ? Color.rgb(183, 186, 194) : Color.rgb(132, 132, 135);
+    }
+
+    public static int secondaryText(Context context, boolean z) {
+        if (isOneUi(context)) {
+            return secondaryText(z);
+        }
+        return systemColor(context, z ? "system_neutral2_200" : "system_neutral2_600",
+                z ? Color.rgb(202, 196, 208) : Color.rgb(89, 82, 96));
     }
 
     public static int divider(boolean z) {
@@ -266,7 +293,9 @@ public final class Ui {
         if (isOneUi(context)) {
             return z ? Color.rgb(92, 169, 255) : Color.rgb(56, 122, 255);
         }
-        return systemColor(context, z ? "system_accent1_200" : "system_accent1_600", z ? Color.rgb(117, 220, 179) : Color.rgb(0, 113, 83));
+        // Primary — punchy, not muted mint leftovers from the old Material pass.
+        return systemColor(context, z ? "system_accent1_200" : "system_accent1_600",
+                z ? Color.rgb(208, 188, 255) : Color.rgb(103, 80, 164));
     }
 
     public static int desaturatedAccent(Context context, boolean dark) {
@@ -284,10 +313,38 @@ public final class Ui {
         if (isOneUi(context)) {
             return Color.luminance(accent(context, z)) > 0.55f ? Color.BLACK : Color.WHITE;
         }
-        if (!z) {
-            return -1;
-        }
-        return Color.rgb(0, 55, 39);
+        return systemColor(context, z ? "system_accent1_800" : "system_accent1_0",
+                z ? Color.rgb(56, 30, 114) : Color.WHITE);
+    }
+
+    public static int primaryContainer(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_accent1_700" : "system_accent1_100",
+                dark ? Color.rgb(79, 55, 139) : Color.rgb(234, 221, 255));
+    }
+
+    public static int onPrimaryContainer(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_accent1_100" : "system_accent1_900",
+                dark ? Color.rgb(234, 221, 255) : Color.rgb(33, 0, 93));
+    }
+
+    public static int secondaryContainer(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_accent2_700" : "system_accent2_100",
+                dark ? Color.rgb(81, 69, 104) : Color.rgb(232, 222, 248));
+    }
+
+    public static int onSecondaryContainer(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_accent2_100" : "system_accent2_900",
+                dark ? Color.rgb(232, 222, 248) : Color.rgb(33, 24, 50));
+    }
+
+    public static int tertiaryContainer(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_accent3_700" : "system_accent3_100",
+                dark ? Color.rgb(99, 59, 72) : Color.rgb(255, 216, 228));
+    }
+
+    public static int onTertiaryContainer(Context context, boolean dark) {
+        return systemColor(context, dark ? "system_accent3_100" : "system_accent3_900",
+                dark ? Color.rgb(255, 216, 228) : Color.rgb(49, 17, 29));
     }
 
     public static int danger(boolean z) {
@@ -299,11 +356,23 @@ public final class Ui {
     }
 
     public static Typeface regularTypeface(Context context) {
-        return Typeface.create(isOneUi(context) ? "sec" : "sans-serif", 0);
+        return Typeface.create(isOneUi(context) ? "sec" : "sans-serif", Typeface.NORMAL);
     }
 
     public static Typeface mediumTypeface(Context context) {
-        return Typeface.create(isOneUi(context) ? "sec" : "sans-serif-medium", 1);
+        return Typeface.create(isOneUi(context) ? "sec" : "sans-serif-medium", Typeface.BOLD);
+    }
+
+    /** Emphasized / display weight — the M3E hierarchy hammer. */
+    public static Typeface emphasizedTypeface(Context context) {
+        if (isOneUi(context)) {
+            return Typeface.create("sec", Typeface.BOLD);
+        }
+        Typeface black = Typeface.create("sans-serif-black", Typeface.NORMAL);
+        if (black != null) {
+            return black;
+        }
+        return Typeface.create("sans-serif", Typeface.BOLD);
     }
 
     public static TextView text(Context context, String str, float f, int i) {
@@ -312,27 +381,32 @@ public final class Ui {
         textView.setTextSize(f);
         textView.setTextColor(i);
         textView.setTypeface(regularTypeface(context));
-        textView.setLineSpacing(0.0f, isOneUi(context) ? 1.12f : 1.14f);
+        textView.setLineSpacing(0.0f, isOneUi(context) ? 1.12f : 1.1f);
         textView.setIncludeFontPadding(false);
         return textView;
     }
 
     public static TextView title(Context context, String str, boolean z) {
-        TextView textViewText = text(context, str, isOneUi(context) ? 42.0f : 36.0f, mainText(z));
-        textViewText.setTypeface(mediumTypeface(context));
-        textViewText.setLetterSpacing(isOneUi(context) ? -0.025f : -0.02f);
+        boolean oneUi = isOneUi(context);
+        TextView textViewText = text(context, str, oneUi ? 42.0f : 40.0f, mainText(context, z));
+        textViewText.setTypeface(oneUi ? mediumTypeface(context) : emphasizedTypeface(context));
+        textViewText.setLetterSpacing(oneUi ? -0.025f : -0.03f);
         return textViewText;
     }
 
     public static TextView sectionTitle(Context context, String str, boolean z) {
         boolean zIsOneUi = isOneUi(context);
-        TextView textViewText = text(context, str, zIsOneUi ? 13.0f : 15.0f, zIsOneUi ? accent(context, z) : mainText(z));
-        textViewText.setTypeface(mediumTypeface(context));
+        TextView textViewText = text(context, str, zIsOneUi ? 13.0f : 16.0f,
+                zIsOneUi ? accent(context, z) : mainText(context, z));
+        textViewText.setTypeface(zIsOneUi ? mediumTypeface(context) : emphasizedTypeface(context));
         if (zIsOneUi) {
             textViewText.setLetterSpacing(0.01f);
+        } else {
+            textViewText.setLetterSpacing(-0.01f);
         }
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(-1, -2);
-        layoutParams.setMargins(zIsOneUi ? dp(context, 4.0f) : 0, dp(context, zIsOneUi ? 30.0f : 28.0f), 0, dp(context, zIsOneUi ? 10.0f : 11.0f));
+        layoutParams.setMargins(zIsOneUi ? dp(context, 4.0f) : 0,
+                dp(context, zIsOneUi ? 30.0f : 24.0f), 0, dp(context, zIsOneUi ? 10.0f : 12.0f));
         textViewText.setLayoutParams(layoutParams);
         return textViewText;
     }
@@ -341,23 +415,38 @@ public final class Ui {
         RoundedLinearLayout linearLayout = new RoundedLinearLayout(context);
         linearLayout.setOrientation(1);
         boolean zIsOneUi = isOneUi(context);
-        int i = zIsOneUi ? 22 : 20;
-        int i2 = zIsOneUi ? 20 : 19;
+        int i = zIsOneUi ? 22 : 24;
+        int i2 = zIsOneUi ? 20 : 22;
         linearLayout.setPadding(dp(context, i), dp(context, i2), dp(context, i), dp(context, i2));
-        linearLayout.setBackground(shape(cardColor(context, z),
-                dp(context, zIsOneUi ? 28.0f : 32.0f)));
+        linearLayout.setBackground(zIsOneUi
+                ? shape(cardColor(context, z), dp(context, 28.0f))
+                : expressiveShape(cardColor(context, z), expressiveRadii(context, 0)));
         linearLayout.setElevation(0.0f);
         linearLayout.setClipToOutline(true);
         linearLayout.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return linearLayout;
     }
 
+    public static LinearLayout expressiveCard(Context context, boolean dark, int fillColor, int tone) {
+        RoundedLinearLayout card = new RoundedLinearLayout(context);
+        card.setOrientation(LinearLayout.VERTICAL);
+        card.setPadding(dp(context, 24.0f), dp(context, 22.0f), dp(context, 24.0f),
+                dp(context, 22.0f));
+        card.setBackground(expressiveShape(fillColor, expressiveRadii(context, tone)));
+        card.setElevation(0.0f);
+        card.setClipToOutline(true);
+        card.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
+        return card;
+    }
+
     public static RoundedLinearLayout seslCard(Context context, boolean dark) {
         RoundedLinearLayout card = new RoundedLinearLayout(context);
         card.setOrientation(LinearLayout.VERTICAL);
         card.setPadding(dp(context, 18.0f), dp(context, 14.0f), dp(context, 18.0f), dp(context, 14.0f));
-        card.setBackground(shape(cardColor(context, dark),
-                dp(context, isOneUi(context) ? 28.0f : 32.0f)));
+        boolean oneUi = isOneUi(context);
+        card.setBackground(oneUi
+                ? shape(cardColor(context, dark), dp(context, 28.0f))
+                : expressiveShape(cardColor(context, dark), expressiveRadii(context, 0)));
         card.setClipToOutline(true);
         card.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return card;
@@ -366,8 +455,10 @@ public final class Ui {
     public static RoundedLinearLayout cardGroup(Context context, boolean dark) {
         RoundedLinearLayout group = new RoundedLinearLayout(context);
         group.setOrientation(LinearLayout.VERTICAL);
-        group.setBackground(shape(cardColor(context, dark),
-                dp(context, isOneUi(context) ? 28.0f : 32.0f)));
+        boolean oneUi = isOneUi(context);
+        group.setBackground(oneUi
+                ? shape(cardColor(context, dark), dp(context, 28.0f))
+                : expressiveShape(cardColor(context, dark), expressiveRadii(context, 1)));
         group.setClipToOutline(true);
         group.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return group;
@@ -376,8 +467,10 @@ public final class Ui {
     public static RoundedLinearLayout seslRowCard(Context context, boolean dark) {
         RoundedLinearLayout card = new RoundedLinearLayout(context);
         card.setOrientation(LinearLayout.VERTICAL);
-        card.setBackground(shape(cardColor(context, dark),
-                dp(context, isOneUi(context) ? 28.0f : 32.0f)));
+        boolean oneUi = isOneUi(context);
+        card.setBackground(oneUi
+                ? shape(cardColor(context, dark), dp(context, 28.0f))
+                : expressiveShape(cardColor(context, dark), expressiveRadii(context, 2)));
         card.setClipToOutline(true);
         card.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return card;
@@ -395,29 +488,35 @@ public final class Ui {
         Button button = new AppCompatButton(context);
         button.setText(str);
         button.setAllCaps(false);
-        button.setTextSize(18.0f);
-        button.setTypeface(mediumTypeface(context));
+        button.setTextSize(zIsOneUi ? 18.0f : 17.0f);
+        button.setTypeface(zIsOneUi ? mediumTypeface(context) : emphasizedTypeface(context));
         button.setGravity(17);
         button.setSingleLine(true);
         button.setIncludeFontPadding(false);
-        button.setMinHeight(dp(context, 52.0f));
+        button.setLetterSpacing(zIsOneUi ? 0f : 0.01f);
+        button.setMinHeight(dp(context, zIsOneUi ? 52.0f : 60.0f));
         button.setMinWidth(0);
-        button.setPadding(dp(context, zIsOneUi ? 18.0f : 20.0f), dp(context, 7.0f), dp(context, zIsOneUi ? 18.0f : 20.0f), dp(context, 7.0f));
-        int iDp = dp(context, 999.0f);
-        int iAccent = z ? accent(context, z2) : controlSurface(context, z2);
-        int iOnAccent = z ? onAccent(context, z2) : mainText(z2);
+        button.setPadding(dp(context, zIsOneUi ? 18.0f : 28.0f), dp(context, zIsOneUi ? 7.0f : 14.0f),
+                dp(context, zIsOneUi ? 18.0f : 28.0f), dp(context, zIsOneUi ? 7.0f : 14.0f));
+        // M3E XL buttons stay fully rounded; tonal buttons use a slightly squared full radius.
+        int iDp = dp(context, zIsOneUi ? 999.0f : (z ? 999.0f : 28.0f));
+        int iAccent = z ? accent(context, z2)
+                : (zIsOneUi ? controlSurface(context, z2) : secondaryContainer(context, z2));
+        int iOnAccent = z ? onAccent(context, z2)
+                : (zIsOneUi ? mainText(z2) : onSecondaryContainer(context, z2));
         GradientDrawable gradientDrawableShape = shape(iAccent, iDp);
         if (z) {
             iArgb = Color.argb(42, 255, 255, 255);
         } else {
-            iArgb = Color.argb(z2 ? 44 : 28, Color.red(mainText(z2)), Color.green(mainText(z2)), Color.blue(mainText(z2)));
+            iArgb = Color.argb(z2 ? 44 : 28, Color.red(mainText(context, z2)),
+                    Color.green(mainText(context, z2)), Color.blue(mainText(context, z2)));
         }
         button.setBackground(new RippleDrawable(ColorStateList.valueOf(iArgb), gradientDrawableShape, null));
         button.setTextColor(iOnAccent);
         int icon = buttonIcon(str);
         if (icon != 0) {
             button.setCompoundDrawablesRelativeWithIntrinsicBounds(icon, 0, 0, 0);
-            button.setCompoundDrawablePadding(dp(context, 8.0f));
+            button.setCompoundDrawablePadding(dp(context, zIsOneUi ? 8.0f : 10.0f));
             button.setCompoundDrawableTintList(ColorStateList.valueOf(iOnAccent));
         }
         button.setElevation(0.0f);
@@ -427,7 +526,10 @@ public final class Ui {
 
     public static Button nativePrimaryButton(Context context, String text) {
         if (!isOneUi(context)) {
-            return button(context, text, true, isDark(context));
+            Button material = button(context, text, true, isDark(context));
+            material.setMinHeight(dp(context, 64.0f));
+            material.setTextSize(18.0f);
+            return material;
         }
         Button button = (Button) LayoutInflater.from(context).inflate(R.layout.view_oneui_primary_button, null, false);
         button.setText(text);
@@ -505,10 +607,24 @@ public final class Ui {
     public static ProgressBar progress(Context context, boolean z) {
         ProgressBar progressBar = new ProgressBar(context, null, android.R.attr.progressBarStyleHorizontal);
         progressBar.setMax(100);
-        progressBar.setProgressTintList(ColorStateList.valueOf(accent(context, z)));
-        progressBar.setProgressBackgroundTintList(ColorStateList.valueOf(controlSurface(context, z)));
         progressBar.setIndeterminate(false);
-        progressBar.setLayoutParams(new LinearLayout.LayoutParams(-1, dp(context, isOneUi(context) ? 7.0f : 8.0f)));
+        boolean oneUi = isOneUi(context);
+        if (oneUi) {
+            progressBar.setProgressTintList(ColorStateList.valueOf(accent(context, z)));
+            progressBar.setProgressBackgroundTintList(ColorStateList.valueOf(controlSurface(context, z)));
+            progressBar.setLayoutParams(new LinearLayout.LayoutParams(-1, dp(context, 7.0f)));
+            return progressBar;
+        }
+        // Fat M3E track — glanceable from across the room.
+        int height = dp(context, 16.0f);
+        GradientDrawable track = shape(controlSurface(context, z), height);
+        GradientDrawable fill = shape(accent(context, z), height);
+        ClipDrawable clip = new ClipDrawable(fill, Gravity.START, ClipDrawable.HORIZONTAL);
+        LayerDrawable layer = new LayerDrawable(new android.graphics.drawable.Drawable[]{track, clip});
+        layer.setId(0, android.R.id.background);
+        layer.setId(1, android.R.id.progress);
+        progressBar.setProgressDrawable(layer);
+        progressBar.setLayoutParams(new LinearLayout.LayoutParams(-1, height));
         return progressBar;
     }
 
@@ -572,9 +688,10 @@ public final class Ui {
             spinner.setPopupBackgroundDrawable(shape(cardColor(context, z), dp(context, 18.0f)));
             spinner.setPadding(0, 0, 0, 0);
         } else {
-            spinner.setBackground(shape(controlSurface(context, z), dp(context, 20.0f)));
-            spinner.setPopupBackgroundDrawable(shape(cardColor(context, z), dp(context, 18.0f)));
-            spinner.setPadding(dp(context, 2.0f), 0, dp(context, 2.0f), 0);
+            spinner.setBackground(shape(secondaryContainer(context, z), dp(context, 28.0f)));
+            spinner.setPopupBackgroundDrawable(expressiveShape(cardColor(context, z),
+                    expressiveRadii(context, 0)));
+            spinner.setPadding(dp(context, 8.0f), 0, dp(context, 8.0f), 0);
         }
         spinner.setElevation(0.0f);
         return spinner;
@@ -662,12 +779,13 @@ public final class Ui {
         }
         boolean dark = isDark(activity);
         toolbar.setTitle(title);
-        toolbar.setTitleTextColor(mainText(dark));
-        toolbar.setSubtitleTextColor(secondaryText(dark));
+        toolbar.setTitleTextColor(mainText(activity, dark));
+        toolbar.setSubtitleTextColor(secondaryText(activity, dark));
+        toolbar.setTitleTextAppearance(activity, R.style.MaterialToolbarTitle);
         toolbar.setBackgroundColor(background(activity, dark));
         toolbar.setNavigationIcon(back ? activity.getDrawable(R.drawable.ic_oui_back) : null);
         if (toolbar.getNavigationIcon() != null) {
-            toolbar.getNavigationIcon().setTint(mainText(dark));
+            toolbar.getNavigationIcon().setTint(mainText(activity, dark));
         }
         toolbar.setNavigationOnClickListener(back ? view ->
                 activity.getOnBackPressedDispatcher().onBackPressed() : null);
@@ -689,17 +807,17 @@ public final class Ui {
 
     public static int materialAccent(Context context, boolean dark) {
         return systemColor(context, dark ? "system_accent1_200" : "system_accent1_600",
-                dark ? Color.rgb(210, 188, 255) : Color.rgb(103, 80, 164));
+                dark ? Color.rgb(208, 188, 255) : Color.rgb(103, 80, 164));
     }
 
     public static int materialSurface(Context context, boolean dark) {
-        return systemColor(context, dark ? "system_neutral2_800" : "system_neutral2_50",
-                dark ? Color.rgb(33, 31, 38) : Color.rgb(245, 242, 250));
+        return systemColor(context, dark ? "system_neutral1_800" : "system_neutral1_50",
+                dark ? Color.rgb(36, 34, 40) : Color.rgb(245, 235, 247));
     }
 
     public static int materialOnSurface(Context context, boolean dark) {
         return systemColor(context, dark ? "system_neutral1_50" : "system_neutral1_900",
-                dark ? Color.rgb(232, 225, 229) : Color.rgb(29, 27, 32));
+                dark ? Color.rgb(230, 224, 233) : Color.rgb(29, 27, 32));
     }
 
     public static LinearLayout horizontal(Context context, int i) {
@@ -735,6 +853,30 @@ public final class Ui {
         gradientDrawable.setColor(i);
         gradientDrawable.setCornerRadius(i2);
         return gradientDrawable;
+    }
+
+    public static GradientDrawable expressiveShape(int color, float[] radii) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(color);
+        drawable.setCornerRadii(radii);
+        return drawable;
+    }
+
+    /**
+     * M3E shape scale: larger / asymmetric corners so containers feel intentional, not bland pills.
+     * tone 0 = XL uniform, 1 = left-heavy, 2 = right-heavy.
+     */
+    public static float[] expressiveRadii(Context context, int tone) {
+        float xl = dp(context, 40.0f);
+        float lg = dp(context, 28.0f);
+        float md = dp(context, 16.0f);
+        if (tone == 1) {
+            return new float[]{xl, xl, lg, lg, xl, xl, md, md};
+        }
+        if (tone == 2) {
+            return new float[]{lg, lg, xl, xl, md, md, xl, xl};
+        }
+        return new float[]{xl, xl, xl, xl, xl, xl, xl, xl};
     }
 
     private static int systemColor(Context context, String str, int i) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -199,9 +199,17 @@ public final class Ui {
             save.setTextSize(16f);
             save.setPadding(dp(activity, 20), dp(activity, 10), dp(activity, 20), dp(activity, 10));
             save.setBackground(shape(accent(activity, dark), dp(activity, 999)));
+            LinearLayout buttonBar = root.findViewById(R.id.config_button_bar);
+            buttonBar.setPadding(dp(activity, 8), dp(activity, 8),
+                    dp(activity, 8), dp(activity, 8));
+            buttonBar.setBackground(shape(cardColor(activity, dark), dp(activity, 999)));
+            buttonBar.setElevation(dp(activity, 8));
+            buttonBar.setClipToOutline(true);
         }
         activity.setContentView(root);
-        configureSystemBars(activity, root, isDark(activity));
+        if (!oneUi) {
+            configureSystemBars(activity, root, isDark(activity));
+        }
         return new ConfigPage(toolbar, materialToolbar, content, preview, cancel, save);
     }
 
@@ -423,7 +431,7 @@ public final class Ui {
                 ? shape(cardColor(context, z), dp(context, 28.0f))
                 : expressiveShape(cardColor(context, z), expressiveRadii(context, 0)));
         linearLayout.setElevation(0.0f);
-        linearLayout.setClipToOutline(true);
+        linearLayout.setClipToOutline(zIsOneUi);
         linearLayout.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return linearLayout;
     }
@@ -436,44 +444,44 @@ public final class Ui {
                 dp(context, 22.0f));
         card.setBackground(expressiveShape(fillColor, expressiveRadii(context, tone)));
         card.setElevation(0.0f);
-        card.setClipToOutline(true);
+        card.setClipToOutline(false);
         card.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return card;
     }
 
-    public static RoundedLinearLayout seslCard(Context context, boolean dark) {
-        RoundedLinearLayout card = new RoundedLinearLayout(context);
+    public static LinearLayout seslCard(Context context, boolean dark) {
+        boolean oneUi = isOneUi(context);
+        LinearLayout card = oneUi ? new RoundedLinearLayout(context) : new LinearLayout(context);
         card.setOrientation(LinearLayout.VERTICAL);
         card.setPadding(dp(context, 18.0f), dp(context, 14.0f), dp(context, 18.0f), dp(context, 14.0f));
-        boolean oneUi = isOneUi(context);
         card.setBackground(oneUi
                 ? shape(cardColor(context, dark), dp(context, 28.0f))
                 : expressiveShape(cardColor(context, dark), expressiveRadii(context, 0)));
-        card.setClipToOutline(true);
+        card.setClipToOutline(oneUi);
         card.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return card;
     }
 
-    public static RoundedLinearLayout cardGroup(Context context, boolean dark) {
-        RoundedLinearLayout group = new RoundedLinearLayout(context);
-        group.setOrientation(LinearLayout.VERTICAL);
+    public static LinearLayout cardGroup(Context context, boolean dark) {
         boolean oneUi = isOneUi(context);
+        LinearLayout group = oneUi ? new RoundedLinearLayout(context) : new LinearLayout(context);
+        group.setOrientation(LinearLayout.VERTICAL);
         group.setBackground(oneUi
                 ? shape(cardColor(context, dark), dp(context, 28.0f))
                 : expressiveShape(cardColor(context, dark), expressiveRadii(context, 1)));
-        group.setClipToOutline(true);
+        group.setClipToOutline(oneUi);
         group.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return group;
     }
 
-    public static RoundedLinearLayout seslRowCard(Context context, boolean dark) {
-        RoundedLinearLayout card = new RoundedLinearLayout(context);
-        card.setOrientation(LinearLayout.VERTICAL);
+    public static LinearLayout seslRowCard(Context context, boolean dark) {
         boolean oneUi = isOneUi(context);
+        LinearLayout card = oneUi ? new RoundedLinearLayout(context) : new LinearLayout(context);
+        card.setOrientation(LinearLayout.VERTICAL);
         card.setBackground(oneUi
                 ? shape(cardColor(context, dark), dp(context, 28.0f))
                 : expressiveShape(cardColor(context, dark), expressiveRadii(context, 2)));
-        card.setClipToOutline(true);
+        card.setClipToOutline(oneUi);
         card.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
         return card;
     }
@@ -507,6 +515,24 @@ public final class Ui {
         int iOnAccent = z ? onAccent(context, z2)
                 : (zIsOneUi ? mainText(z2) : onSecondaryContainer(context, z2));
         GradientDrawable gradientDrawableShape = shape(iAccent, iDp);
+        int enabledText = iOnAccent;
+        if (!zIsOneUi) {
+            int onSurface = mainText(context, z2);
+            int disabledFill = Color.argb(31, Color.red(onSurface),
+                    Color.green(onSurface), Color.blue(onSurface));
+            int disabledText = Color.argb(97, Color.red(onSurface),
+                    Color.green(onSurface), Color.blue(onSurface));
+            int[][] states = new int[][]{
+                    new int[]{-android.R.attr.state_enabled},
+                    new int[0]
+            };
+            gradientDrawableShape.setColor(new ColorStateList(states,
+                    new int[]{disabledFill, iAccent}));
+            ColorStateList textColors = new ColorStateList(states,
+                    new int[]{disabledText, enabledText});
+            button.setTextColor(textColors);
+            button.setCompoundDrawableTintList(textColors);
+        }
         if (z) {
             iArgb = Color.argb(42, 255, 255, 255);
         } else {
@@ -514,12 +540,16 @@ public final class Ui {
                     Color.green(mainText(context, z2)), Color.blue(mainText(context, z2)));
         }
         button.setBackground(new RippleDrawable(ColorStateList.valueOf(iArgb), gradientDrawableShape, null));
-        button.setTextColor(iOnAccent);
+        if (zIsOneUi) {
+            button.setTextColor(enabledText);
+        }
         int icon = buttonIcon(str);
         if (icon != 0) {
             button.setCompoundDrawablesRelativeWithIntrinsicBounds(icon, 0, 0, 0);
             button.setCompoundDrawablePadding(dp(context, zIsOneUi ? 8.0f : 10.0f));
-            button.setCompoundDrawableTintList(ColorStateList.valueOf(iOnAccent));
+            if (zIsOneUi) {
+                button.setCompoundDrawableTintList(ColorStateList.valueOf(enabledText));
+            }
         }
         button.setElevation(0.0f);
         button.setStateListAnimator(null);
@@ -729,9 +759,11 @@ public final class Ui {
         checkBox.setText(str);
         checkBox.setChecked(z);
         checkBox.setTextSize(isOneUi(context) ? 15.0f : 14.0f);
-        checkBox.setTextColor(mainText(z2));
+        checkBox.setTextColor(mainText(context, z2));
         checkBox.setTypeface(regularTypeface(context));
-        checkBox.setButtonTintList(new ColorStateList(new int[][]{new int[]{android.R.attr.state_checked}, new int[0]}, new int[]{accent(context, z2), secondaryText(z2)}));
+        checkBox.setButtonTintList(new ColorStateList(
+                new int[][]{new int[]{android.R.attr.state_checked}, new int[0]},
+                new int[]{accent(context, z2), secondaryText(context, z2)}));
         checkBox.setMinHeight(dp(context, isOneUi(context) ? 52.0f : 48.0f));
         checkBox.setPadding(0, dp(context, 4.0f), 0, dp(context, 4.0f));
         return checkBox;

--- a/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/Ui.java
@@ -412,9 +412,10 @@ public final class Ui {
     }
 
     public static LinearLayout card(Context context, boolean z) {
-        RoundedLinearLayout linearLayout = new RoundedLinearLayout(context);
-        linearLayout.setOrientation(1);
         boolean zIsOneUi = isOneUi(context);
+        // SESL RoundedLinearLayout paints its own One UI corners — never use it for M3E shapes.
+        LinearLayout linearLayout = zIsOneUi ? new RoundedLinearLayout(context) : new LinearLayout(context);
+        linearLayout.setOrientation(1);
         int i = zIsOneUi ? 22 : 24;
         int i2 = zIsOneUi ? 20 : 22;
         linearLayout.setPadding(dp(context, i), dp(context, i2), dp(context, i), dp(context, i2));
@@ -428,7 +429,8 @@ public final class Ui {
     }
 
     public static LinearLayout expressiveCard(Context context, boolean dark, int fillColor, int tone) {
-        RoundedLinearLayout card = new RoundedLinearLayout(context);
+        // Plain LinearLayout so GradientDrawable cornerRadii (incl. asymmetric) actually win.
+        LinearLayout card = new LinearLayout(context);
         card.setOrientation(LinearLayout.VERTICAL);
         card.setPadding(dp(context, 24.0f), dp(context, 22.0f), dp(context, 24.0f),
                 dp(context, 22.0f));

--- a/android/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -184,11 +184,11 @@ public final class UpdateActivity extends AppCompatActivity {
             });
             card.addView(action, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
 
-            progress = new ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal);
+            progress = Ui.progress(this, dark);
             progress.setMax(1000);
             progress.setVisibility(View.GONE);
             LinearLayout.LayoutParams progressParams =
-                    new LinearLayout.LayoutParams(-1, Ui.dp(this, 8));
+                    new LinearLayout.LayoutParams(-1, Ui.dp(this, Ui.isOneUi(this) ? 8 : 12));
             progressParams.setMargins(0, Ui.dp(this, 18), 0, 0);
             card.addView(progress, progressParams);
             status = Ui.text(this, "", 13, Ui.secondaryText(dark));

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
@@ -34,9 +34,9 @@ public final class UsageWaveView extends View {
 
     public UsageWaveView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        titlePaint.setTypeface(Typeface.create("sec", Typeface.BOLD));
-        resetPaint.setTypeface(Typeface.create("sec", Typeface.NORMAL));
-        percentPaint.setTypeface(Typeface.create("sec", Typeface.BOLD));
+        titlePaint.setTypeface(Ui.mediumTypeface(context));
+        resetPaint.setTypeface(Ui.regularTypeface(context));
+        percentPaint.setTypeface(Ui.mediumTypeface(context));
         percentPaint.setTextAlign(Paint.Align.CENTER);
         setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
@@ -28,7 +28,6 @@ import androidx.appcompat.widget.SeslSeekBar;
 import dev.oneuiproject.oneui.widget.CardItemView;
 import dev.oneuiproject.oneui.widget.RadioItemView;
 import dev.oneuiproject.oneui.widget.RadioItemViewGroup;
-import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 
 public final class WidgetConfigActivity extends AppCompatActivity {
     private Spinner accentSpinner;
@@ -90,7 +89,7 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         this.tapAction = AppPreferences.getWidgetTapAction(this, this.appWidgetId);
 
         content.addView(Ui.separator(this, "Appearance"));
-        RoundedLinearLayout appearanceCard = Ui.seslRowCard(this, this.dark);
+        LinearLayout appearanceCard = Ui.seslRowCard(this, this.dark);
         this.opacityControl = LayoutInflater.from(this).inflate(
                 R.layout.view_widget_opacity, appearanceCard, false);
         appearanceCard.addView(this.opacityControl);
@@ -120,7 +119,7 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         content.addView(appearanceCard);
 
         content.addView(Ui.separator(this, "Content"));
-        RoundedLinearLayout contentCard = Ui.seslRowCard(this, this.dark);
+        LinearLayout contentCard = Ui.seslRowCard(this, this.dark);
         this.displaySpinner = Ui.spinner(this, WidgetOptionCatalog.DISPLAY_LABELS, this.dark);
         WidgetOptionCatalog.selectString(this.displaySpinner, WidgetOptionCatalog.DISPLAY_VALUES,
                 saved.displayMode);
@@ -186,8 +185,8 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         renderPreview();
     }
 
-    private RoundedLinearLayout buildTapActionCard() {
-        RoundedLinearLayout card = Ui.seslRowCard(this, this.dark);
+    private LinearLayout buildTapActionCard() {
+        LinearLayout card = Ui.seslRowCard(this, this.dark);
         RadioItemViewGroup group = new RadioItemViewGroup(this);
         group.setOrientation(LinearLayout.VERTICAL);
         group.addView(radioRow(this.tapOpenId, "Open Codex Meter", false));
@@ -225,7 +224,7 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         return this.tapOpenId;
     }
 
-    private CardItemView addOptionRow(RoundedLinearLayout card, String title, Spinner spinner,
+    private CardItemView addOptionRow(LinearLayout card, String title, Spinner spinner,
             String[] labels, boolean divider) {
         CardItemView row = new CardItemView(this);
         row.setTitle(title);

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
@@ -334,6 +334,15 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     }
 
     private void applyPreviewSelection(Spinner spinner, int position) {
+        if (spinner == this.surfaceSpinner
+                && position != spinner.getSelectedItemPosition()
+                && WidgetOptions.SURFACE_MATERIAL.equals(
+                        WidgetOptionCatalog.SURFACE_VALUES[position])
+                && WidgetOptions.ACCENT_BLUE.equals(WidgetOptionCatalog.ACCENT_VALUES[
+                        this.accentSpinner.getSelectedItemPosition()])) {
+            WidgetOptionCatalog.selectString(this.accentSpinner,
+                    WidgetOptionCatalog.ACCENT_VALUES, WidgetOptions.ACCENT_APP);
+        }
         spinner.setSelection(position);
         updateRowSummaries();
         renderPreview();

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
@@ -37,6 +37,8 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     private boolean dark;
     private Spinner displaySpinner;
     private CardItemView displayRow;
+    private Spinner surfaceSpinner;
+    private CardItemView surfaceRow;
     private SeslSeekBar opacitySlider;
     private SwitchCompat percentSymbolSwitch;
     private View opacityControl;
@@ -100,11 +102,16 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         }
 
         this.themeSpinner = Ui.spinner(this, WidgetOptionCatalog.THEME_LABELS, this.dark);
+        this.surfaceSpinner = Ui.spinner(this, WidgetOptionCatalog.SURFACE_LABELS, this.dark);
         this.accentSpinner = Ui.spinner(this, WidgetOptionCatalog.ACCENT_LABELS, this.dark);
+        WidgetOptionCatalog.selectString(this.surfaceSpinner, WidgetOptionCatalog.SURFACE_VALUES,
+                saved.surfaceStyle);
         WidgetOptionCatalog.selectString(this.themeSpinner, WidgetOptionCatalog.THEME_VALUES,
                 saved.theme);
         WidgetOptionCatalog.selectString(this.accentSpinner, WidgetOptionCatalog.ACCENT_VALUES,
                 saved.accent);
+        this.surfaceRow = addOptionRow(appearanceCard, "Design", this.surfaceSpinner,
+                WidgetOptionCatalog.SURFACE_LABELS, true);
         this.themeRow = addOptionRow(appearanceCard, "Theme", this.themeSpinner,
                 WidgetOptionCatalog.THEME_LABELS, true);
         this.accentRow = addOptionRow(appearanceCard, "Accent", this.accentSpinner,
@@ -153,6 +160,7 @@ public final class WidgetConfigActivity extends AppCompatActivity {
             }
         };
         this.themeSpinner.setOnItemSelectedListener(selectionListener);
+        this.surfaceSpinner.setOnItemSelectedListener(selectionListener);
         this.accentSpinner.setOnItemSelectedListener(selectionListener);
         this.displaySpinner.setOnItemSelectedListener(selectionListener);
         this.percentSymbolSwitch.setOnCheckedChangeListener((button, checked) -> renderPreview());
@@ -334,7 +342,9 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     private WidgetOptions currentOptions() {
         return new WidgetOptions(WidgetOptions.STYLE_RINGS,
                 WidgetOptions.DENSITY_AUTO,
-                WidgetOptions.SURFACE_ONE_UI, WidgetOptions.GRAPHIC_AUTO,
+                WidgetOptionCatalog.SURFACE_VALUES[
+                        this.surfaceSpinner.getSelectedItemPosition()],
+                WidgetOptions.GRAPHIC_AUTO,
                 WidgetOptionCatalog.THEME_VALUES[this.themeSpinner.getSelectedItemPosition()],
                 WidgetOptionCatalog.ACCENT_VALUES[this.accentSpinner.getSelectedItemPosition()],
                 WidgetOptionCatalog.OPACITY_VALUES[this.opacitySlider.getProgress()],
@@ -351,6 +361,8 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         }
         this.themeRow.setSummary(WidgetOptionCatalog.THEME_LABELS[
                 this.themeSpinner.getSelectedItemPosition()]);
+        this.surfaceRow.setSummary(WidgetOptionCatalog.SURFACE_LABELS[
+                this.surfaceSpinner.getSelectedItemPosition()]);
         this.accentRow.setSummary(WidgetOptionCatalog.ACCENT_LABELS[
                 this.accentSpinner.getSelectedItemPosition()]);
         this.displayRow.setSummary(WidgetOptionCatalog.DISPLAY_LABELS[
@@ -377,9 +389,16 @@ public final class WidgetConfigActivity extends AppCompatActivity {
                 boolean previewDark = WidgetOptions.THEME_DARK.equals(options.theme)
                         || (!WidgetOptions.THEME_LIGHT.equals(options.theme) && this.dark);
                 int alpha = Math.round(options.opacity * 2.55f);
-                background.setColor(previewDark ? Color.argb(alpha, 0, 0, 0)
-                        : Color.argb(alpha, 255, 255, 255));
-                background.setCornerRadius(Ui.dp(this, 28.0f));
+                if (WidgetOptions.SURFACE_MATERIAL.equals(options.surfaceStyle)) {
+                    int surfaceColor = Ui.materialSurface(this, previewDark);
+                    background.setColor(Color.argb(alpha, Color.red(surfaceColor),
+                            Color.green(surfaceColor), Color.blue(surfaceColor)));
+                    background.setCornerRadius(Ui.dp(this, 32.0f));
+                } else {
+                    background.setColor(previewDark ? Color.argb(alpha, 0, 0, 0)
+                            : Color.argb(alpha, 255, 255, 255));
+                    background.setCornerRadius(Ui.dp(this, 28.0f));
+                }
                 surface.setBackground(background);
                 // Use the application inflater so AppCompat does not substitute its ImageView;
                 // RemoteViews reflection is intentionally restricted to framework widgets.

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
@@ -96,27 +96,25 @@ public final class WidgetGraphics {
     public static Bitmap expressiveDial(int value, int progressColor, int trackColor, int textColor,
             String label, float scale) {
         float s = clampScale(scale);
-        // Tall canvas (~2.5:1): RemoteViews ImageViews top-align scaled bitmaps, so the
-        // dial is drawn mid-canvas and lands centered in typical 2x2 half-cells.
+        // Compact canvas for 2x1 hosts. All strokes and labels remain inside the bitmap.
         int width = Math.round(200.0f * s);
-        int height = Math.round(500.0f * s);
+        int height = Math.round(158.0f * s);
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        // Avoid mdpi density upscaling — RemoteViews would treat 160dpi bitmaps as huge
-        // and top-align the downscaled result, leaving a dead strip under the dials.
         bitmap.setDensity(Bitmap.DENSITY_NONE);
         Canvas canvas = new Canvas(bitmap);
         Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeCap(Paint.Cap.ROUND);
-        float stroke = 20.0f * s;
+        float stroke = 18.0f * s;
         paint.setStrokeWidth(stroke);
-        float pad = (stroke * 0.5f) + 6.0f * s;
+        float pad = (stroke * 0.5f) + 4.0f * s;
         boolean hasLabel = label != null && !label.isEmpty();
-        float labelReserve = hasLabel ? 30.0f * s : 14.0f * s;
-        float contentHeight = height - (pad * 2.0f);
-        float arcSpan = Math.min(width - (pad * 2.0f), contentHeight - labelReserve);
+        float chipHeight = hasLabel ? 22.0f * s : 0.0f;
+        float chipGap = hasLabel ? 7.0f * s : 0.0f;
+        float arcSpan = Math.min(width - (pad * 2.0f),
+                height - (pad * 2.0f) - chipHeight - chipGap);
         float cx = width / 2.0f;
-        float cy = (height - labelReserve) / 2.0f;
+        float cy = pad + (arcSpan / 2.0f);
         RectF oval = new RectF(cx - (arcSpan / 2.0f), cy - (arcSpan / 2.0f),
                 cx + (arcSpan / 2.0f), cy + (arcSpan / 2.0f));
         final float arcStart = 150.0f;
@@ -140,16 +138,23 @@ public final class WidgetGraphics {
         paint.setTextAlign(Paint.Align.CENTER);
         paint.setTypeface(Typeface.create("sans-serif-black", Typeface.NORMAL));
         paint.setColor(textColor);
-        paint.setTextSize(42.0f * s);
+        paint.setTextSize(34.0f * s);
         Paint.FontMetrics fm = paint.getFontMetrics();
         float valueBaseline = cy - ((fm.ascent + fm.descent) / 2.0f);
         canvas.drawText(value < 0 ? "—" : clamp(value) + "%", cx, valueBaseline, paint);
         if (hasLabel) {
+            float chipWidth = 44.0f * s;
+            float chipTop = height - chipHeight - (2.0f * s);
+            RectF chip = new RectF(cx - (chipWidth / 2.0f), chipTop,
+                    cx + (chipWidth / 2.0f), chipTop + chipHeight);
+            paint.setColor(withAlpha(progressColor, 0.14f));
+            canvas.drawRoundRect(chip, chipHeight / 2.0f, chipHeight / 2.0f, paint);
             paint.setTypeface(Typeface.create("sans-serif-black", Typeface.NORMAL));
-            paint.setTextSize(18.0f * s);
-            paint.setColor(withAlpha(textColor, 0.78f));
-            canvas.drawText(label, cx, Math.min(height - (8.0f * s),
-                    oval.bottom + (22.0f * s)), paint);
+            paint.setTextSize(13.0f * s);
+            paint.setColor(progressColor);
+            Paint.FontMetrics chipFm = paint.getFontMetrics();
+            float chipBaseline = chip.centerY() - ((chipFm.ascent + chipFm.descent) / 2.0f);
+            canvas.drawText(label, cx, chipBaseline, paint);
         }
         return bitmap;
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
@@ -86,6 +86,16 @@ public final class WidgetGraphics {
     }
 
     public static Bitmap dial(int i, int i2, int i3, int i4, String str, float f) {
+        return dialInternal(i, i2, i3, i4, str, f, false);
+    }
+
+    /** M3E dial — thicker stroke, black display type, stronger end-cap. */
+    public static Bitmap expressiveDial(int i, int i2, int i3, int i4, String str, float f) {
+        return dialInternal(i, i2, i3, i4, str, f, true);
+    }
+
+    private static Bitmap dialInternal(int i, int i2, int i3, int i4, String str, float f,
+            boolean expressive) {
         float fClampScale = clampScale(f);
         int iRound = Math.round(260.0f * fClampScale);
         Bitmap bitmapCreateBitmap = Bitmap.createBitmap(iRound, Math.round(190.0f * fClampScale), Bitmap.Config.ARGB_8888);
@@ -94,7 +104,7 @@ public final class WidgetGraphics {
         Paint paint = new Paint(1);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeCap(Paint.Cap.ROUND);
-        paint.setStrokeWidth(20.0f * fClampScale);
+        paint.setStrokeWidth((expressive ? 26.0f : 20.0f) * fClampScale);
         RectF rectF = new RectF(22.0f * fClampScale, 20.0f * fClampScale, iRound - (22.0f * fClampScale), iRound - (24.0f * fClampScale));
         paint.setColor(i3);
         canvas.drawArc(rectF, 145.0f, 250.0f, false, paint);
@@ -107,19 +117,22 @@ public final class WidgetGraphics {
             float fCenterX = rectF.centerX() + (((float) Math.cos(radians)) * fWidth);
             float fCenterY = rectF.centerY() + (((float) Math.sin(radians)) * fWidth);
             paint.setStyle(Paint.Style.FILL);
-            canvas.drawCircle(fCenterX, fCenterY, 9.5f * fClampScale, paint);
+            canvas.drawCircle(fCenterX, fCenterY, (expressive ? 11.5f : 9.5f) * fClampScale, paint);
             paint.setColor(withAlpha(i4, 0.22f));
-            canvas.drawCircle(fCenterX, fCenterY, 4.2f * fClampScale, paint);
+            canvas.drawCircle(fCenterX, fCenterY, (expressive ? 5.0f : 4.2f) * fClampScale, paint);
         }
         paint.setStyle(Paint.Style.FILL);
         paint.setTextAlign(Paint.Align.CENTER);
-        paint.setTypeface(Typeface.create("sans-serif", 1));
+        Typeface valueFace = expressive
+                ? Typeface.create("sans-serif-black", Typeface.NORMAL)
+                : Typeface.create("sans-serif", Typeface.BOLD);
+        paint.setTypeface(valueFace);
         paint.setColor(i4);
-        paint.setTextSize(48.0f * fClampScale);
+        paint.setTextSize((expressive ? 54.0f : 48.0f) * fClampScale);
         canvas.drawText(i < 0 ? "—" : clamp(i) + "%", iRound / 2.0f, 130.0f * fClampScale, paint);
-        paint.setTypeface(Typeface.create("sans-serif-medium", 0));
-        paint.setTextSize(19.0f * fClampScale);
-        paint.setColor(withAlpha(i4, 0.68f));
+        paint.setTypeface(Typeface.create(expressive ? "sans-serif-medium" : "sans-serif-medium", 0));
+        paint.setTextSize((expressive ? 18.0f : 19.0f) * fClampScale);
+        paint.setColor(withAlpha(i4, expressive ? 0.78f : 0.68f));
         if (str == null) {
             str = "";
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
@@ -86,16 +86,70 @@ public final class WidgetGraphics {
     }
 
     public static Bitmap dial(int i, int i2, int i3, int i4, String str, float f) {
-        return dialInternal(i, i2, i3, i4, str, f, false);
+        return dialInternal(i, i2, i3, i4, str, f);
     }
 
-    /** M3E dial — thicker stroke, black display type, stronger end-cap. */
-    public static Bitmap expressiveDial(int i, int i2, int i3, int i4, String str, float f) {
-        return dialInternal(i, i2, i3, i4, str, f, true);
+    /**
+     * M3E dial — thicker stroke, black display type, stronger end-cap.
+     * Canvas and oval stay fully in-bounds so home-screen RemoteViews never clip the arc.
+     */
+    public static Bitmap expressiveDial(int value, int progressColor, int trackColor, int textColor,
+            String label, float scale) {
+        float s = clampScale(scale);
+        int width = Math.round(200.0f * s);
+        int height = Math.round(172.0f * s);
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        bitmap.setDensity(160);
+        Canvas canvas = new Canvas(bitmap);
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setStrokeCap(Paint.Cap.ROUND);
+        float stroke = 22.0f * s;
+        paint.setStrokeWidth(stroke);
+        float pad = stroke * 0.55f + 3.0f * s;
+        boolean hasLabel = label != null && !label.isEmpty();
+        float labelReserve = hasLabel ? 26.0f * s : 10.0f * s;
+        float arcSpan = Math.min(width - (pad * 2.0f), height - pad - labelReserve);
+        float cx = width / 2.0f;
+        float cy = pad + (arcSpan / 2.0f);
+        RectF oval = new RectF(cx - (arcSpan / 2.0f), cy - (arcSpan / 2.0f),
+                cx + (arcSpan / 2.0f), cy + (arcSpan / 2.0f));
+        final float arcStart = 150.0f;
+        final float arcSweep = 240.0f;
+        paint.setColor(trackColor);
+        canvas.drawArc(oval, arcStart, arcSweep, false, paint);
+        if (value >= 0) {
+            paint.setColor(progressColor);
+            float sweep = (arcSweep * clamp(value)) / 100.0f;
+            canvas.drawArc(oval, arcStart, sweep, false, paint);
+            double radians = Math.toRadians(arcStart + sweep);
+            float radius = oval.width() / 2.0f;
+            float tipX = oval.centerX() + (((float) Math.cos(radians)) * radius);
+            float tipY = oval.centerY() + (((float) Math.sin(radians)) * radius);
+            paint.setStyle(Paint.Style.FILL);
+            canvas.drawCircle(tipX, tipY, 10.0f * s, paint);
+            paint.setColor(withAlpha(textColor, 0.22f));
+            canvas.drawCircle(tipX, tipY, 4.4f * s, paint);
+        }
+        paint.setStyle(Paint.Style.FILL);
+        paint.setTextAlign(Paint.Align.CENTER);
+        paint.setTypeface(Typeface.create("sans-serif-black", Typeface.NORMAL));
+        paint.setColor(textColor);
+        paint.setTextSize(40.0f * s);
+        Paint.FontMetrics fm = paint.getFontMetrics();
+        float valueBaseline = cy - ((fm.ascent + fm.descent) / 2.0f);
+        canvas.drawText(value < 0 ? "—" : clamp(value) + "%", cx, valueBaseline, paint);
+        if (hasLabel) {
+            paint.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+            paint.setTextSize(15.0f * s);
+            paint.setColor(withAlpha(textColor, 0.72f));
+            canvas.drawText(label, cx, height - (6.0f * s), paint);
+        }
+        return bitmap;
     }
 
-    private static Bitmap dialInternal(int i, int i2, int i3, int i4, String str, float f,
-            boolean expressive) {
+    private static Bitmap dialInternal(int i, int i2, int i3, int i4, String str, float f) {
+        // One UI path only — keep the established geometry untouched.
         float fClampScale = clampScale(f);
         int iRound = Math.round(260.0f * fClampScale);
         Bitmap bitmapCreateBitmap = Bitmap.createBitmap(iRound, Math.round(190.0f * fClampScale), Bitmap.Config.ARGB_8888);
@@ -104,7 +158,7 @@ public final class WidgetGraphics {
         Paint paint = new Paint(1);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeCap(Paint.Cap.ROUND);
-        paint.setStrokeWidth((expressive ? 26.0f : 20.0f) * fClampScale);
+        paint.setStrokeWidth(20.0f * fClampScale);
         RectF rectF = new RectF(22.0f * fClampScale, 20.0f * fClampScale, iRound - (22.0f * fClampScale), iRound - (24.0f * fClampScale));
         paint.setColor(i3);
         canvas.drawArc(rectF, 145.0f, 250.0f, false, paint);
@@ -117,22 +171,19 @@ public final class WidgetGraphics {
             float fCenterX = rectF.centerX() + (((float) Math.cos(radians)) * fWidth);
             float fCenterY = rectF.centerY() + (((float) Math.sin(radians)) * fWidth);
             paint.setStyle(Paint.Style.FILL);
-            canvas.drawCircle(fCenterX, fCenterY, (expressive ? 11.5f : 9.5f) * fClampScale, paint);
+            canvas.drawCircle(fCenterX, fCenterY, 9.5f * fClampScale, paint);
             paint.setColor(withAlpha(i4, 0.22f));
-            canvas.drawCircle(fCenterX, fCenterY, (expressive ? 5.0f : 4.2f) * fClampScale, paint);
+            canvas.drawCircle(fCenterX, fCenterY, 4.2f * fClampScale, paint);
         }
         paint.setStyle(Paint.Style.FILL);
         paint.setTextAlign(Paint.Align.CENTER);
-        Typeface valueFace = expressive
-                ? Typeface.create("sans-serif-black", Typeface.NORMAL)
-                : Typeface.create("sans-serif", Typeface.BOLD);
-        paint.setTypeface(valueFace);
+        paint.setTypeface(Typeface.create("sans-serif", Typeface.BOLD));
         paint.setColor(i4);
-        paint.setTextSize((expressive ? 54.0f : 48.0f) * fClampScale);
+        paint.setTextSize(48.0f * fClampScale);
         canvas.drawText(i < 0 ? "—" : clamp(i) + "%", iRound / 2.0f, 130.0f * fClampScale, paint);
-        paint.setTypeface(Typeface.create(expressive ? "sans-serif-medium" : "sans-serif-medium", 0));
-        paint.setTextSize((expressive ? 18.0f : 19.0f) * fClampScale);
-        paint.setColor(withAlpha(i4, expressive ? 0.78f : 0.68f));
+        paint.setTypeface(Typeface.create("sans-serif-medium", 0));
+        paint.setTextSize(19.0f * fClampScale);
+        paint.setColor(withAlpha(i4, 0.68f));
         if (str == null) {
             str = "";
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
@@ -96,22 +96,27 @@ public final class WidgetGraphics {
     public static Bitmap expressiveDial(int value, int progressColor, int trackColor, int textColor,
             String label, float scale) {
         float s = clampScale(scale);
+        // Tall canvas (~2.5:1): RemoteViews ImageViews top-align scaled bitmaps, so the
+        // dial is drawn mid-canvas and lands centered in typical 2x2 half-cells.
         int width = Math.round(200.0f * s);
-        int height = Math.round(172.0f * s);
+        int height = Math.round(500.0f * s);
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        bitmap.setDensity(160);
+        // Avoid mdpi density upscaling — RemoteViews would treat 160dpi bitmaps as huge
+        // and top-align the downscaled result, leaving a dead strip under the dials.
+        bitmap.setDensity(Bitmap.DENSITY_NONE);
         Canvas canvas = new Canvas(bitmap);
         Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeCap(Paint.Cap.ROUND);
-        float stroke = 22.0f * s;
+        float stroke = 20.0f * s;
         paint.setStrokeWidth(stroke);
-        float pad = stroke * 0.55f + 3.0f * s;
+        float pad = (stroke * 0.5f) + 6.0f * s;
         boolean hasLabel = label != null && !label.isEmpty();
-        float labelReserve = hasLabel ? 26.0f * s : 10.0f * s;
-        float arcSpan = Math.min(width - (pad * 2.0f), height - pad - labelReserve);
+        float labelReserve = hasLabel ? 30.0f * s : 14.0f * s;
+        float contentHeight = height - (pad * 2.0f);
+        float arcSpan = Math.min(width - (pad * 2.0f), contentHeight - labelReserve);
         float cx = width / 2.0f;
-        float cy = pad + (arcSpan / 2.0f);
+        float cy = (height - labelReserve) / 2.0f;
         RectF oval = new RectF(cx - (arcSpan / 2.0f), cy - (arcSpan / 2.0f),
                 cx + (arcSpan / 2.0f), cy + (arcSpan / 2.0f));
         final float arcStart = 150.0f;
@@ -135,15 +140,16 @@ public final class WidgetGraphics {
         paint.setTextAlign(Paint.Align.CENTER);
         paint.setTypeface(Typeface.create("sans-serif-black", Typeface.NORMAL));
         paint.setColor(textColor);
-        paint.setTextSize(40.0f * s);
+        paint.setTextSize(42.0f * s);
         Paint.FontMetrics fm = paint.getFontMetrics();
         float valueBaseline = cy - ((fm.ascent + fm.descent) / 2.0f);
         canvas.drawText(value < 0 ? "—" : clamp(value) + "%", cx, valueBaseline, paint);
         if (hasLabel) {
-            paint.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-            paint.setTextSize(15.0f * s);
-            paint.setColor(withAlpha(textColor, 0.72f));
-            canvas.drawText(label, cx, height - (6.0f * s), paint);
+            paint.setTypeface(Typeface.create("sans-serif-black", Typeface.NORMAL));
+            paint.setTextSize(18.0f * s);
+            paint.setColor(withAlpha(textColor, 0.78f));
+            canvas.drawText(label, cx, Math.min(height - (8.0f * s),
+                    oval.bottom + (22.0f * s)), paint);
         }
         return bitmap;
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
@@ -97,7 +97,7 @@ public final class WidgetGraphics {
             String label, float scale) {
         float s = clampScale(scale);
         // Compact canvas for 2x1 hosts. All strokes and labels remain inside the bitmap.
-        int width = Math.round(200.0f * s);
+        int width = Math.round(160.0f * s);
         int height = Math.round(158.0f * s);
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
         bitmap.setDensity(Bitmap.DENSITY_NONE);
@@ -110,9 +110,8 @@ public final class WidgetGraphics {
         float pad = (stroke * 0.5f) + 4.0f * s;
         boolean hasLabel = label != null && !label.isEmpty();
         float chipHeight = hasLabel ? 22.0f * s : 0.0f;
-        float chipGap = hasLabel ? 7.0f * s : 0.0f;
-        float arcSpan = Math.min(width - (pad * 2.0f),
-                height - (pad * 2.0f) - chipHeight - chipGap);
+        // The label chip occupies the dial's open bottom rather than shrinking the arc.
+        float arcSpan = Math.min(width - (pad * 2.0f), height - (pad * 2.0f));
         float cx = width / 2.0f;
         float cy = pad + (arcSpan / 2.0f);
         RectF oval = new RectF(cx - (arcSpan / 2.0f), cy - (arcSpan / 2.0f),
@@ -143,14 +142,14 @@ public final class WidgetGraphics {
         float valueBaseline = cy - ((fm.ascent + fm.descent) / 2.0f);
         canvas.drawText(value < 0 ? "—" : clamp(value) + "%", cx, valueBaseline, paint);
         if (hasLabel) {
-            float chipWidth = 44.0f * s;
+            float chipWidth = 50.0f * s;
             float chipTop = height - chipHeight - (2.0f * s);
             RectF chip = new RectF(cx - (chipWidth / 2.0f), chipTop,
                     cx + (chipWidth / 2.0f), chipTop + chipHeight);
             paint.setColor(withAlpha(progressColor, 0.14f));
             canvas.drawRoundRect(chip, chipHeight / 2.0f, chipHeight / 2.0f, paint);
             paint.setTypeface(Typeface.create("sans-serif-black", Typeface.NORMAL));
-            paint.setTextSize(13.0f * s);
+            paint.setTextSize(16.0f * s);
             paint.setColor(progressColor);
             Paint.FontMetrics chipFm = paint.getFontMetrics();
             float chipBaseline = chip.centerY() - ((chipFm.ascent + chipFm.descent) / 2.0f);

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java
@@ -6,16 +6,17 @@ import android.widget.Spinner;
 final class WidgetOptionCatalog {
     static final String[] THEME_LABELS = {"Follow system", "Dark", "Light"};
     static final String[] THEME_VALUES = {WidgetOptions.THEME_SYSTEM, WidgetOptions.THEME_DARK, WidgetOptions.THEME_LIGHT};
-    static final String[] SURFACE_LABELS = {"One UI"};
-    static final String[] SURFACE_VALUES = {WidgetOptions.SURFACE_ONE_UI};
+    static final String[] SURFACE_LABELS = {"One UI", "Material 3 Expressive"};
+    static final String[] SURFACE_VALUES = {
+            WidgetOptions.SURFACE_ONE_UI, WidgetOptions.SURFACE_MATERIAL};
     static final String[] STYLE_LABELS = {"Two usage dials"};
     static final String[] STYLE_VALUES = {WidgetOptions.STYLE_RINGS};
     static final String[] DENSITY_LABELS = {"Auto", "Compact", "Comfortable"};
     static final String[] DENSITY_VALUES = {"auto", "compact", WidgetOptions.DENSITY_COMFORTABLE};
     static final String[] GRAPHIC_LABELS = {"Fit automatically", "Large", "Maximum"};
     static final String[] GRAPHIC_VALUES = {"auto", WidgetOptions.GRAPHIC_LARGE, WidgetOptions.GRAPHIC_MAX};
-    static final String[] ACCENT_LABELS = {"Mint", "Blue", "Amber", "Violet", "Rose", "Cyan", "Lime", "Monochrome"};
-    static final String[] ACCENT_VALUES = {WidgetOptions.ACCENT_MINT, WidgetOptions.ACCENT_BLUE, WidgetOptions.ACCENT_AMBER, WidgetOptions.ACCENT_VIOLET, WidgetOptions.ACCENT_ROSE, WidgetOptions.ACCENT_CYAN, WidgetOptions.ACCENT_LIME, WidgetOptions.ACCENT_MONO};
+    static final String[] ACCENT_LABELS = {"Dynamic color", "Mint", "Blue", "Amber", "Violet", "Rose", "Cyan", "Lime", "Monochrome"};
+    static final String[] ACCENT_VALUES = {WidgetOptions.ACCENT_APP, WidgetOptions.ACCENT_MINT, WidgetOptions.ACCENT_BLUE, WidgetOptions.ACCENT_AMBER, WidgetOptions.ACCENT_VIOLET, WidgetOptions.ACCENT_ROSE, WidgetOptions.ACCENT_CYAN, WidgetOptions.ACCENT_LIME, WidgetOptions.ACCENT_MONO};
     static final String[] OPACITY_LABELS = {"15%", "40%", "70%", "94%"};
     static final int[] OPACITY_VALUES = {15, 40, 70, 94};
     static final String[] RESET_LABELS = {"Absolute time", "Relative time", "Both", "Hide reset time"};

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java
@@ -86,7 +86,8 @@ public final class WidgetOptions {
             boolean z3, boolean z4, boolean z5, boolean z6, boolean showPercentSymbol) {
         this.layout = normalizeStyle(str);
         this.density = oneOf(str2, "auto", "compact", DENSITY_COMFORTABLE) ? str2 : "auto";
-        this.surfaceStyle = oneOf(str3, SURFACE_MATERIAL, SURFACE_ONE_UI) ? str3 : SURFACE_MATERIAL;
+        this.surfaceStyle = oneOf(str3, SURFACE_MATERIAL, SURFACE_ONE_UI)
+                ? str3 : SURFACE_ONE_UI;
         this.graphicScale = oneOf(str4, "auto", GRAPHIC_LARGE, GRAPHIC_MAX) ? str4 : "auto";
         this.theme = oneOf(str5, THEME_SYSTEM, THEME_DARK, THEME_LIGHT) ? str5 : THEME_SYSTEM;
         this.accent = validAccent(str6) ? str6 : ACCENT_MINT;

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -59,7 +59,8 @@ public final class WidgetRenderer {
                     remoteViewsBuildViews = buildResponsiveWidget(context, i, widgetOptionsLoadWidgetOptions);
                 } else {
                     remoteViewsBuildViews = buildViews(context, i, widgetOptionsLoadWidgetOptions,
-                            styleForSize(context, appWidgetOptions), appWidgetOptions);
+                            styleForSize(context, widgetOptionsLoadWidgetOptions, appWidgetOptions),
+                            appWidgetOptions);
                 }
                 appWidgetManager.updateAppWidget(i, remoteViewsBuildViews);
             } catch (RuntimeException e) {
@@ -75,17 +76,22 @@ public final class WidgetRenderer {
     @SuppressLint({"NewApi", "UseRequiresApi"})
     private static RemoteViews buildResponsiveWidget(Context context, int i, WidgetOptions widgetOptions) {
         LinkedHashMap<SizeF, RemoteViews> linkedHashMap = new LinkedHashMap<>();
+        boolean material = isMaterial(widgetOptions);
         linkedHashMap.put(new SizeF(110.0f, 60.0f),
-                buildViews(context, i, widgetOptions, WidgetOptions.STYLE_RINGS,
+                buildViews(context, i, widgetOptions,
+                        material ? WidgetOptions.STYLE_MINIMAL : WidgetOptions.STYLE_RINGS,
                         sizeBundle(110, 70), GRAPHIC_STANDARD));
         linkedHashMap.put(new SizeF(250.0f, 60.0f),
-                buildViews(context, i, widgetOptions, STYLE_FOUR_DIALS,
+                buildViews(context, i, widgetOptions,
+                        material ? WidgetOptions.STYLE_MINIMAL : STYLE_FOUR_DIALS,
                         sizeBundle(250, 70), GRAPHIC_STANDARD));
         linkedHashMap.put(new SizeF(110.0f, 130.0f),
-                buildViews(context, i, widgetOptions, STYLE_BATTERY_LIST,
+                buildViews(context, i, widgetOptions,
+                        material ? WidgetOptions.STYLE_DIALS : STYLE_BATTERY_LIST,
                         sizeBundle(110, 156), GRAPHIC_STANDARD));
         linkedHashMap.put(new SizeF(250.0f, 130.0f),
-                buildViews(context, i, widgetOptions, STYLE_BATTERY_LIST,
+                buildViews(context, i, widgetOptions,
+                        material ? WidgetOptions.STYLE_DIALS : STYLE_BATTERY_LIST,
                         sizeBundle(250, 156), GRAPHIC_STANDARD));
         return new RemoteViews(linkedHashMap);
     }
@@ -93,14 +99,21 @@ public final class WidgetRenderer {
     static RemoteViews buildPreview(Context context, int appWidgetId, WidgetOptions widgetOptions,
             Bundle appWidgetOptions) {
         RemoteViews preview = buildViews(context, appWidgetId, widgetOptions,
-                styleForSize(context, appWidgetOptions), appWidgetOptions);
+                styleForSize(context, widgetOptions, appWidgetOptions), appWidgetOptions);
         preview.setInt(android.R.id.background, "setBackgroundColor", Color.TRANSPARENT);
         return preview;
     }
 
-    private static String styleForSize(Context context, Bundle bundle) {
+    private static String styleForSize(Context context, WidgetOptions options, Bundle bundle) {
         int rows = option(bundle, "semAppWidgetRowSpan");
         int columns = option(bundle, "semAppWidgetColumnSpan");
+        if (isMaterial(options)) {
+            if (rows > 0) {
+                return rows >= 2 ? WidgetOptions.STYLE_DIALS : WidgetOptions.STYLE_MINIMAL;
+            }
+            return currentHeight(context, bundle) >= 110
+                    ? WidgetOptions.STYLE_DIALS : WidgetOptions.STYLE_MINIMAL;
+        }
         if (rows > 0) {
             if (rows >= 2) {
                 return STYLE_BATTERY_LIST;
@@ -126,14 +139,16 @@ public final class WidgetRenderer {
     }
 
     private static RemoteViews buildViews(Context context, int i, WidgetOptions widgetOptions, String str, Bundle bundle, int i2) {
-        RemoteViews remoteViews = new RemoteViews(context.getPackageName(), layoutForStyle(str, i2));
+        RemoteViews remoteViews = new RemoteViews(context.getPackageName(),
+                layoutForStyle(str, i2, widgetOptions));
         boolean zChooseDark = chooseDark(context, widgetOptions);
         WidgetState widgetStateFrom = WidgetState.from(context, widgetOptions);
         applyRootAndHeader(context, remoteViews, i, widgetOptions, zChooseDark, widgetStateFrom);
         if (STYLE_MICRO.equals(str)) {
             renderMicro(remoteViews, widgetOptions, zChooseDark, widgetStateFrom);
         } else if (WidgetOptions.STYLE_RINGS.equals(str)) {
-            renderGraphic(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom, true, i2);
+            renderGraphic(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom,
+                    !isMaterial(widgetOptions), i2);
         } else if (STYLE_FOUR_DIALS.equals(str)) {
             renderFourDials(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom);
         } else if (STYLE_BATTERY_LIST.equals(str)) {
@@ -186,7 +201,11 @@ public final class WidgetRenderer {
         return (context == null || context.getResources().getConfiguration().orientation != GRAPHIC_MAX) ? iOption2 > 0 ? iOption2 : iOption : iOption > 0 ? iOption : iOption2;
     }
 
-    private static int layoutForStyle(String str, int i) {
+    private static int layoutForStyle(String str, int i, WidgetOptions options) {
+        if (isMaterial(options)) {
+            return WidgetOptions.STYLE_DIALS.equals(str)
+                    ? R.layout.widget_material_dials : R.layout.widget_material_compact;
+        }
         if (STYLE_BATTERY_LIST.equals(str)) {
             return R.layout.widget_battery_list;
         }
@@ -223,7 +242,13 @@ public final class WidgetRenderer {
     }
 
     private static void applyRootAndHeader(Context context, RemoteViews remoteViews, int i, WidgetOptions widgetOptions, boolean z, WidgetState widgetState) {
-        if (WidgetOptions.SURFACE_ONE_UI.equals(widgetOptions.surfaceStyle) && isSamsung(context)) {
+        if (isMaterial(widgetOptions) && Build.VERSION.SDK_INT >= 31) {
+            int alpha = Math.round(Math.max(0, Math.min(100, widgetOptions.opacity)) * 2.55f);
+            int surface = Ui.materialSurface(context, z);
+            remoteViews.setInt(android.R.id.background, "setBackgroundColor",
+                    Color.argb(alpha, Color.red(surface), Color.green(surface),
+                            Color.blue(surface)));
+        } else if (WidgetOptions.SURFACE_ONE_UI.equals(widgetOptions.surfaceStyle) && isSamsung(context)) {
             int alpha = Math.round(Math.max(0, Math.min(100, widgetOptions.opacity)) * 2.55f);
             remoteViews.setInt(android.R.id.background, "setBackgroundColor",
                     z ? Color.argb(alpha, 0, 0, 0) : Color.argb(alpha, 255, 255, 255));
@@ -231,12 +256,15 @@ public final class WidgetRenderer {
             remoteViews.setInt(android.R.id.background, "setBackgroundResource",
                     backgroundResource(context, z, widgetOptions.opacity, widgetOptions.surfaceStyle));
         }
-        remoteViews.setTextColor(R.id.widget_title, WidgetGraphics.mainTextColor(z));
+        remoteViews.setTextColor(R.id.widget_title, mainTextColor(context, widgetOptions, z));
         remoteViews.setViewVisibility(R.id.widget_title, widgetOptions.showTitle ? GRAPHIC_STANDARD : 8);
-        remoteViews.setTextColor(R.id.plan_label, mutedColor(z));
+        remoteViews.setTextColor(R.id.plan_label, mutedColor(context, widgetOptions, z));
         remoteViews.setTextViewText(R.id.plan_label, widgetState.plan);
         remoteViews.setViewVisibility(R.id.plan_label, (!widgetOptions.showPlan || widgetState.plan.isEmpty()) ? 8 : GRAPHIC_STANDARD);
-        remoteViews.setImageViewResource(R.id.refresh_button, z ? R.drawable.ic_oui_refresh_widget_light : R.drawable.ic_oui_refresh_widget_dark);
+        remoteViews.setImageViewResource(R.id.refresh_button, isMaterial(widgetOptions)
+                ? R.drawable.ic_refresh
+                : (z ? R.drawable.ic_oui_refresh_widget_light
+                        : R.drawable.ic_oui_refresh_widget_dark));
         remoteViews.setViewVisibility(R.id.refresh_button, widgetOptions.showRefresh ? GRAPHIC_STANDARD : 8);
         applyIntents(context, remoteViews, i);
     }
@@ -356,10 +384,10 @@ public final class WidgetRenderer {
     private static void renderMinimal(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState) {
         String str;
         int i = R.drawable.progress_track_light;
-        int iMainTextColor = WidgetGraphics.mainTextColor(z);
-        int iSecondaryColor = secondaryColor(z);
-        int iMutedColor = mutedColor(z);
-        int iFaintColor = faintColor(z);
+        int iMainTextColor = mainTextColor(context, widgetOptions, z);
+        int iSecondaryColor = secondaryColor(context, widgetOptions, z);
+        int iMutedColor = mutedColor(context, widgetOptions, z);
+        int iFaintColor = faintColor(context, widgetOptions, z);
         remoteViews.setTextColor(R.id.primary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.secondary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.primary_percent, iMainTextColor);
@@ -374,7 +402,7 @@ public final class WidgetRenderer {
         int iProgressResource = progressResource(widgetOptions.accent, z);
         remoteViews.setImageViewResource(R.id.primary_progress, iProgressResource);
         remoteViews.setImageViewResource(R.id.secondary_progress, iProgressResource);
-        applyAppAccentFilter(context, remoteViews, widgetOptions.accent,
+        applyAppAccentFilter(context, remoteViews, widgetOptions,
                 R.id.primary_progress, R.id.secondary_progress);
         remoteViews.setInt(R.id.primary_progress, "setImageLevel", Math.max(GRAPHIC_STANDARD, widgetState.primaryValue) * 100);
         remoteViews.setInt(R.id.secondary_progress, "setImageLevel", Math.max(GRAPHIC_STANDARD, widgetState.secondaryValue) * 100);
@@ -397,12 +425,12 @@ public final class WidgetRenderer {
 
     private static void renderGraphic(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState, boolean z2, int i) {
         float f;
-        int iMainTextColor = WidgetGraphics.mainTextColor(z);
-        int iSecondaryColor = secondaryColor(z);
-        int iMutedColor = mutedColor(z);
-        int iFaintColor = faintColor(z);
-        int iAccentColor = WidgetGraphics.accentColor(context, widgetOptions.accent, z);
-        int iTrackColor = WidgetGraphics.trackColor(z);
+        int iMainTextColor = mainTextColor(context, widgetOptions, z);
+        int iSecondaryColor = secondaryColor(context, widgetOptions, z);
+        int iMutedColor = mutedColor(context, widgetOptions, z);
+        int iFaintColor = faintColor(context, widgetOptions, z);
+        int iAccentColor = accentColor(context, widgetOptions, z);
+        int iTrackColor = trackColor(context, widgetOptions, z);
         String str = WidgetOptions.DISPLAY_USED.equals(widgetOptions.displayMode) ? WidgetOptions.DISPLAY_USED : "left";
         if (i == GRAPHIC_MAX) {
             f = 1.36f;
@@ -618,6 +646,19 @@ public final class WidgetRenderer {
         }
     }
 
+    private static void applyAppAccentFilter(Context context, RemoteViews views,
+            WidgetOptions options, int... viewIds) {
+        if (!WidgetOptions.ACCENT_APP.equals(options.accent)) {
+            return;
+        }
+        int color = isMaterial(options)
+                ? Ui.materialAccent(context, chooseDark(context, options))
+                : Ui.accent(context, Ui.isDark(context));
+        for (int viewId : viewIds) {
+            views.setInt(viewId, "setColorFilter", color);
+        }
+    }
+
     private static int backgroundResource(Context context, boolean z, int i, String str) {
         if (i == 0) {
             return R.drawable.widget_bg_transparent;
@@ -681,6 +722,52 @@ public final class WidgetRenderer {
         String str = Build.MANUFACTURER;
         String str2 = Build.BRAND;
         return (str != null && "samsung".equalsIgnoreCase(str)) || (str2 != null && "samsung".equalsIgnoreCase(str2));
+    }
+
+    private static boolean isMaterial(WidgetOptions options) {
+        return options != null
+                && WidgetOptions.SURFACE_MATERIAL.equals(options.surfaceStyle);
+    }
+
+    private static int mainTextColor(Context context, WidgetOptions options, boolean dark) {
+        return isMaterial(options)
+                ? Ui.materialOnSurface(context, dark) : WidgetGraphics.mainTextColor(dark);
+    }
+
+    private static int accentColor(Context context, WidgetOptions options, boolean dark) {
+        if (isMaterial(options) && WidgetOptions.ACCENT_APP.equals(options.accent)) {
+            return Ui.materialAccent(context, dark);
+        }
+        return WidgetGraphics.accentColor(context, options.accent, dark);
+    }
+
+    private static int trackColor(Context context, WidgetOptions options, boolean dark) {
+        if (!isMaterial(options)) {
+            return WidgetGraphics.trackColor(dark);
+        }
+        int foreground = Ui.materialOnSurface(context, dark);
+        return Color.argb(dark ? 74 : 48, Color.red(foreground), Color.green(foreground),
+                Color.blue(foreground));
+    }
+
+    private static int secondaryColor(Context context, WidgetOptions options, boolean dark) {
+        return isMaterial(options) ? withAlpha(mainTextColor(context, options, dark), 0.82f)
+                : secondaryColor(dark);
+    }
+
+    private static int mutedColor(Context context, WidgetOptions options, boolean dark) {
+        return isMaterial(options) ? withAlpha(mainTextColor(context, options, dark), 0.66f)
+                : mutedColor(dark);
+    }
+
+    private static int faintColor(Context context, WidgetOptions options, boolean dark) {
+        return isMaterial(options) ? withAlpha(mainTextColor(context, options, dark), 0.48f)
+                : faintColor(dark);
+    }
+
+    private static int withAlpha(int color, float alpha) {
+        return Color.argb(Math.round(255.0f * alpha), Color.red(color), Color.green(color),
+                Color.blue(color));
     }
 
     private static int secondaryColor(boolean z) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -93,6 +93,15 @@ public final class WidgetRenderer {
                 buildViews(context, i, widgetOptions,
                         material ? WidgetOptions.STYLE_DIALS : STYLE_BATTERY_LIST,
                         sizeBundle(250, 156), GRAPHIC_STANDARD));
+        if (material) {
+            // 3-row hosts switch to compact bars; keep 2-row on dials (SizeF 130).
+            linkedHashMap.put(new SizeF(110.0f, 260.0f),
+                    buildViews(context, i, widgetOptions, WidgetOptions.STYLE_MINIMAL,
+                            sizeBundle(110, 280), GRAPHIC_STANDARD));
+            linkedHashMap.put(new SizeF(250.0f, 260.0f),
+                    buildViews(context, i, widgetOptions, WidgetOptions.STYLE_MINIMAL,
+                            sizeBundle(250, 280), GRAPHIC_STANDARD));
+        }
         return new RemoteViews(linkedHashMap);
     }
 
@@ -108,11 +117,15 @@ public final class WidgetRenderer {
         int rows = option(bundle, "semAppWidgetRowSpan");
         int columns = option(bundle, "semAppWidgetColumnSpan");
         if (isMaterial(options)) {
-            if (rows > 0) {
-                return rows >= 2 ? WidgetOptions.STYLE_DIALS : WidgetOptions.STYLE_MINIMAL;
+            int height = currentHeight(context, bundle);
+            if (rows >= 3 || height >= 260) {
+                // 3-row+ hosts: expandable compact bars fill the cell cleanly.
+                return WidgetOptions.STYLE_MINIMAL;
             }
-            return currentHeight(context, bundle) >= 110
-                    ? WidgetOptions.STYLE_DIALS : WidgetOptions.STYLE_MINIMAL;
+            if (rows >= 2 || height >= 110) {
+                return WidgetOptions.STYLE_DIALS;
+            }
+            return WidgetOptions.STYLE_MINIMAL;
         }
         if (rows > 0) {
             if (rows >= 2) {
@@ -479,13 +492,14 @@ public final class WidgetRenderer {
             remoteViews.setInt(R.id.primary_samsung_icon, "setColorFilter", iMainTextColor);
             remoteViews.setInt(R.id.secondary_samsung_icon, "setColorFilter", iMainTextColor);
         } else if (isMaterial(widgetOptions)) {
-            // Metric chips live inside the dial bitmap so the arc can use the full cell.
+            // Fixed scale — host density already sizes the bitmap; oversized scales clip.
+            float materialScale = 1.1f;
             remoteViews.setImageViewBitmap(R.id.primary_graphic,
                     WidgetGraphics.expressiveDial(widgetState.primaryValue, iAccentColor, iTrackColor,
-                            iMainTextColor, "5H", fMin));
+                            iMainTextColor, "5H", materialScale));
             remoteViews.setImageViewBitmap(R.id.secondary_graphic,
                     WidgetGraphics.expressiveDial(widgetState.secondaryValue, iAccentColor,
-                            iTrackColor, iMainTextColor, "WK", fMin));
+                            iTrackColor, iMainTextColor, "WK", materialScale));
         } else {
             remoteViews.setImageViewBitmap(R.id.primary_graphic, WidgetGraphics.dial(widgetState.primaryValue, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
             remoteViews.setImageViewBitmap(R.id.secondary_graphic, WidgetGraphics.dial(widgetState.secondaryValue, iAccentColor, iTrackColor, iMainTextColor, str, fMin));

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -514,8 +514,8 @@ public final class WidgetRenderer {
         remoteViews.setTextViewText(R.id.primary_label, isMaterial(widgetOptions) ? "5H" : "5-hour");
         remoteViews.setTextViewText(R.id.secondary_label, isMaterial(widgetOptions) ? "WK" : "Weekly");
         if (isMaterial(widgetOptions)) {
-            remoteViews.setViewVisibility(R.id.primary_label, GRAPHIC_STANDARD);
-            remoteViews.setViewVisibility(R.id.secondary_label, GRAPHIC_STANDARD);
+            remoteViews.setViewVisibility(R.id.primary_label, View.VISIBLE);
+            remoteViews.setViewVisibility(R.id.secondary_label, View.VISIBLE);
             if (Build.VERSION.SDK_INT >= 31) {
                 remoteViews.setColorStateList(R.id.primary_label, "setBackgroundTintList",
                         ColorStateList.valueOf(Ui.primaryContainer(context, z)));
@@ -523,8 +523,8 @@ public final class WidgetRenderer {
                         ColorStateList.valueOf(Ui.secondaryContainer(context, z)));
             }
         } else {
-            remoteViews.setViewVisibility(R.id.primary_label, 8);
-            remoteViews.setViewVisibility(R.id.secondary_label, 8);
+            remoteViews.setViewVisibility(R.id.primary_label, View.GONE);
+            remoteViews.setViewVisibility(R.id.secondary_label, View.GONE);
         }
         remoteViews.setTextViewText(R.id.primary_reset, widgetState.primaryShortReset);
         remoteViews.setTextViewText(R.id.secondary_reset, widgetState.secondaryShortReset);
@@ -644,12 +644,12 @@ public final class WidgetRenderer {
         boolean z3 = widgetOptions.showResetCredits;
         boolean z4 = widgetOptions.showResetAction && i2 > 0 && SecureTokenStore.isSignedIn(context);
         if (!z3 && !z4) {
-            remoteViews.setViewVisibility(R.id.reset_credit_row, 8);
+            remoteViews.setViewVisibility(R.id.reset_credit_row, View.GONE);
             return;
         }
-        remoteViews.setViewVisibility(R.id.reset_credit_row, GRAPHIC_STANDARD);
-        remoteViews.setViewVisibility(R.id.reset_credit_info, z3 ? GRAPHIC_STANDARD : 8);
-        remoteViews.setViewVisibility(R.id.reset_credit_button, z4 ? GRAPHIC_STANDARD : 8);
+        remoteViews.setViewVisibility(R.id.reset_credit_row, View.VISIBLE);
+        remoteViews.setViewVisibility(R.id.reset_credit_info, z3 ? View.VISIBLE : View.GONE);
+        remoteViews.setViewVisibility(R.id.reset_credit_button, z4 ? View.VISIBLE : View.GONE);
         if (i2 <= 0) {
             str2 = "No reset credits";
         } else if (jNextExpiryMillis > 0) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -104,6 +104,21 @@ public final class WidgetRenderer {
         return preview;
     }
 
+    /** In-app Material showcase — keeps the expressive rounded surface. */
+    static RemoteViews buildMaterialShowcase(Context context, String style, int widthDp,
+            int heightDp) {
+        WidgetOptions options = new WidgetOptions(style, WidgetOptions.DENSITY_COMFORTABLE,
+                WidgetOptions.SURFACE_MATERIAL, WidgetOptions.GRAPHIC_LARGE,
+                WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_APP, 100,
+                WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING, "both",
+                false, false, false, false, false, false);
+        Bundle size = sizeBundle(widthDp, heightDp);
+        String resolved = WidgetOptions.STYLE_DIALS.equals(style)
+                ? WidgetOptions.STYLE_DIALS : WidgetOptions.STYLE_MINIMAL;
+        return buildViews(context, AppWidgetManager.INVALID_APPWIDGET_ID, options, resolved, size,
+                GRAPHIC_LARGE);
+    }
+
     private static String styleForSize(Context context, WidgetOptions options, Bundle bundle) {
         int rows = option(bundle, "semAppWidgetRowSpan");
         int columns = option(bundle, "semAppWidgetColumnSpan");
@@ -478,19 +493,39 @@ public final class WidgetRenderer {
             remoteViews.setTextColor(R.id.secondary_samsung_value, iMainTextColor);
             remoteViews.setInt(R.id.primary_samsung_icon, "setColorFilter", iMainTextColor);
             remoteViews.setInt(R.id.secondary_samsung_icon, "setColorFilter", iMainTextColor);
+        } else if (isMaterial(widgetOptions)) {
+            remoteViews.setImageViewBitmap(R.id.primary_graphic,
+                    WidgetGraphics.expressiveDial(widgetState.primaryValue, iAccentColor, iTrackColor,
+                            iMainTextColor, str, fMin));
+            remoteViews.setImageViewBitmap(R.id.secondary_graphic,
+                    WidgetGraphics.expressiveDial(widgetState.secondaryValue, iAccentColor,
+                            iTrackColor, iMainTextColor, str, fMin));
         } else {
             remoteViews.setImageViewBitmap(R.id.primary_graphic, WidgetGraphics.dial(widgetState.primaryValue, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
             remoteViews.setImageViewBitmap(R.id.secondary_graphic, WidgetGraphics.dial(widgetState.secondaryValue, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
         }
-        remoteViews.setTextColor(R.id.primary_label, iSecondaryColor);
-        remoteViews.setTextColor(R.id.secondary_label, iSecondaryColor);
+        remoteViews.setTextColor(R.id.primary_label,
+                isMaterial(widgetOptions) ? Ui.onPrimaryContainer(context, z) : iSecondaryColor);
+        remoteViews.setTextColor(R.id.secondary_label,
+                isMaterial(widgetOptions) ? Ui.onSecondaryContainer(context, z) : iSecondaryColor);
         remoteViews.setTextColor(R.id.primary_reset, iMutedColor);
         remoteViews.setTextColor(R.id.secondary_reset, iMutedColor);
         remoteViews.setTextColor(R.id.updated_label, iFaintColor);
-        remoteViews.setTextViewText(R.id.primary_label, "5-hour");
-        remoteViews.setTextViewText(R.id.secondary_label, "Weekly");
-        remoteViews.setViewVisibility(R.id.primary_label, 8);
-        remoteViews.setViewVisibility(R.id.secondary_label, 8);
+        remoteViews.setTextViewText(R.id.primary_label, isMaterial(widgetOptions) ? "5H" : "5-hour");
+        remoteViews.setTextViewText(R.id.secondary_label, isMaterial(widgetOptions) ? "WK" : "Weekly");
+        if (isMaterial(widgetOptions)) {
+            remoteViews.setViewVisibility(R.id.primary_label, GRAPHIC_STANDARD);
+            remoteViews.setViewVisibility(R.id.secondary_label, GRAPHIC_STANDARD);
+            if (Build.VERSION.SDK_INT >= 31) {
+                remoteViews.setColorStateList(R.id.primary_label, "setBackgroundTintList",
+                        ColorStateList.valueOf(Ui.primaryContainer(context, z)));
+                remoteViews.setColorStateList(R.id.secondary_label, "setBackgroundTintList",
+                        ColorStateList.valueOf(Ui.secondaryContainer(context, z)));
+            }
+        } else {
+            remoteViews.setViewVisibility(R.id.primary_label, 8);
+            remoteViews.setViewVisibility(R.id.secondary_label, 8);
+        }
         remoteViews.setTextViewText(R.id.primary_reset, widgetState.primaryShortReset);
         remoteViews.setTextViewText(R.id.secondary_reset, widgetState.secondaryShortReset);
         remoteViews.setViewVisibility(R.id.primary_reset, 8);
@@ -876,7 +911,9 @@ public final class WidgetRenderer {
             boolean zIsSignedIn = SecureTokenStore.isSignedIn(context);
             UsageSnapshot usageSnapshotLoadSnapshot = AppPreferences.loadSnapshot(context);
             long jCurrentTimeMillis = System.currentTimeMillis();
-            if (!zIsSignedIn) {
+            // Prefer cached snapshot when present so Material/home widgets stay glanceable
+            // after a session drop or during demos — only show Sign in when there is no cache.
+            if (!zIsSignedIn && usageSnapshotLoadSnapshot == null) {
                 return new WidgetState("", -1, -1, "Sign in", "—", "SIGN IN", "—", "Open the app to connect ChatGPT", "", "Tap to connect", "", "Open the app to connect ChatGPT", "Tap anywhere to sign in", "—", 0);
             }
             if (usageSnapshotLoadSnapshot == null) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -104,21 +104,6 @@ public final class WidgetRenderer {
         return preview;
     }
 
-    /** In-app Material showcase — keeps the expressive rounded surface. */
-    static RemoteViews buildMaterialShowcase(Context context, String style, int widthDp,
-            int heightDp) {
-        WidgetOptions options = new WidgetOptions(style, WidgetOptions.DENSITY_COMFORTABLE,
-                WidgetOptions.SURFACE_MATERIAL, WidgetOptions.GRAPHIC_LARGE,
-                WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_APP, 100,
-                WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING, "both",
-                false, false, false, false, false, false);
-        Bundle size = sizeBundle(widthDp, heightDp);
-        String resolved = WidgetOptions.STYLE_DIALS.equals(style)
-                ? WidgetOptions.STYLE_DIALS : WidgetOptions.STYLE_MINIMAL;
-        return buildViews(context, AppWidgetManager.INVALID_APPWIDGET_ID, options, resolved, size,
-                GRAPHIC_LARGE);
-    }
-
     private static String styleForSize(Context context, WidgetOptions options, Bundle bundle) {
         int rows = option(bundle, "semAppWidgetRowSpan");
         int columns = option(bundle, "semAppWidgetColumnSpan");
@@ -494,38 +479,26 @@ public final class WidgetRenderer {
             remoteViews.setInt(R.id.primary_samsung_icon, "setColorFilter", iMainTextColor);
             remoteViews.setInt(R.id.secondary_samsung_icon, "setColorFilter", iMainTextColor);
         } else if (isMaterial(widgetOptions)) {
+            // Metric chips live inside the dial bitmap so the arc can use the full cell.
             remoteViews.setImageViewBitmap(R.id.primary_graphic,
                     WidgetGraphics.expressiveDial(widgetState.primaryValue, iAccentColor, iTrackColor,
-                            iMainTextColor, str, fMin));
+                            iMainTextColor, "5H", fMin));
             remoteViews.setImageViewBitmap(R.id.secondary_graphic,
                     WidgetGraphics.expressiveDial(widgetState.secondaryValue, iAccentColor,
-                            iTrackColor, iMainTextColor, str, fMin));
+                            iTrackColor, iMainTextColor, "WK", fMin));
         } else {
             remoteViews.setImageViewBitmap(R.id.primary_graphic, WidgetGraphics.dial(widgetState.primaryValue, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
             remoteViews.setImageViewBitmap(R.id.secondary_graphic, WidgetGraphics.dial(widgetState.secondaryValue, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
         }
-        remoteViews.setTextColor(R.id.primary_label,
-                isMaterial(widgetOptions) ? Ui.onPrimaryContainer(context, z) : iSecondaryColor);
-        remoteViews.setTextColor(R.id.secondary_label,
-                isMaterial(widgetOptions) ? Ui.onSecondaryContainer(context, z) : iSecondaryColor);
+        remoteViews.setTextColor(R.id.primary_label, iSecondaryColor);
+        remoteViews.setTextColor(R.id.secondary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.primary_reset, iMutedColor);
         remoteViews.setTextColor(R.id.secondary_reset, iMutedColor);
         remoteViews.setTextColor(R.id.updated_label, iFaintColor);
-        remoteViews.setTextViewText(R.id.primary_label, isMaterial(widgetOptions) ? "5H" : "5-hour");
-        remoteViews.setTextViewText(R.id.secondary_label, isMaterial(widgetOptions) ? "WK" : "Weekly");
-        if (isMaterial(widgetOptions)) {
-            remoteViews.setViewVisibility(R.id.primary_label, View.VISIBLE);
-            remoteViews.setViewVisibility(R.id.secondary_label, View.VISIBLE);
-            if (Build.VERSION.SDK_INT >= 31) {
-                remoteViews.setColorStateList(R.id.primary_label, "setBackgroundTintList",
-                        ColorStateList.valueOf(Ui.primaryContainer(context, z)));
-                remoteViews.setColorStateList(R.id.secondary_label, "setBackgroundTintList",
-                        ColorStateList.valueOf(Ui.secondaryContainer(context, z)));
-            }
-        } else {
-            remoteViews.setViewVisibility(R.id.primary_label, View.GONE);
-            remoteViews.setViewVisibility(R.id.secondary_label, View.GONE);
-        }
+        remoteViews.setTextViewText(R.id.primary_label, "5-hour");
+        remoteViews.setTextViewText(R.id.secondary_label, "Weekly");
+        remoteViews.setViewVisibility(R.id.primary_label, View.GONE);
+        remoteViews.setViewVisibility(R.id.secondary_label, View.GONE);
         remoteViews.setTextViewText(R.id.primary_reset, widgetState.primaryShortReset);
         remoteViews.setTextViewText(R.id.secondary_reset, widgetState.secondaryShortReset);
         remoteViews.setViewVisibility(R.id.primary_reset, 8);

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -242,12 +242,17 @@ public final class WidgetRenderer {
     }
 
     private static void applyRootAndHeader(Context context, RemoteViews remoteViews, int i, WidgetOptions widgetOptions, boolean z, WidgetState widgetState) {
-        if (isMaterial(widgetOptions) && Build.VERSION.SDK_INT >= 31) {
-            int alpha = Math.round(Math.max(0, Math.min(100, widgetOptions.opacity)) * 2.55f);
-            int surface = Ui.materialSurface(context, z);
-            remoteViews.setInt(android.R.id.background, "setBackgroundColor",
-                    Color.argb(alpha, Color.red(surface), Color.green(surface),
-                            Color.blue(surface)));
+        if (isMaterial(widgetOptions)) {
+            // Keep the 32dp expressive round rect — flat setBackgroundColor kills the shape.
+            remoteViews.setInt(android.R.id.background, "setBackgroundResource",
+                    R.drawable.widget_bg_material_round);
+            if (Build.VERSION.SDK_INT >= 31) {
+                int alpha = Math.round(Math.max(0, Math.min(100, widgetOptions.opacity)) * 2.55f);
+                int surface = Ui.materialSurface(context, z);
+                remoteViews.setColorStateList(android.R.id.background, "setBackgroundTintList",
+                        ColorStateList.valueOf(Color.argb(alpha, Color.red(surface),
+                                Color.green(surface), Color.blue(surface))));
+            }
         } else if (WidgetOptions.SURFACE_ONE_UI.equals(widgetOptions.surfaceStyle) && isSamsung(context)) {
             int alpha = Math.round(Math.max(0, Math.min(100, widgetOptions.opacity)) * 2.55f);
             remoteViews.setInt(android.R.id.background, "setBackgroundColor",
@@ -388,17 +393,35 @@ public final class WidgetRenderer {
         int iSecondaryColor = secondaryColor(context, widgetOptions, z);
         int iMutedColor = mutedColor(context, widgetOptions, z);
         int iFaintColor = faintColor(context, widgetOptions, z);
-        remoteViews.setTextColor(R.id.primary_label, iSecondaryColor);
-        remoteViews.setTextColor(R.id.secondary_label, iSecondaryColor);
+        boolean material = isMaterial(widgetOptions);
+        remoteViews.setTextColor(R.id.primary_label,
+                material ? Ui.onPrimaryContainer(context, z) : iSecondaryColor);
+        remoteViews.setTextColor(R.id.secondary_label,
+                material ? Ui.onSecondaryContainer(context, z) : iSecondaryColor);
         remoteViews.setTextColor(R.id.primary_percent, iMainTextColor);
         remoteViews.setTextColor(R.id.secondary_percent, iMainTextColor);
         remoteViews.setTextColor(R.id.primary_reset, iMutedColor);
         remoteViews.setTextColor(R.id.updated_label, iFaintColor);
-        remoteViews.setImageViewResource(R.id.primary_track, z ? R.drawable.progress_track : R.drawable.progress_track_light);
-        if (z) {
-            i = R.drawable.progress_track;
+        if (material) {
+            remoteViews.setImageViewResource(R.id.primary_track,
+                    z ? R.drawable.progress_track_material_dark : R.drawable.progress_track_material);
+            remoteViews.setImageViewResource(R.id.secondary_track,
+                    z ? R.drawable.progress_track_material_dark : R.drawable.progress_track_material);
+            if (Build.VERSION.SDK_INT >= 31) {
+                remoteViews.setColorStateList(R.id.primary_label, "setBackgroundTintList",
+                        ColorStateList.valueOf(Ui.primaryContainer(context, z)));
+                remoteViews.setColorStateList(R.id.secondary_label, "setBackgroundTintList",
+                        ColorStateList.valueOf(Ui.secondaryContainer(context, z)));
+            }
+            remoteViews.setTextViewTextSize(R.id.primary_percent, GRAPHIC_MAX, 22.0f);
+            remoteViews.setTextViewTextSize(R.id.secondary_percent, GRAPHIC_MAX, 22.0f);
+        } else {
+            remoteViews.setImageViewResource(R.id.primary_track, z ? R.drawable.progress_track : R.drawable.progress_track_light);
+            if (z) {
+                i = R.drawable.progress_track;
+            }
+            remoteViews.setImageViewResource(R.id.secondary_track, i);
         }
-        remoteViews.setImageViewResource(R.id.secondary_track, i);
         int iProgressResource = progressResource(widgetOptions.accent, z);
         remoteViews.setImageViewResource(R.id.primary_progress, iProgressResource);
         remoteViews.setImageViewResource(R.id.secondary_progress, iProgressResource);
@@ -406,8 +429,8 @@ public final class WidgetRenderer {
                 R.id.primary_progress, R.id.secondary_progress);
         remoteViews.setInt(R.id.primary_progress, "setImageLevel", Math.max(GRAPHIC_STANDARD, widgetState.primaryValue) * 100);
         remoteViews.setInt(R.id.secondary_progress, "setImageLevel", Math.max(GRAPHIC_STANDARD, widgetState.secondaryValue) * 100);
-        remoteViews.setTextViewText(R.id.primary_label, "5h");
-        remoteViews.setTextViewText(R.id.secondary_label, "Week");
+        remoteViews.setTextViewText(R.id.primary_label, material ? "5H" : "5h");
+        remoteViews.setTextViewText(R.id.secondary_label, material ? "WK" : "Week");
         remoteViews.setTextViewText(R.id.primary_percent, widgetState.primaryShort);
         remoteViews.setTextViewText(R.id.secondary_percent, widgetState.secondaryShort);
         if ("five_hour".equals(widgetOptions.metricMode)) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -79,22 +79,22 @@ public final class WidgetRenderer {
         boolean material = isMaterial(widgetOptions);
         linkedHashMap.put(new SizeF(110.0f, 60.0f),
                 buildViews(context, i, widgetOptions,
-                        material ? WidgetOptions.STYLE_MINIMAL : WidgetOptions.STYLE_RINGS,
+                        material ? WidgetOptions.STYLE_DIALS : WidgetOptions.STYLE_RINGS,
                         sizeBundle(110, 70), GRAPHIC_STANDARD));
         linkedHashMap.put(new SizeF(250.0f, 60.0f),
                 buildViews(context, i, widgetOptions,
-                        material ? WidgetOptions.STYLE_MINIMAL : STYLE_FOUR_DIALS,
+                        material ? WidgetOptions.STYLE_DIALS : STYLE_FOUR_DIALS,
                         sizeBundle(250, 70), GRAPHIC_STANDARD));
         linkedHashMap.put(new SizeF(110.0f, 130.0f),
                 buildViews(context, i, widgetOptions,
-                        material ? WidgetOptions.STYLE_DIALS : STYLE_BATTERY_LIST,
+                        material ? WidgetOptions.STYLE_MINIMAL : STYLE_BATTERY_LIST,
                         sizeBundle(110, 156), GRAPHIC_STANDARD));
         linkedHashMap.put(new SizeF(250.0f, 130.0f),
                 buildViews(context, i, widgetOptions,
-                        material ? WidgetOptions.STYLE_DIALS : STYLE_BATTERY_LIST,
+                        material ? WidgetOptions.STYLE_MINIMAL : STYLE_BATTERY_LIST,
                         sizeBundle(250, 156), GRAPHIC_STANDARD));
         if (material) {
-            // 3-row hosts switch to compact bars; keep 2-row on dials (SizeF 130).
+            // Larger Material hosts keep the same expandable two-row bar treatment.
             linkedHashMap.put(new SizeF(110.0f, 260.0f),
                     buildViews(context, i, widgetOptions, WidgetOptions.STYLE_MINIMAL,
                             sizeBundle(110, 280), GRAPHIC_STANDARD));
@@ -117,15 +117,12 @@ public final class WidgetRenderer {
         int rows = option(bundle, "semAppWidgetRowSpan");
         int columns = option(bundle, "semAppWidgetColumnSpan");
         if (isMaterial(options)) {
-            int height = currentHeight(context, bundle);
-            if (rows >= 3 || height >= 260) {
-                // 3-row+ hosts: expandable compact bars fill the cell cleanly.
-                return WidgetOptions.STYLE_MINIMAL;
+            if (rows > 0) {
+                return rows >= 2
+                        ? WidgetOptions.STYLE_MINIMAL : WidgetOptions.STYLE_DIALS;
             }
-            if (rows >= 2 || height >= 110) {
-                return WidgetOptions.STYLE_DIALS;
-            }
-            return WidgetOptions.STYLE_MINIMAL;
+            return currentHeight(context, bundle) >= 110
+                    ? WidgetOptions.STYLE_MINIMAL : WidgetOptions.STYLE_DIALS;
         }
         if (rows > 0) {
             if (rows >= 2) {

--- a/android/app/src/main/res/drawable/chip_material_label.xml
+++ b/android/app/src/main/res/drawable/chip_material_label.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="999dp" />
+    <solid android:color="#FFFFFFFF" />
+    <padding
+        android:left="8dp"
+        android:top="2dp"
+        android:right="8dp"
+        android:bottom="2dp" />
+</shape>

--- a/android/app/src/main/res/drawable/progress_track_material.xml
+++ b/android/app/src/main/res/drawable/progress_track_material.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="999dp" />
+    <solid android:color="#3A000000" />
+</shape>

--- a/android/app/src/main/res/drawable/progress_track_material_dark.xml
+++ b/android/app/src/main/res/drawable/progress_track_material_dark.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="999dp" />
+    <solid android:color="#52FFFFFF" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_bg_material_round.xml
+++ b/android/app/src/main/res/drawable/widget_bg_material_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="32dp" />
+    <solid android:color="#FFFFFFFF" />
+</shape>

--- a/android/app/src/main/res/layout/activity_material_dashboard.xml
+++ b/android/app/src/main/res/layout/activity_material_dashboard.xml
@@ -8,9 +8,9 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/material_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="88dp"
+        android:layout_height="64dp"
         android:contentInsetStartWithNavigation="8dp"
-        android:minHeight="72dp"
+        android:minHeight="64dp"
         android:paddingStart="4dp"
         android:paddingEnd="8dp" />
 

--- a/android/app/src/main/res/layout/activity_material_dashboard.xml
+++ b/android/app/src/main/res/layout/activity_material_dashboard.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/material_page_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/material_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="72dp"
+        android:contentInsetStartWithNavigation="8dp"
+        android:minHeight="64dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="12dp" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/dashboard_refresh"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/dashboard_scroll"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:fillViewport="true"
+            android:overScrollMode="ifContentScrolls">
+
+            <LinearLayout
+                android:id="@+id/dashboard_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingStart="20dp"
+                android:paddingTop="12dp"
+                android:paddingEnd="20dp"
+                android:paddingBottom="36dp" />
+        </androidx.core.widget.NestedScrollView>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/activity_material_dashboard.xml
+++ b/android/app/src/main/res/layout/activity_material_dashboard.xml
@@ -8,11 +8,11 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/material_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="88dp"
         android:contentInsetStartWithNavigation="8dp"
-        android:minHeight="64dp"
-        android:paddingStart="8dp"
-        android:paddingEnd="12dp" />
+        android:minHeight="72dp"
+        android:paddingStart="4dp"
+        android:paddingEnd="8dp" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/dashboard_refresh"
@@ -33,10 +33,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingStart="20dp"
-                android:paddingTop="12dp"
-                android:paddingEnd="20dp"
-                android:paddingBottom="36dp" />
+                android:paddingStart="16dp"
+                android:paddingTop="8dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="40dp" />
         </androidx.core.widget.NestedScrollView>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/activity_material_settings.xml
+++ b/android/app/src/main/res/layout/activity_material_settings.xml
@@ -8,9 +8,9 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/material_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="88dp"
+        android:layout_height="64dp"
         android:contentInsetStartWithNavigation="8dp"
-        android:minHeight="72dp"
+        android:minHeight="64dp"
         android:paddingStart="4dp"
         android:paddingEnd="8dp" />
 

--- a/android/app/src/main/res/layout/activity_material_settings.xml
+++ b/android/app/src/main/res/layout/activity_material_settings.xml
@@ -8,11 +8,11 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/material_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="88dp"
         android:contentInsetStartWithNavigation="8dp"
-        android:minHeight="64dp"
-        android:paddingStart="8dp"
-        android:paddingEnd="12dp" />
+        android:minHeight="72dp"
+        android:paddingStart="4dp"
+        android:paddingEnd="8dp" />
 
     <FrameLayout
         android:id="@+id/settings_fragment"

--- a/android/app/src/main/res/layout/activity_material_settings.xml
+++ b/android/app/src/main/res/layout/activity_material_settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/material_settings_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/material_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="72dp"
+        android:contentInsetStartWithNavigation="8dp"
+        android:minHeight="64dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="12dp" />
+
+    <FrameLayout
+        android:id="@+id/settings_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/activity_material_widget_settings.xml
+++ b/android/app/src/main/res/layout/activity_material_widget_settings.xml
@@ -8,9 +8,9 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/material_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="88dp"
+        android:layout_height="64dp"
         android:contentInsetStartWithNavigation="8dp"
-        android:minHeight="72dp"
+        android:minHeight="64dp"
         android:paddingStart="4dp"
         android:paddingEnd="8dp" />
 

--- a/android/app/src/main/res/layout/activity_material_widget_settings.xml
+++ b/android/app/src/main/res/layout/activity_material_widget_settings.xml
@@ -14,72 +14,68 @@
         android:paddingStart="4dp"
         android:paddingEnd="8dp" />
 
-    <FrameLayout
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/widget_settings_scroll"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1">
-
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/widget_settings_scroll"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:fillViewport="true"
-            android:overScrollMode="ifContentScrolls"
-            android:paddingStart="20dp"
-            android:paddingEnd="20dp"
-            android:paddingBottom="104dp">
-
-            <LinearLayout
-                android:id="@+id/widget_settings_content"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <FrameLayout
-                    android:id="@+id/widget_preview_container"
-                    android:layout_width="match_parent"
-                    android:layout_height="236dp"
-                    android:layout_marginTop="8dp" />
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:fillViewport="true"
+        android:overScrollMode="ifContentScrolls"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="24dp">
 
         <LinearLayout
-            android:id="@+id/config_button_bar"
-            android:layout_width="wrap_content"
+            android:id="@+id/widget_settings_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="bottom|center_horizontal"
-            android:layout_marginBottom="16dp"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/config_cancel"
-                android:layout_width="wrap_content"
-                android:layout_height="56dp"
-                android:background="?android:attr/selectableItemBackground"
-                android:clickable="true"
-                android:focusable="true"
-                android:fontFamily="sans-serif-medium"
-                android:gravity="center"
-                android:minWidth="112dp"
-                android:paddingHorizontal="24dp"
-                android:text="@string/widget_config_cancel"
-                android:textSize="15sp" />
-
-            <TextView
-                android:id="@+id/config_save"
-                android:layout_width="wrap_content"
-                android:layout_height="56dp"
-                android:layout_marginStart="8dp"
-                android:clickable="true"
-                android:focusable="true"
-                android:fontFamily="sans-serif-medium"
-                android:gravity="center"
-                android:minWidth="112dp"
-                android:paddingHorizontal="24dp"
-                android:text="@string/widget_config_save"
-                android:textSize="15sp" />
+            <FrameLayout
+                android:id="@+id/widget_preview_container"
+                android:layout_width="match_parent"
+                android:layout_height="236dp"
+                android:layout_marginTop="8dp" />
         </LinearLayout>
-    </FrameLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:id="@+id/config_button_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="16dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/config_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="56dp"
+            android:background="?android:attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center"
+            android:minWidth="112dp"
+            android:paddingHorizontal="24dp"
+            android:text="@string/widget_config_cancel"
+            android:textSize="15sp" />
+
+        <TextView
+            android:id="@+id/config_save"
+            android:layout_width="wrap_content"
+            android:layout_height="56dp"
+            android:layout_marginStart="8dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center"
+            android:minWidth="112dp"
+            android:paddingHorizontal="24dp"
+            android:text="@string/widget_config_save"
+            android:textSize="15sp" />
+    </LinearLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/activity_material_widget_settings.xml
+++ b/android/app/src/main/res/layout/activity_material_widget_settings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/material_widget_settings_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/material_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="72dp"
+        android:contentInsetStartWithNavigation="8dp"
+        android:minHeight="64dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="12dp" />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/widget_settings_scroll"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:fillViewport="true"
+            android:overScrollMode="ifContentScrolls"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:paddingBottom="104dp">
+
+            <LinearLayout
+                android:id="@+id/widget_settings_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <FrameLayout
+                    android:id="@+id/widget_preview_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="236dp"
+                    android:layout_marginTop="8dp" />
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+
+        <LinearLayout
+            android:id="@+id/config_button_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_marginBottom="16dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/config_cancel"
+                android:layout_width="wrap_content"
+                android:layout_height="56dp"
+                android:background="?android:attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center"
+                android:minWidth="112dp"
+                android:paddingHorizontal="24dp"
+                android:text="@string/widget_config_cancel"
+                android:textSize="15sp" />
+
+            <TextView
+                android:id="@+id/config_save"
+                android:layout_width="wrap_content"
+                android:layout_height="56dp"
+                android:layout_marginStart="8dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center"
+                android:minWidth="112dp"
+                android:paddingHorizontal="24dp"
+                android:text="@string/widget_config_save"
+                android:textSize="15sp" />
+        </LinearLayout>
+    </FrameLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/activity_material_widget_settings.xml
+++ b/android/app/src/main/res/layout/activity_material_widget_settings.xml
@@ -8,11 +8,11 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/material_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="88dp"
         android:contentInsetStartWithNavigation="8dp"
-        android:minHeight="64dp"
-        android:paddingStart="8dp"
-        android:paddingEnd="12dp" />
+        android:minHeight="72dp"
+        android:paddingStart="4dp"
+        android:paddingEnd="8dp" />
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/preference_account_card.xml
+++ b/android/app/src/main/res/layout/preference_account_card.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<dev.oneuiproject.oneui.widget.RoundedLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/settings_account_card"
     android:layout_width="match_parent"
@@ -68,6 +68,7 @@
     </LinearLayout>
 
     <View
+        android:id="@+id/settings_account_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginStart="20dp"
@@ -83,4 +84,4 @@
         app:showTopDivider="false"
         app:title="Sign out" />
 
-</dev.oneuiproject.oneui.widget.RoundedLinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_material_compact.xml
+++ b/android/app/src/main/res/layout/widget_material_compact.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/widget_bg_material_round"
-    android:padding="10dp">
+    android:padding="14dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -28,14 +28,14 @@
                 android:fontFamily="sans-serif-black"
                 android:includeFontPadding="false"
                 android:text="@string/widget_sample_five_hour_short"
-                android:textSize="12sp"
+                android:textSize="13sp"
                 android:textStyle="bold" />
 
             <FrameLayout
                 android:layout_width="0dp"
-                android:layout_height="16dp"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
+                android:layout_height="18dp"
+                android:layout_marginStart="10dp"
+                android:layout_marginEnd="10dp"
                 android:layout_weight="1">
 
                 <ImageView
@@ -65,7 +65,7 @@
                 android:includeFontPadding="false"
                 android:maxLines="1"
                 android:text="@string/widget_sample_primary_percent_short"
-                android:textSize="20sp"
+                android:textSize="22sp"
                 android:textStyle="bold" />
         </LinearLayout>
 
@@ -85,14 +85,14 @@
                 android:fontFamily="sans-serif-black"
                 android:includeFontPadding="false"
                 android:text="@string/widget_sample_week_short"
-                android:textSize="12sp"
+                android:textSize="13sp"
                 android:textStyle="bold" />
 
             <FrameLayout
                 android:layout_width="0dp"
-                android:layout_height="16dp"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
+                android:layout_height="18dp"
+                android:layout_marginStart="10dp"
+                android:layout_marginEnd="10dp"
                 android:layout_weight="1">
 
                 <ImageView
@@ -122,7 +122,7 @@
                 android:includeFontPadding="false"
                 android:maxLines="1"
                 android:text="@string/widget_sample_secondary_percent_short"
-                android:textSize="20sp"
+                android:textSize="22sp"
                 android:textStyle="bold" />
         </LinearLayout>
     </LinearLayout>

--- a/android/app/src/main/res/layout/widget_material_compact.xml
+++ b/android/app/src/main/res/layout/widget_material_compact.xml
@@ -3,38 +3,38 @@
     android:id="@android:id/background"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/widget_bg_light_88">
+    android:background="@drawable/widget_bg_material_round"
+    android:padding="10dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center_vertical"
-        android:orientation="vertical"
-        android:paddingStart="12dp"
-        android:paddingTop="5dp"
-        android:paddingEnd="12dp"
-        android:paddingBottom="5dp">
+        android:orientation="vertical">
 
         <LinearLayout
             android:id="@+id/primary_section"
             android:layout_width="match_parent"
-            android:layout_height="24dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
             android:gravity="center_vertical"
             android:orientation="horizontal">
 
             <TextView
                 android:id="@+id/primary_label"
-                android:layout_width="32dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-medium"
+                android:background="@drawable/chip_material_label"
+                android:fontFamily="sans-serif-black"
                 android:includeFontPadding="false"
                 android:text="@string/widget_sample_five_hour_short"
-                android:textSize="11sp" />
+                android:textSize="12sp"
+                android:textStyle="bold" />
 
             <FrameLayout
                 android:layout_width="0dp"
-                android:layout_height="9dp"
-                android:layout_marginStart="5dp"
+                android:layout_height="14dp"
+                android:layout_marginStart="8dp"
                 android:layout_marginEnd="8dp"
                 android:layout_weight="1">
 
@@ -44,7 +44,7 @@
                     android:layout_height="match_parent"
                     android:contentDescription="@null"
                     android:scaleType="fitXY"
-                    android:src="@drawable/progress_track_light" />
+                    android:src="@drawable/progress_track_material" />
 
                 <ImageView
                     android:id="@+id/primary_progress"
@@ -58,35 +58,39 @@
 
             <TextView
                 android:id="@+id/primary_percent"
-                android:layout_width="48dp"
+                android:layout_width="56dp"
                 android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-medium"
+                android:fontFamily="sans-serif-black"
                 android:gravity="end"
                 android:includeFontPadding="false"
                 android:text="@string/widget_sample_primary_percent_short"
-                android:textSize="17sp" />
+                android:textSize="22sp"
+                android:textStyle="bold" />
         </LinearLayout>
 
         <LinearLayout
             android:id="@+id/secondary_section"
             android:layout_width="match_parent"
-            android:layout_height="24dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
             android:gravity="center_vertical"
             android:orientation="horizontal">
 
             <TextView
                 android:id="@+id/secondary_label"
-                android:layout_width="32dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-medium"
+                android:background="@drawable/chip_material_label"
+                android:fontFamily="sans-serif-black"
                 android:includeFontPadding="false"
                 android:text="@string/widget_sample_week_short"
-                android:textSize="11sp" />
+                android:textSize="12sp"
+                android:textStyle="bold" />
 
             <FrameLayout
                 android:layout_width="0dp"
-                android:layout_height="9dp"
-                android:layout_marginStart="5dp"
+                android:layout_height="14dp"
+                android:layout_marginStart="8dp"
                 android:layout_marginEnd="8dp"
                 android:layout_weight="1">
 
@@ -96,7 +100,7 @@
                     android:layout_height="match_parent"
                     android:contentDescription="@null"
                     android:scaleType="fitXY"
-                    android:src="@drawable/progress_track_light" />
+                    android:src="@drawable/progress_track_material" />
 
                 <ImageView
                     android:id="@+id/secondary_progress"
@@ -110,13 +114,14 @@
 
             <TextView
                 android:id="@+id/secondary_percent"
-                android:layout_width="48dp"
+                android:layout_width="56dp"
                 android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-medium"
+                android:fontFamily="sans-serif-black"
                 android:gravity="end"
                 android:includeFontPadding="false"
                 android:text="@string/widget_sample_secondary_percent_short"
-                android:textSize="17sp" />
+                android:textSize="22sp"
+                android:textStyle="bold" />
         </LinearLayout>
     </LinearLayout>
 

--- a/android/app/src/main/res/layout/widget_material_compact.xml
+++ b/android/app/src/main/res/layout/widget_material_compact.xml
@@ -9,7 +9,6 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:gravity="center_vertical"
         android:orientation="vertical">
 
         <LinearLayout
@@ -18,25 +17,44 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="vertical"
+            android:paddingBottom="8dp">
 
-            <TextView
-                android:id="@+id/primary_label"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/chip_material_label"
-                android:fontFamily="sans-serif-black"
-                android:includeFontPadding="false"
-                android:text="@string/widget_sample_five_hour_short"
-                android:textSize="13sp"
-                android:textStyle="bold" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/primary_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/chip_material_label"
+                    android:fontFamily="sans-serif-black"
+                    android:includeFontPadding="false"
+                    android:text="@string/widget_sample_five_hour_short"
+                    android:textSize="13sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/primary_percent"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:fontFamily="sans-serif-black"
+                    android:gravity="end"
+                    android:includeFontPadding="false"
+                    android:maxLines="1"
+                    android:text="@string/widget_sample_primary_percent_short"
+                    android:textSize="26sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
 
             <FrameLayout
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="18dp"
-                android:layout_marginStart="10dp"
-                android:layout_marginEnd="10dp"
-                android:layout_weight="1">
+                android:layout_marginTop="10dp">
 
                 <ImageView
                     android:id="@+id/primary_track"
@@ -55,18 +73,6 @@
                     android:scaleType="fitXY"
                     android:src="@drawable/progress_mint" />
             </FrameLayout>
-
-            <TextView
-                android:id="@+id/primary_percent"
-                android:layout_width="64dp"
-                android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-black"
-                android:gravity="end"
-                android:includeFontPadding="false"
-                android:maxLines="1"
-                android:text="@string/widget_sample_primary_percent_short"
-                android:textSize="22sp"
-                android:textStyle="bold" />
         </LinearLayout>
 
         <LinearLayout
@@ -75,25 +81,44 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="vertical"
+            android:paddingTop="8dp">
 
-            <TextView
-                android:id="@+id/secondary_label"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/chip_material_label"
-                android:fontFamily="sans-serif-black"
-                android:includeFontPadding="false"
-                android:text="@string/widget_sample_week_short"
-                android:textSize="13sp"
-                android:textStyle="bold" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/secondary_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/chip_material_label"
+                    android:fontFamily="sans-serif-black"
+                    android:includeFontPadding="false"
+                    android:text="@string/widget_sample_week_short"
+                    android:textSize="13sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/secondary_percent"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:fontFamily="sans-serif-black"
+                    android:gravity="end"
+                    android:includeFontPadding="false"
+                    android:maxLines="1"
+                    android:text="@string/widget_sample_secondary_percent_short"
+                    android:textSize="26sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
 
             <FrameLayout
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="18dp"
-                android:layout_marginStart="10dp"
-                android:layout_marginEnd="10dp"
-                android:layout_weight="1">
+                android:layout_marginTop="10dp">
 
                 <ImageView
                     android:id="@+id/secondary_track"
@@ -112,18 +137,6 @@
                     android:scaleType="fitXY"
                     android:src="@drawable/progress_mint" />
             </FrameLayout>
-
-            <TextView
-                android:id="@+id/secondary_percent"
-                android:layout_width="64dp"
-                android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-black"
-                android:gravity="end"
-                android:includeFontPadding="false"
-                android:maxLines="1"
-                android:text="@string/widget_sample_secondary_percent_short"
-                android:textSize="22sp"
-                android:textStyle="bold" />
         </LinearLayout>
     </LinearLayout>
 

--- a/android/app/src/main/res/layout/widget_material_compact.xml
+++ b/android/app/src/main/res/layout/widget_material_compact.xml
@@ -33,7 +33,7 @@
 
             <FrameLayout
                 android:layout_width="0dp"
-                android:layout_height="14dp"
+                android:layout_height="16dp"
                 android:layout_marginStart="8dp"
                 android:layout_marginEnd="8dp"
                 android:layout_weight="1">
@@ -58,13 +58,14 @@
 
             <TextView
                 android:id="@+id/primary_percent"
-                android:layout_width="56dp"
+                android:layout_width="64dp"
                 android:layout_height="wrap_content"
                 android:fontFamily="sans-serif-black"
                 android:gravity="end"
                 android:includeFontPadding="false"
+                android:maxLines="1"
                 android:text="@string/widget_sample_primary_percent_short"
-                android:textSize="22sp"
+                android:textSize="20sp"
                 android:textStyle="bold" />
         </LinearLayout>
 
@@ -89,7 +90,7 @@
 
             <FrameLayout
                 android:layout_width="0dp"
-                android:layout_height="14dp"
+                android:layout_height="16dp"
                 android:layout_marginStart="8dp"
                 android:layout_marginEnd="8dp"
                 android:layout_weight="1">
@@ -114,13 +115,14 @@
 
             <TextView
                 android:id="@+id/secondary_percent"
-                android:layout_width="56dp"
+                android:layout_width="64dp"
                 android:layout_height="wrap_content"
                 android:fontFamily="sans-serif-black"
                 android:gravity="end"
                 android:includeFontPadding="false"
+                android:maxLines="1"
                 android:text="@string/widget_sample_secondary_percent_short"
-                android:textSize="22sp"
+                android:textSize="20sp"
                 android:textStyle="bold" />
         </LinearLayout>
     </LinearLayout>

--- a/android/app/src/main/res/layout/widget_material_compact.xml
+++ b/android/app/src/main/res/layout/widget_material_compact.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/background"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_bg_light_88">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:paddingStart="12dp"
+        android:paddingTop="5dp"
+        android:paddingEnd="12dp"
+        android:paddingBottom="5dp">
+
+        <LinearLayout
+            android:id="@+id/primary_section"
+            android:layout_width="match_parent"
+            android:layout_height="24dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/primary_label"
+                android:layout_width="32dp"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:includeFontPadding="false"
+                android:text="@string/widget_sample_five_hour_short"
+                android:textSize="11sp" />
+
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="9dp"
+                android:layout_marginStart="5dp"
+                android:layout_marginEnd="8dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/primary_track"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@null"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/progress_track_light" />
+
+                <ImageView
+                    android:id="@+id/primary_progress"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@null"
+                    android:level="7300"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/progress_mint" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/primary_percent"
+                android:layout_width="48dp"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="end"
+                android:includeFontPadding="false"
+                android:text="@string/widget_sample_primary_percent_short"
+                android:textSize="17sp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/secondary_section"
+            android:layout_width="match_parent"
+            android:layout_height="24dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/secondary_label"
+                android:layout_width="32dp"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:includeFontPadding="false"
+                android:text="@string/widget_sample_week_short"
+                android:textSize="11sp" />
+
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="9dp"
+                android:layout_marginStart="5dp"
+                android:layout_marginEnd="8dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/secondary_track"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@null"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/progress_track_light" />
+
+                <ImageView
+                    android:id="@+id/secondary_progress"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@null"
+                    android:level="4400"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/progress_mint" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/secondary_percent"
+                android:layout_width="48dp"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="end"
+                android:includeFontPadding="false"
+                android:text="@string/widget_sample_secondary_percent_short"
+                android:textSize="17sp" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <TextView android:id="@+id/widget_title" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <TextView android:id="@+id/plan_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <ImageView android:id="@+id/refresh_button" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" android:contentDescription="@null" />
+    <TextView android:id="@+id/primary_reset" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <TextView android:id="@+id/secondary_reset" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <LinearLayout android:id="@+id/reset_credit_row" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp">
+        <TextView android:id="@+id/reset_credit_info" android:layout_width="0dp" android:layout_height="0dp" />
+        <TextView android:id="@+id/reset_credit_button" android:layout_width="0dp" android:layout_height="0dp" />
+    </LinearLayout>
+    <TextView android:id="@+id/updated_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+</FrameLayout>

--- a/android/app/src/main/res/layout/widget_material_dials.xml
+++ b/android/app/src/main/res/layout/widget_material_dials.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/widget_bg_material_round"
-    android:padding="8dp">
+    android:padding="10dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -13,42 +13,84 @@
         android:gravity="center"
         android:orientation="horizontal">
 
-        <FrameLayout
+        <LinearLayout
             android:id="@+id/primary_section"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
 
             <ImageView
                 android:id="@+id/primary_graphic"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/five_hour"
-                android:scaleType="centerInside" />
+                android:scaleType="fitCenter" />
 
-            <TextView android:id="@+id/primary_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
-            <TextView android:id="@+id/primary_reset" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
-        </FrameLayout>
+            <TextView
+                android:id="@+id/primary_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:background="@drawable/chip_material_label"
+                android:fontFamily="sans-serif-black"
+                android:includeFontPadding="false"
+                android:text="@string/widget_sample_five_hour_short"
+                android:textSize="11sp"
+                android:textStyle="bold" />
 
-        <FrameLayout
+            <TextView
+                android:id="@+id/primary_reset"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:includeFontPadding="false"
+                android:textSize="10sp"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/secondary_section"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_marginStart="4dp"
-            android:layout_weight="1">
+            android:layout_marginStart="6dp"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
 
             <ImageView
                 android:id="@+id/secondary_graphic"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/weekly"
-                android:scaleType="centerInside" />
+                android:scaleType="fitCenter" />
 
-            <TextView android:id="@+id/secondary_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
-            <TextView android:id="@+id/secondary_reset" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
-        </FrameLayout>
+            <TextView
+                android:id="@+id/secondary_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:background="@drawable/chip_material_label"
+                android:fontFamily="sans-serif-black"
+                android:includeFontPadding="false"
+                android:text="@string/widget_sample_week_short"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/secondary_reset"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:includeFontPadding="false"
+                android:textSize="10sp"
+                android:visibility="gone" />
+        </LinearLayout>
     </LinearLayout>
 
     <TextView android:id="@+id/widget_title" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />

--- a/android/app/src/main/res/layout/widget_material_dials.xml
+++ b/android/app/src/main/res/layout/widget_material_dials.xml
@@ -3,18 +3,15 @@
     android:id="@android:id/background"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/widget_bg_light_88">
+    android:background="@drawable/widget_bg_material_round"
+    android:padding="8dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:baselineAligned="false"
         android:gravity="center"
-        android:orientation="horizontal"
-        android:paddingStart="6dp"
-        android:paddingTop="6dp"
-        android:paddingEnd="6dp"
-        android:paddingBottom="4dp">
+        android:orientation="horizontal">
 
         <FrameLayout
             android:id="@+id/primary_section"
@@ -38,6 +35,7 @@
             android:id="@+id/secondary_section"
             android:layout_width="0dp"
             android:layout_height="match_parent"
+            android:layout_marginStart="4dp"
             android:layout_weight="1">
 
             <ImageView

--- a/android/app/src/main/res/layout/widget_material_dials.xml
+++ b/android/app/src/main/res/layout/widget_material_dials.xml
@@ -1,51 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@android:id/background"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/widget_bg_material_round"
-    android:padding="8dp">
+    android:gravity="center"
+    android:orientation="horizontal"
+    android:padding="10dp">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <FrameLayout
+        android:id="@+id/primary_section"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:baselineAligned="false"
-        android:gravity="center"
-        android:orientation="horizontal">
+        android:layout_weight="1">
 
-        <FrameLayout
-            android:id="@+id/primary_section"
-            android:layout_width="0dp"
+        <ImageView
+            android:id="@+id/primary_graphic"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1">
+            android:contentDescription="@string/five_hour"
+            android:scaleType="fitCenter" />
+    </FrameLayout>
 
-            <ImageView
-                android:id="@+id/primary_graphic"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:adjustViewBounds="true"
-                android:contentDescription="@string/five_hour"
-                android:scaleType="fitCenter" />
-        </FrameLayout>
+    <FrameLayout
+        android:id="@+id/secondary_section"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginStart="6dp"
+        android:layout_weight="1">
 
-        <FrameLayout
-            android:id="@+id/secondary_section"
-            android:layout_width="0dp"
+        <ImageView
+            android:id="@+id/secondary_graphic"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginStart="4dp"
-            android:layout_weight="1">
+            android:contentDescription="@string/weekly"
+            android:scaleType="fitCenter" />
+    </FrameLayout>
 
-            <ImageView
-                android:id="@+id/secondary_graphic"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:adjustViewBounds="true"
-                android:contentDescription="@string/weekly"
-                android:scaleType="fitCenter" />
-        </FrameLayout>
-    </LinearLayout>
-
-    <!-- Stub ids kept for shared RemoteViews binding. -->
+    <!-- Stub ids for shared RemoteViews binding. -->
     <TextView android:id="@+id/widget_title" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
     <TextView android:id="@+id/plan_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
     <ImageView android:id="@+id/refresh_button" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" android:contentDescription="@null" />
@@ -58,4 +50,4 @@
         <TextView android:id="@+id/reset_credit_button" android:layout_width="0dp" android:layout_height="0dp" />
     </LinearLayout>
     <TextView android:id="@+id/updated_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
-</FrameLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_material_dials.xml
+++ b/android/app/src/main/res/layout/widget_material_dials.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/widget_bg_material_round"
-    android:padding="10dp">
+    android:padding="8dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -13,89 +13,46 @@
         android:gravity="center"
         android:orientation="horizontal">
 
-        <LinearLayout
+        <FrameLayout
             android:id="@+id/primary_section"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center_horizontal"
-            android:orientation="vertical">
+            android:layout_weight="1">
 
             <ImageView
                 android:id="@+id/primary_graphic"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1"
+                android:layout_height="match_parent"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/five_hour"
                 android:scaleType="fitCenter" />
+        </FrameLayout>
 
-            <TextView
-                android:id="@+id/primary_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:background="@drawable/chip_material_label"
-                android:fontFamily="sans-serif-black"
-                android:includeFontPadding="false"
-                android:text="@string/widget_sample_five_hour_short"
-                android:textSize="11sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/primary_reset"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-medium"
-                android:includeFontPadding="false"
-                android:textSize="10sp"
-                android:visibility="gone" />
-        </LinearLayout>
-
-        <LinearLayout
+        <FrameLayout
             android:id="@+id/secondary_section"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_marginStart="6dp"
-            android:layout_weight="1"
-            android:gravity="center_horizontal"
-            android:orientation="vertical">
+            android:layout_marginStart="4dp"
+            android:layout_weight="1">
 
             <ImageView
                 android:id="@+id/secondary_graphic"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1"
+                android:layout_height="match_parent"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/weekly"
                 android:scaleType="fitCenter" />
-
-            <TextView
-                android:id="@+id/secondary_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:background="@drawable/chip_material_label"
-                android:fontFamily="sans-serif-black"
-                android:includeFontPadding="false"
-                android:text="@string/widget_sample_week_short"
-                android:textSize="11sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/secondary_reset"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-medium"
-                android:includeFontPadding="false"
-                android:textSize="10sp"
-                android:visibility="gone" />
-        </LinearLayout>
+        </FrameLayout>
     </LinearLayout>
 
+    <!-- Stub ids kept for shared RemoteViews binding. -->
     <TextView android:id="@+id/widget_title" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
     <TextView android:id="@+id/plan_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
     <ImageView android:id="@+id/refresh_button" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" android:contentDescription="@null" />
+    <TextView android:id="@+id/primary_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <TextView android:id="@+id/secondary_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <TextView android:id="@+id/primary_reset" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <TextView android:id="@+id/secondary_reset" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
     <LinearLayout android:id="@+id/reset_credit_row" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp">
         <TextView android:id="@+id/reset_credit_info" android:layout_width="0dp" android:layout_height="0dp" />
         <TextView android:id="@+id/reset_credit_button" android:layout_width="0dp" android:layout_height="0dp" />

--- a/android/app/src/main/res/layout/widget_material_dials.xml
+++ b/android/app/src/main/res/layout/widget_material_dials.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/background"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_bg_light_88">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:baselineAligned="false"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:paddingStart="6dp"
+        android:paddingTop="6dp"
+        android:paddingEnd="6dp"
+        android:paddingBottom="4dp">
+
+        <FrameLayout
+            android:id="@+id/primary_section"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+            <ImageView
+                android:id="@+id/primary_graphic"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:adjustViewBounds="true"
+                android:contentDescription="@string/five_hour"
+                android:scaleType="centerInside" />
+
+            <TextView android:id="@+id/primary_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+            <TextView android:id="@+id/primary_reset" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/secondary_section"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+            <ImageView
+                android:id="@+id/secondary_graphic"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:adjustViewBounds="true"
+                android:contentDescription="@string/weekly"
+                android:scaleType="centerInside" />
+
+            <TextView android:id="@+id/secondary_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+            <TextView android:id="@+id/secondary_reset" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+        </FrameLayout>
+    </LinearLayout>
+
+    <TextView android:id="@+id/widget_title" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <TextView android:id="@+id/plan_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+    <ImageView android:id="@+id/refresh_button" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" android:contentDescription="@null" />
+    <LinearLayout android:id="@+id/reset_credit_row" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp">
+        <TextView android:id="@+id/reset_credit_info" android:layout_width="0dp" android:layout_height="0dp" />
+        <TextView android:id="@+id/reset_credit_button" android:layout_width="0dp" android:layout_height="0dp" />
+    </LinearLayout>
+    <TextView android:id="@+id/updated_label" android:visibility="gone" android:layout_width="0dp" android:layout_height="0dp" />
+</FrameLayout>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -11,6 +11,16 @@
         <item name="buttonCornerRadius">999dp</item>
     </style>
 
+    <style name="AppThemeMaterial" parent="AppTheme">
+        <item name="colorPrimary">#D0BCFF</item>
+        <item name="android:colorAccent">#D0BCFF</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:windowBackground">#141218</item>
+        <item name="android:navigationBarColor">#141218</item>
+        <item name="android:statusBarColor">#141218</item>
+        <item name="buttonCornerRadius">999dp</item>
+    </style>
+
     <style name="AppThemeDark" parent="AppTheme" />
     <style name="AppThemeLight" parent="AppTheme" />
 </resources>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -21,6 +21,13 @@
         <item name="buttonCornerRadius">999dp</item>
     </style>
 
+    <style name="MaterialToolbarTitle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
+        <item name="android:textSize">28sp</item>
+        <item name="android:fontFamily">sans-serif-black</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:letterSpacing">-0.02</item>
+    </style>
+
     <style name="AppThemeDark" parent="AppTheme" />
     <style name="AppThemeLight" parent="AppTheme" />
 </resources>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -21,11 +21,12 @@
         <item name="buttonCornerRadius">999dp</item>
     </style>
 
-    <style name="MaterialToolbarTitle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
+    <style name="MaterialToolbarTitle" parent="TextAppearance.AppCompat.Title">
         <item name="android:textSize">28sp</item>
         <item name="android:fontFamily">sans-serif-black</item>
         <item name="android:textStyle">bold</item>
         <item name="android:letterSpacing">-0.02</item>
+        <item name="android:textColor">#FFE6E0E9</item>
     </style>
 
     <style name="AppThemeDark" parent="AppTheme" />

--- a/android/app/src/main/res/values/settings_arrays.xml
+++ b/android/app/src/main/res/values/settings_arrays.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string-array name="app_surface_style_entries">
+        <item>One UI</item>
+        <item>Material 3 Expressive</item>
+    </string-array>
+    <string-array name="app_surface_style_values">
+        <item>one_ui</item>
+        <item>material</item>
+    </string-array>
+
     <array name="preferences_darkmode_entries_image">
         <item>@drawable/display_help_light_mode</item>
         <item>@drawable/display_help_dark_mode</item>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -17,6 +17,16 @@
         <item name="android:fontFamily">sec</item>
     </style>
 
+    <style name="AppThemeMaterial" parent="AppTheme">
+        <item name="colorPrimary">#6750A4</item>
+        <item name="android:colorAccent">#6750A4</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:windowBackground">#FFFBFE</item>
+        <item name="android:navigationBarColor">#FFFBFE</item>
+        <item name="android:statusBarColor">#FFFBFE</item>
+        <item name="buttonCornerRadius">999dp</item>
+    </style>
+
     <style name="AppThemeDark" parent="AppTheme" />
     <style name="AppThemeLight" parent="AppTheme" />
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -27,11 +27,12 @@
         <item name="buttonCornerRadius">999dp</item>
     </style>
 
-    <style name="MaterialToolbarTitle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
+    <style name="MaterialToolbarTitle" parent="TextAppearance.AppCompat.Title">
         <item name="android:textSize">28sp</item>
         <item name="android:fontFamily">sans-serif-black</item>
         <item name="android:textStyle">bold</item>
         <item name="android:letterSpacing">-0.02</item>
+        <item name="android:textColor">@android:color/black</item>
     </style>
 
     <style name="AppThemeDark" parent="AppTheme" />

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -21,10 +21,17 @@
         <item name="colorPrimary">#6750A4</item>
         <item name="android:colorAccent">#6750A4</item>
         <item name="android:fontFamily">sans-serif</item>
-        <item name="android:windowBackground">#FFFBFE</item>
-        <item name="android:navigationBarColor">#FFFBFE</item>
-        <item name="android:statusBarColor">#FFFBFE</item>
+        <item name="android:windowBackground">#FEF7FF</item>
+        <item name="android:navigationBarColor">#FEF7FF</item>
+        <item name="android:statusBarColor">#FEF7FF</item>
         <item name="buttonCornerRadius">999dp</item>
+    </style>
+
+    <style name="MaterialToolbarTitle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
+        <item name="android:textSize">28sp</item>
+        <item name="android:fontFamily">sans-serif-black</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:letterSpacing">-0.02</item>
     </style>
 
     <style name="AppThemeDark" parent="AppTheme" />

--- a/android/app/src/main/res/xml/preferences_settings.xml
+++ b/android/app/src/main/res/xml/preferences_settings.xml
@@ -9,6 +9,13 @@
         app:allowDividerBelow="false" />
 
     <PreferenceCategory android:title="Appearance">
+        <ListPreference
+            android:entries="@array/app_surface_style_entries"
+            android:entryValues="@array/app_surface_style_values"
+            android:key="app_surface_style"
+            android:summary="Choose the Android design language"
+            android:title="Interface style"
+            app:useSimpleSummaryProvider="true" />
         <dev.oneuiproject.oneui.preference.HorizontalRadioPreference
             android:key="app_theme"
             app:entries="@array/preferences_darkmode_entries"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -175,6 +175,8 @@ grep -q 'app_surface_style' "$ROOT/app/src/main/res/xml/preferences_settings.xml
 grep -q 'Material 3 Expressive' "$ROOT/app/src/main/res/values/settings_arrays.xml"
 grep -q 'AppDesignStyle.normalize' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java"
+! grep -q 'setNavigationIcon(back ? R.drawable.ic_oui_back : 0)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
 ! grep -q 'AppPreferences.setAppStyle(this, WidgetOptions.SURFACE_ONE_UI)' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 test -f "$ROOT/app/src/main/res/layout/activity_oneui_dashboard.xml"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -44,6 +44,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/Pkce.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/JwtClaims.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppDesignStyle.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingFlow.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthBrowserPage.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseVersion.java" \
@@ -168,6 +169,21 @@ grep -q 'Ui.configureReachToolbar(toolbar, "Settings", true);' \
 grep -q 'toolbar.setExpandable(false);' "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
 grep -q 'toolbar.setExpandable(true);' "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
 grep -q 'toolbar.setExpanded(true, false);' "$ROOT/app/src/main/java/dev/bennett/codexmeter/Ui.java"
+
+# One UI remains the default while Material 3 Expressive is independently selectable.
+grep -q 'app_surface_style' "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'Material 3 Expressive' "$ROOT/app/src/main/res/values/settings_arrays.xml"
+grep -q 'AppDesignStyle.normalize' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java"
+! grep -q 'AppPreferences.setAppStyle(this, WidgetOptions.SURFACE_ONE_UI)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+test -f "$ROOT/app/src/main/res/layout/activity_oneui_dashboard.xml"
+test -f "$ROOT/app/src/main/res/layout/activity_material_dashboard.xml"
+test -f "$ROOT/app/src/main/res/layout/widget_material_compact.xml"
+test -f "$ROOT/app/src/main/res/layout/widget_material_dials.xml"
+grep -q 'SURFACE_ONE_UI' "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java"
+grep -q 'SURFACE_MATERIAL' "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java"
+grep -q 'One UI remains the widget default' "$ROOT/tests/ParserSelfTest.java"
 
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertPreferences.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetAlertScheduler.java"

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -630,6 +630,13 @@ public final class ParserSelfTest {
     }
 
     private static void testWidgetOptions() {
+        check(AppDesignStyle.ONE_UI.equals(AppDesignStyle.normalize(null)),
+                "missing app style keeps One UI default");
+        check(AppDesignStyle.ONE_UI.equals(AppDesignStyle.normalize("unknown")),
+                "invalid app style keeps One UI default");
+        check(AppDesignStyle.MATERIAL_EXPRESSIVE.equals(
+                        AppDesignStyle.normalize(WidgetOptions.SURFACE_MATERIAL)),
+                "Material Expressive app style accepted");
         WidgetOptions migrated = new WidgetOptions(WidgetOptions.LAYOUT_DETAILED,
                 WidgetOptions.THEME_DARK, WidgetOptions.ACCENT_BLUE, 72,
                 WidgetOptions.RESET_BOTH, WidgetOptions.DISPLAY_USED);
@@ -653,6 +660,8 @@ public final class ParserSelfTest {
         check(WidgetOptions.SURFACE_ONE_UI.equals(transparent.surfaceStyle), "One UI widget style");
         check(WidgetOptions.GRAPHIC_MAX.equals(transparent.graphicScale), "maximum graphic scale");
         check(!WidgetOptions.defaults().showTitle, "widget title defaults off");
+        check(WidgetOptions.SURFACE_ONE_UI.equals(WidgetOptions.defaults().surfaceStyle),
+                "One UI remains the widget default");
     }
 
     private static void testOnboardingFlow() {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -647,10 +647,18 @@ public final class ParserSelfTest {
         check(WidgetOptions.STYLE_AUTO.equals(safe.layout), "invalid style fallback");
         check(safe.opacity == 88, "invalid opacity fallback");
         check(WidgetOptions.ACCENT_MINT.equals(safe.accent), "invalid accent fallback");
-        check(WidgetOptions.SURFACE_ONE_UI.equals(safe.surfaceStyle),
-                "invalid widget surface keeps One UI default");
+        check(WidgetOptions.SURFACE_MATERIAL.equals(safe.surfaceStyle),
+                "legacy constructor keeps Material surface");
         check(WidgetOptions.GRAPHIC_AUTO.equals(safe.graphicScale), "legacy graphic fallback");
         check(!safe.showUpdated && safe.showRefresh, "boolean options");
+
+        WidgetOptions invalidSurface = new WidgetOptions(WidgetOptions.STYLE_RINGS,
+                WidgetOptions.DENSITY_AUTO, "invalid", WidgetOptions.GRAPHIC_AUTO,
+                WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_APP, 88,
+                WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING,
+                WidgetOptions.METRIC_BOTH, false, false, false, false, false, false);
+        check(WidgetOptions.SURFACE_ONE_UI.equals(invalidSurface.surfaceStyle),
+                "invalid widget surface keeps One UI default");
 
         WidgetOptions transparent = new WidgetOptions(WidgetOptions.STYLE_RINGS,
                 WidgetOptions.DENSITY_COMFORTABLE, WidgetOptions.SURFACE_ONE_UI,

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -647,7 +647,8 @@ public final class ParserSelfTest {
         check(WidgetOptions.STYLE_AUTO.equals(safe.layout), "invalid style fallback");
         check(safe.opacity == 88, "invalid opacity fallback");
         check(WidgetOptions.ACCENT_MINT.equals(safe.accent), "invalid accent fallback");
-        check(WidgetOptions.SURFACE_MATERIAL.equals(safe.surfaceStyle), "legacy surface fallback");
+        check(WidgetOptions.SURFACE_ONE_UI.equals(safe.surfaceStyle),
+                "invalid widget surface keeps One UI default");
         check(WidgetOptions.GRAPHIC_AUTO.equals(safe.graphicScale), "legacy graphic fallback");
         check(!safe.showUpdated && safe.showRefresh, "boolean options");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds the Material 3 Expressive app/widget surface while preserving One UI as the default.

## In-app regression and polish pass
- Fixed the One UI widget-config inset regression; SESL owns One UI system-bar spacing again.
- Preserved One UI dashboard waves, reachable toolbar behavior, Settings structure, About collapse/expand treatment, and widget configuration styling.
- Material screens now use plain expressive/asymmetric containers instead of SESL corner masks.
- Added Material disabled button states, consistent toolbar sizing, thicker onboarding/update progress, and improved About section hierarchy.
- Removed Material Settings account-card mask artifacts.
- Moved Material widget-config Save/Cancel outside scrolling content so it cannot overlap controls.
- Extended the existing demo-only seed hook so both designs can display the same cached sample values while signed out.
- Responsive widgets remain corrected: small hosts use dials; large hosts use bars.

## Full in-app screen recording
One UI dashboard, Settings, expanding About screen, widget configuration, visible style switch, then Material dashboard, About, widget configuration, and Settings:

[codex-meter-oneui-material-demo.mp4](https://cursor.com/agents/bc-448dfe59-a65f-4ad6-9329-043d0f591419/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp-recording%2Fcodex-meter-oneui-material-demo.mp4)

## Verification
- `./run-tests.sh` — passed
- `./lint.sh` — passed (existing baseline warnings only)
- `./build.sh` — passed; signed phone and Wear release APKs produced
- Emulator walkthrough completed for both design modes

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-448dfe59-a65f-4ad6-9329-043d0f591419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-448dfe59-a65f-4ad6-9329-043d0f591419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

