### PR TITLE
Prepare Codex Meter 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,35 @@
 # Changelog
 
-## Unreleased
+## 2.4.0 — 2026-07-18
 
 ### Added
 
-- Android settings transfer: export and import selected sections (app settings, notifications, Now Bar, and ChatGPT authentication) from Settings, with explicit warnings when authentication tokens are included.
-- Widget Background toggle in customize settings so the fill can be turned off entirely, matching official One UI widgets.
+- Wear OS companion app with phone↔watch usage and settings sync, plus tiles, complications, and Ongoing Activity monitoring (#37).
+- Native iOS / iPadOS SwiftUI + WidgetKit client under `ios/`, with portable meters, reset credits, notifications, widgets, and Keychain-backed auth (#22).
+- Android settings transfer: export and import selected sections (app settings, notifications, Now Bar, and ChatGPT authentication) from Settings, with explicit warnings when authentication tokens are included (#42).
+- Configurable automatic update-check frequency (hourly through weekly) and optional notifications when a newer signed GitHub release is available (#38).
+- Estimated usage-pace projections on dashboard cards, with One UI functional-orange accelerated-usage warnings and matching Now Bar auto-start / regress triggers (#47).
+- Widget Background toggle in customize settings so the fill can be turned off entirely, matching official One UI widgets (#45).
+- Optional Material You accent switch under Settings → Appearance so app accents can follow the system palette on Android 12+ (#44).
 
 ### Changed
 
-- Widget opacity control now uses three discrete fill strengths (56% / 88% / 100%) instead of four, aligning with current Samsung One UI widget transparency steps.
+- Default theme primary now uses Samsung's official One UI Primary (`#0381FE`) instead of the lighter SESL sample blue (#44).
+- Widget opacity control now uses three discrete fill strengths (56% / 88% / 100%) instead of four, aligning with current Samsung One UI widget transparency steps (#45).
+- Centralized observation-based reset fallback timing across the dashboard, widgets, Now Bar, and Wear surfaces (#47).
+
+### Fixed
+
+- App update and release-history loading now use a centered One UI spinner instead of clipped status text, and idle update cards no longer reserve empty status-line height (#35).
+- Live usage monitor progress uses a plain progress dot, and Now Bar / notification Codex logos adapt to light, dark, and accent surfaces without a baked white square (#36).
 
 ### Development
 
-- Added pure-Java coverage for transfer document parsing, section selection, and embedded authentication warnings.
-- Expanded widget-option self-tests for background-off opacity, three-step snapping, and legacy four-step migration.
+- Restructured the repository into `android/` and `ios/` project roots with thin root wrappers and CI paths pointed at the Android Gradle tree (#40).
+- Fixed Cloud Agent setup to invoke `android/gradlew` after the monorepo move (#43).
+- Expanded regression coverage for settings transfer, update-check frequency, usage-pace estimates, widget fill controls, Material You preferences, and Wear sync contracts (#37, #38, #42, #44, #45, #47).
+
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.3.3...v2.4.0 <!-- pragma: allowlist secret -->
 
 ## 2.3.3 — 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
 
-## Android — Version 2.3.3
+## Android — Version 2.4.0
 
-Version 2.3.3 adds a Now Bar percentage-mode setting (Auto / 5-hour / Weekly), clearer weekly Live Update labels, and consistent full-pill action buttons.
+Version 2.4.0 adds a Wear OS companion, estimated usage-pace warnings, settings transfer (including optional auth), configurable update-check frequency with update notifications, Material You accents, and One UI-aligned widget fill controls.
 
 ### Live countdowns
 
@@ -93,7 +93,7 @@ xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.3.3`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
+Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.4.0`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
 
 ## Platform stability
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 16
-        versionName = "2.3.3"
+        versionCode = 17
+        versionName = "2.4.0"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 16;
-    public static final String VERSION_NAME = "2.3.3";
+    public static final int VERSION_CODE = 17;
+    public static final String VERSION_NAME = "2.4.0";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.3.3 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.4.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.3.3"
+VERSION_NAME="2.4.0"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -61,12 +61,12 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.3.3"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 16' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.3.3"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 16' "$ROOT/app/build.gradle.kts"
-grep -q 'codex-meter-android/2.3.3' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.3.3"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.4.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 17' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.4.0"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 17' "$ROOT/app/build.gradle.kts"
+grep -q 'codex-meter-android/2.4.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.4.0"' "$ROOT/build.sh"
 grep -q 'BenItBuhner/Codex-Meter/releases?per_page=30' "$ROOT/app/build.gradle.kts" # pragma: allowlist secret
 ! grep -R -q 'thatjoshguy67/Codex-Meter' \
   "$ROOT/app/src" "$ROOT/app/build.gradle.kts"

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 16
-        versionName = "2.3.3"
+        versionCode = 17
+        versionName = "2.4.0"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump Codex Meter to **2.4.0** (versionCode **17**) and document everything merged since `v2.3.3`.

## Release contents

### Added
- Wear OS companion with phone↔watch sync, tiles, complications, and Ongoing Activity monitoring (#37)
- Native iOS / iPadOS SwiftUI + WidgetKit client under `ios/` (#22)
- Android settings / auth export-import transfer with auth warnings (#42)
- Configurable update-check frequency and update-available notifications (#38)
- Estimated usage-pace projections, accelerated-usage warnings, and matching Now Bar triggers (#47)
- Widget Background toggle matching official One UI widgets (#45)
- Optional Material You accent switch under Appearance (#44)

### Changed
- Default theme primary uses official One UI Primary `#0381FE` (#44)
- Widget opacity steps reduced to three One UI-style fills (56% / 88% / 100%) (#45)
- Centralized observation-based reset fallback timing across phone + Wear surfaces (#47)

### Fixed
- Update / release-history loading spinner no longer clips under ToolbarLayout corners (#35)
- Now Bar progress dot and theme-adaptive Codex logos without a baked white square (#36)

### Development
- Monorepo split into `android/` and `ios/` project roots (#40)
- Cloud Agent install hook fixed for `android/gradlew` (#43)
- Expanded regression coverage for the features above

## Release boundary

`v2.3.3...HEAD` is PRs **#22**, **#35**, **#36**, **#37**, **#38**, **#40**, **#42**, **#43**, **#44**, **#45**, and **#47**. This PR only bumps version metadata and release docs — it does **not** create the `v2.4.0` tag or GitHub Release. After merge, tagging `v2.4.0` on the merge commit triggers CI to build the signed phone + Wear APKs and publish them as **Latest**.

## Testing

- `./run-tests.sh` passed (parser/updater/OAuth/onboarding/widget/Wear checks + version guards for 2.4.0 / code 17)
- `./lint.sh` passed (`:app:lintRelease` + `:wear:lintRelease`)
- `./build.sh` produced `android/dist/CodexMeter-2.4.0.apk` and `CodexMeter-Wear-2.4.0.apk` (`versionCode=17`, `versionName=2.4.0`, APK Signature Scheme v2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c27020b9-bb48-4d51-b4d5-eb6a996ade97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c27020b9-bb48-4d51-b4d5-eb6a996ade97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

