### PR TITLE
ios: usage-pace estimates (Android 2.4 parity, phase 1)

### DIFF
--- a/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
+++ b/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
@@ -1,3 +1,4 @@
+import CodexMeterCore
 import Combine
 import Foundation
 
@@ -52,6 +53,9 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
     public var creditExpiryRemindersEnabled: Bool
     /// Minutes before expiry. Multiple values schedule one reminder each (2.2 parity).
     public var creditExpiryLeadMinutes: [Int]
+    /// Show estimated time-to-exhaustion from average window pace (Android 2.4).
+    public var usagePaceEnabled: Bool
+    public var usagePaceSensitivity: UsagePace.Sensitivity
 
     public init(
         appearance: AppAppearance = .system,
@@ -63,7 +67,9 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         creditIncreaseAlertsEnabled: Bool = true,
         unexpectedRefillAlertsEnabled: Bool = true,
         creditExpiryRemindersEnabled: Bool = true,
-        creditExpiryLeadMinutes: [Int] = AppSettings.defaultCreditExpiryLeadMinutes
+        creditExpiryLeadMinutes: [Int] = AppSettings.defaultCreditExpiryLeadMinutes,
+        usagePaceEnabled: Bool = true,
+        usagePaceSensitivity: UsagePace.Sensitivity = .balanced
     ) {
         self.appearance = appearance
         self.refreshOnLaunch = refreshOnLaunch
@@ -75,6 +81,8 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         self.unexpectedRefillAlertsEnabled = unexpectedRefillAlertsEnabled
         self.creditExpiryRemindersEnabled = creditExpiryRemindersEnabled
         self.creditExpiryLeadMinutes = Self.sanitizedLeadMinutes(creditExpiryLeadMinutes)
+        self.usagePaceEnabled = usagePaceEnabled
+        self.usagePaceSensitivity = usagePaceSensitivity
     }
 
     public var effectiveCreditExpiryLeadMinutes: [Int] {
@@ -108,6 +116,8 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         case unexpectedRefillAlertsEnabled
         case creditExpiryRemindersEnabled
         case creditExpiryLeadMinutes
+        case usagePaceEnabled
+        case usagePaceSensitivity
     }
 
     public init(from decoder: any Decoder) throws {
@@ -123,7 +133,10 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
             unexpectedRefillAlertsEnabled: try container.decodeIfPresent(Bool.self, forKey: .unexpectedRefillAlertsEnabled) ?? true,
             creditExpiryRemindersEnabled: try container.decodeIfPresent(Bool.self, forKey: .creditExpiryRemindersEnabled) ?? true,
             creditExpiryLeadMinutes: try container.decodeIfPresent([Int].self, forKey: .creditExpiryLeadMinutes)
-                ?? Self.defaultCreditExpiryLeadMinutes
+                ?? Self.defaultCreditExpiryLeadMinutes,
+            usagePaceEnabled: try container.decodeIfPresent(Bool.self, forKey: .usagePaceEnabled) ?? true,
+            usagePaceSensitivity: try container.decodeIfPresent(UsagePace.Sensitivity.self, forKey: .usagePaceSensitivity)
+                ?? .balanced
         )
     }
 }

--- a/ios/CodexMeter/Views/DashboardView.swift
+++ b/ios/CodexMeter/Views/DashboardView.swift
@@ -47,14 +47,18 @@ struct DashboardView: View {
                             systemImage: "clock",
                             window: model.usage?.fiveHour,
                             accent: .mint,
-                            fetchedAt: model.usage?.fetchedAt ?? .now
+                            fetchedAt: model.usage?.fetchedAt ?? .now,
+                            paceEnabled: model.settings.usagePaceEnabled,
+                            paceSensitivity: model.settings.usagePaceSensitivity
                         )
                         UsageMeterCard(
                             title: "Weekly",
                             systemImage: "calendar",
                             window: model.usage?.weekly,
                             accent: .indigo,
-                            fetchedAt: model.usage?.fetchedAt ?? .now
+                            fetchedAt: model.usage?.fetchedAt ?? .now,
+                            paceEnabled: model.settings.usagePaceEnabled,
+                            paceSensitivity: model.settings.usagePaceSensitivity
                         )
                     }
 

--- a/ios/CodexMeter/Views/SettingsView.swift
+++ b/ios/CodexMeter/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import CodexMeterCore
 import SwiftUI
 
 struct SettingsView: View {
@@ -56,6 +57,22 @@ struct SettingsView: View {
             } footer: {
                 Text("iOS decides when background work runs. This interval is an earliest preference, not a guaranteed schedule.")
             }
+
+            Section {
+                Toggle("Usage pace estimates", isOn: $model.settings.usagePaceEnabled)
+                if model.settings.usagePaceEnabled {
+                    Picker("Sensitivity", selection: $model.settings.usagePaceSensitivity) {
+                        ForEach(UsagePace.Sensitivity.allCases) { sensitivity in
+                            Text(sensitivity.title).tag(sensitivity)
+                        }
+                    }
+                }
+            } header: {
+                Text("Usage pace")
+            } footer: {
+                Text("Projects how long the current average consumption rate would take to exhaust the window. Orange highlights mean you are on track to run out before the scheduled reset.")
+            }
+            .disabled(model.mode == .signedOut)
 
             Section {
                 Toggle("Allow notifications", isOn: $model.settings.notificationsEnabled)

--- a/ios/CodexMeter/Views/UsageMeterCard.swift
+++ b/ios/CodexMeter/Views/UsageMeterCard.swift
@@ -7,74 +7,129 @@ struct UsageMeterCard: View {
     let window: UsageWindow?
     let accent: Color
     var fetchedAt: Date = .now
+    var paceEnabled = true
+    var paceSensitivity: UsagePace.Sensitivity = .balanced
 
     private var remaining: Int { window?.remainingPercent ?? 0 }
     private var used: Int { window?.usedPercent ?? 0 }
 
-    var body: some View {
-        HStack(spacing: 18) {
-            ZStack {
-                Circle()
-                    .stroke(accent.opacity(0.16), lineWidth: 11)
-                Circle()
-                    .trim(from: 0, to: Double(remaining) / 100)
-                    .stroke(accent, style: StrokeStyle(lineWidth: 11, lineCap: .round))
-                    .rotationEffect(.degrees(-90))
-                    .animation(.snappy, value: remaining)
-                VStack(spacing: -2) {
-                    Text("\(remaining)")
-                        .font(.title2.bold())
-                        .contentTransition(.numericText())
-                    Text("%")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .frame(width: 92, height: 92)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(Text(title))
-            .accessibilityValue(accessibilityValue)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Label(title, systemImage: systemImage)
-                    .font(.headline)
-
-                if window != nil {
-                    Text("\(used)% used")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .contentTransition(.numericText())
-                }
-
-                if let window, let resetAt = window.effectiveResetDate(relativeTo: fetchedAt) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Resets in")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(resetAt, style: .relative)
-                            .font(.subheadline.weight(.semibold))
-                            .monospacedDigit()
-                        Text(resetAt, format: .dateTime.weekday(.abbreviated).hour().minute())
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    Text(window == nil ? "Waiting for data" : "Reset time unavailable")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(AppChrome.cardPadding)
-        .frame(maxWidth: .infinity, minHeight: 138, alignment: .leading)
-        .cardSurface()
+    private var showsResetCountdown: Bool {
+        guard let window, window.usedPercent > 0 else { return false }
+        return window.effectiveResetDate(relativeTo: fetchedAt) != nil
     }
 
-    private var accessibilityValue: String {
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 30)) { context in
+            let paceNow = paceEnabled
+                ? UsagePace.assess(
+                    window: window,
+                    observedAt: fetchedAt,
+                    now: context.date,
+                    sensitivity: paceSensitivity
+                )
+                : .unavailable
+
+            HStack(spacing: 18) {
+                ZStack {
+                    Circle()
+                        .stroke(accent.opacity(0.16), lineWidth: 11)
+                    Circle()
+                        .trim(from: 0, to: Double(remaining) / 100)
+                        .stroke(
+                            paceNow.accelerated ? Color.orange : accent,
+                            style: StrokeStyle(lineWidth: 11, lineCap: .round)
+                        )
+                        .rotationEffect(.degrees(-90))
+                        .animation(.snappy, value: remaining)
+                        .animation(.snappy, value: paceNow.accelerated)
+                    VStack(spacing: -2) {
+                        Text("\(remaining)")
+                            .font(.title2.bold())
+                            .contentTransition(.numericText())
+                        Text("%")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 92, height: 92)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(title))
+                .accessibilityValue(accessibilityValue(pace: paceNow))
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(title, systemImage: systemImage)
+                        .font(.headline)
+
+                    if window != nil {
+                        Text("\(used)% used")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .contentTransition(.numericText())
+                    }
+
+                    if paceNow.available {
+                        Label {
+                            Text(UsageFormat.estimatedRemaining(paceNow))
+                        } icon: {
+                            Image(systemName: paceNow.accelerated
+                                  ? "flame.fill"
+                                  : "speedometer")
+                        }
+                        .font(.subheadline.weight(paceNow.accelerated ? .semibold : .regular))
+                        .foregroundStyle(paceNow.accelerated ? .orange : .secondary)
+                    }
+
+                    if showsResetCountdown, let resetAt = window?.effectiveResetDate(relativeTo: fetchedAt) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Resets in")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(resetAt, style: .relative)
+                                .font(.subheadline.weight(.semibold))
+                                .monospacedDigit()
+                            Text(resetAt, format: .dateTime.weekday(.abbreviated).hour().minute())
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else if window == nil {
+                        Text("Waiting for data")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    } else if window?.usedPercent == 0 {
+                        Text("Unused this window")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Reset time unavailable")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(AppChrome.cardPadding)
+            .frame(maxWidth: .infinity, minHeight: 138, alignment: .leading)
+            .cardSurface()
+            .overlay {
+                if paceNow.accelerated {
+                    RoundedRectangle(cornerRadius: AppChrome.cardRadius, style: .continuous)
+                        .stroke(Color.orange.opacity(0.35), lineWidth: 1)
+                }
+            }
+        }
+    }
+
+    private func accessibilityValue(pace: UsagePace.Assessment) -> String {
         guard window != nil else {
             return "Unavailable"
         }
-        return "\(remaining) percent remaining, \(used) percent used"
+        var parts = ["\(remaining) percent remaining, \(used) percent used"]
+        if pace.available {
+            parts.append(UsageFormat.estimatedRemaining(pace))
+            if pace.accelerated {
+                parts.append("accelerated usage")
+            }
+        }
+        return parts.joined(separator: ", ")
     }
 }

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsageFormat.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsageFormat.swift
@@ -142,4 +142,27 @@ public enum UsageFormat {
         let hours = minutes / 60
         return hours < 24 ? "Updated \(hours)h ago" : "Updated \(hours / 24)d ago"
     }
+
+    /// Compact estimate label for usage-pace projections (Android `UsageFormat.estimatedRemaining`).
+    public static func estimatedRemaining(_ assessment: UsagePace.Assessment) -> String {
+        guard assessment.available else { return "" }
+        if assessment.estimatedRemaining <= 0 {
+            return "Est. depleted"
+        }
+        return "Est. \(compactDuration(assessment.estimatedRemaining))"
+    }
+
+    public static func compactDuration(_ interval: TimeInterval) -> String {
+        let minutes = max(1, Int64(max(0, interval) / 60))
+        let days = minutes / 1_440
+        let hours = (minutes % 1_440) / 60
+        let remainingMinutes = minutes % 60
+        if days > 0 {
+            return "\(days)d \(hours)h"
+        }
+        if hours > 0 {
+            return "\(hours)h \(remainingMinutes)m"
+        }
+        return "\(minutes)m"
+    }
 }

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsagePace.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsagePace.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+/// Estimates quota exhaustion from average consumption over the complete current window.
+///
+/// The elapsed sample begins at `resetAt - windowDuration`, so pauses and idle periods
+/// remain part of the average instead of making a later burst look permanently representative.
+///
+/// Port of Android `UsagePace` (shared module, Codex Meter 2.4).
+public enum UsagePace {
+    public enum Sensitivity: String, Codable, Sendable, CaseIterable, Identifiable {
+        case sensitive
+        case balanced
+        case relaxed
+
+        public var id: String { rawValue }
+
+        public var title: String {
+            switch self {
+            case .sensitive: "Sensitive"
+            case .balanced: "Balanced"
+            case .relaxed: "Relaxed"
+            }
+        }
+    }
+
+    public enum AcceleratedWindow: Int, Sendable, Equatable {
+        case none = 0
+        case fiveHour = 1
+        case weekly = 2
+    }
+
+    public struct Assessment: Sendable, Equatable {
+        public let available: Bool
+        public let accelerated: Bool
+        public let estimatedRemaining: TimeInterval
+        public let estimatedTotal: TimeInterval
+        public let actualRemaining: TimeInterval
+        public let estimatedExhaustionAt: Date?
+        public let resetAt: Date?
+        public let observedDuration: TimeInterval
+        public let usedPercent: Int
+
+        public static let unavailable = Assessment(
+            available: false,
+            accelerated: false,
+            estimatedRemaining: 0,
+            estimatedTotal: 0,
+            actualRemaining: 0,
+            estimatedExhaustionAt: nil,
+            resetAt: nil,
+            observedDuration: 0,
+            usedPercent: 0
+        )
+
+        public var coverageRatio: Double {
+            guard available, actualRemaining > 0 else {
+                return .infinity
+            }
+            return estimatedRemaining / actualRemaining
+        }
+    }
+
+    public static func normalizeSensitivity(_ raw: String?) -> Sensitivity {
+        guard let raw, let value = Sensitivity(rawValue: raw) else {
+            return .balanced
+        }
+        return value
+    }
+
+    public static func assess(
+        window: UsageWindow?,
+        observedAt: Date,
+        now: Date = Date(),
+        sensitivity: Sensitivity = .balanced
+    ) -> Assessment {
+        guard let window, window.windowSeconds > 0 else {
+            return .unavailable
+        }
+        let windowDuration = TimeInterval(window.windowSeconds)
+        guard let resetAt = window.effectiveResetDate(relativeTo: observedAt),
+              resetAt > observedAt,
+              resetAt > now
+        else {
+            return .unavailable
+        }
+
+        let windowStart = resetAt.addingTimeInterval(-windowDuration)
+        let elapsed = observedAt.timeIntervalSince(windowStart)
+        guard elapsed > 0,
+              elapsed <= windowDuration,
+              window.usedPercent > 0
+        else {
+            return .unavailable
+        }
+
+        let policy = policy(for: sensitivity, windowDuration: windowDuration)
+        guard elapsed >= policy.minimumElapsed,
+              window.usedPercent >= policy.minimumUsedPercent
+        else {
+            return .unavailable
+        }
+
+        let used = Double(window.usedPercent)
+        let estimatedRemainingAtObservation = elapsed * (100.0 - used) / used
+        let estimatedTotal = elapsed * 100.0 / used
+        let estimatedExhaustionAt = observedAt.addingTimeInterval(estimatedRemainingAtObservation)
+        let actualRemainingAtObservation = resetAt.timeIntervalSince(observedAt)
+        let accelerated =
+            estimatedRemainingAtObservation * 100.0
+            <= actualRemainingAtObservation * Double(policy.maximumCoveragePercent)
+
+        let estimatedRemainingNow = max(0, estimatedExhaustionAt.timeIntervalSince(now))
+        let actualRemainingNow = max(0, resetAt.timeIntervalSince(now))
+
+        return Assessment(
+            available: true,
+            accelerated: accelerated,
+            estimatedRemaining: estimatedRemainingNow,
+            estimatedTotal: estimatedTotal,
+            actualRemaining: actualRemainingNow,
+            estimatedExhaustionAt: estimatedExhaustionAt,
+            resetAt: resetAt,
+            observedDuration: elapsed,
+            usedPercent: window.usedPercent
+        )
+    }
+
+    public static func mostAcceleratedWindow(
+        snapshot: UsageSnapshot?,
+        now: Date = Date(),
+        sensitivity: Sensitivity = .balanced
+    ) -> AcceleratedWindow {
+        guard let snapshot else { return .none }
+        let fiveHour = assess(
+            window: snapshot.fiveHour,
+            observedAt: snapshot.fetchedAt,
+            now: now,
+            sensitivity: sensitivity
+        )
+        let weekly = assess(
+            window: snapshot.weekly,
+            observedAt: snapshot.fetchedAt,
+            now: now,
+            sensitivity: sensitivity
+        )
+        if !fiveHour.accelerated && !weekly.accelerated { return .none }
+        if !fiveHour.accelerated { return .weekly }
+        if !weekly.accelerated { return .fiveHour }
+        return fiveHour.coverageRatio <= weekly.coverageRatio ? .fiveHour : .weekly
+    }
+
+    private struct Policy {
+        let minimumUsedPercent: Int
+        let minimumElapsed: TimeInterval
+        let maximumCoveragePercent: Int
+    }
+
+    private static func policy(for sensitivity: Sensitivity, windowDuration: TimeInterval) -> Policy {
+        switch sensitivity {
+        case .sensitive:
+            return Policy(
+                minimumUsedPercent: 2,
+                minimumElapsed: max(2 * 60, windowDuration / 400),
+                maximumCoveragePercent: 100
+            )
+        case .relaxed:
+            return Policy(
+                minimumUsedPercent: 10,
+                minimumElapsed: max(10 * 60, windowDuration / 100),
+                maximumCoveragePercent: 50
+            )
+        case .balanced:
+            return Policy(
+                minimumUsedPercent: 5,
+                minimumElapsed: max(5 * 60, windowDuration / 200),
+                maximumCoveragePercent: 75
+            )
+        }
+    }
+}

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsagePaceTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsagePaceTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import CodexMeterCore
+
+final class UsagePaceTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 2_000_000_000)
+    private let hour: TimeInterval = 3_600
+    private let week: TimeInterval = 7 * 24 * 3_600
+
+    func testFastWeeklyConsumptionIsAccelerated() {
+        let fastWeekly = UsageWindow(
+            usedPercent: 15,
+            windowSeconds: Int64(week),
+            resetAt: now.addingTimeInterval(-hour + week)
+        )
+        let fast = UsagePace.assess(
+            window: fastWeekly,
+            observedAt: now,
+            now: now,
+            sensitivity: .balanced
+        )
+        XCTAssertTrue(fast.available)
+        XCTAssertTrue(fast.accelerated)
+        // 15% per hour → ~6h40m total
+        XCTAssertEqual(fast.estimatedTotal, 400 * 60, accuracy: 60)
+    }
+
+    func testResetAfterFallbackMatchesAbsoluteReset() {
+        let fallbackWeekly = UsageWindow(
+            usedPercent: 15,
+            windowSeconds: Int64(week),
+            resetAfterSeconds: Int64(week - hour)
+        )
+        let fallback = UsagePace.assess(
+            window: fallbackWeekly,
+            observedAt: now,
+            now: now,
+            sensitivity: .balanced
+        )
+        XCTAssertTrue(fallback.available)
+        XCTAssertTrue(fallback.accelerated)
+    }
+
+    func testSameRateOnFiveHourIsSustainable() {
+        let fiveHour: TimeInterval = 5 * hour
+        let sameRate = UsageWindow(
+            usedPercent: 15,
+            windowSeconds: Int64(fiveHour),
+            resetAt: now.addingTimeInterval(-hour + fiveHour)
+        )
+        let sustainable = UsagePace.assess(
+            window: sameRate,
+            observedAt: now,
+            now: now,
+            sensitivity: .balanced
+        )
+        XCTAssertTrue(sustainable.available)
+        XCTAssertFalse(sustainable.accelerated)
+    }
+
+    func testIdleTimeReducesNoise() {
+        let pausedWeekly = UsageWindow(
+            usedPercent: 15,
+            windowSeconds: Int64(week),
+            resetAt: now.addingTimeInterval(3 * 24 * hour + 12 * hour)
+        )
+        let paused = UsagePace.assess(
+            window: pausedWeekly,
+            observedAt: now,
+            now: now,
+            sensitivity: .balanced
+        )
+        XCTAssertTrue(paused.available)
+        XCTAssertFalse(paused.accelerated)
+    }
+
+    func testSensitivityPolicies() {
+        let borderline = UsageWindow(
+            usedPercent: 55,
+            windowSeconds: Int64(5 * hour),
+            resetAt: now.addingTimeInterval(3 * hour)
+        )
+        XCTAssertTrue(
+            UsagePace.assess(window: borderline, observedAt: now, now: now, sensitivity: .sensitive)
+                .accelerated
+        )
+        XCTAssertTrue(
+            UsagePace.assess(window: borderline, observedAt: now, now: now, sensitivity: .balanced)
+                .accelerated
+        )
+        XCTAssertFalse(
+            UsagePace.assess(window: borderline, observedAt: now, now: now, sensitivity: .relaxed)
+                .accelerated
+        )
+    }
+
+    func testTinySampleThresholds() {
+        let tinySample = UsageWindow(
+            usedPercent: 4,
+            windowSeconds: Int64(week),
+            resetAt: now.addingTimeInterval(-hour + week)
+        )
+        XCTAssertFalse(
+            UsagePace.assess(window: tinySample, observedAt: now, now: now, sensitivity: .balanced)
+                .available
+        )
+        XCTAssertTrue(
+            UsagePace.assess(window: tinySample, observedAt: now, now: now, sensitivity: .sensitive)
+                .available
+        )
+    }
+
+    func testMostAcceleratedWindowSelection() {
+        let fiveHour: TimeInterval = 5 * hour
+        let sameRateFiveHour = UsageWindow(
+            usedPercent: 15,
+            windowSeconds: Int64(fiveHour),
+            resetAt: now.addingTimeInterval(-hour + fiveHour)
+        )
+        let fastWeekly = UsageWindow(
+            usedPercent: 15,
+            windowSeconds: Int64(week),
+            resetAt: now.addingTimeInterval(-hour + week)
+        )
+        let both = UsageSnapshot(
+            planType: "pro",
+            allowed: true,
+            limitReached: false,
+            fiveHour: sameRateFiveHour,
+            weekly: fastWeekly,
+            fetchedAt: now
+        )
+        XCTAssertEqual(
+            UsagePace.mostAcceleratedWindow(snapshot: both, now: now, sensitivity: .balanced),
+            .weekly
+        )
+    }
+
+    func testInvalidSensitivityFallsBackToBalanced() {
+        XCTAssertEqual(UsagePace.normalizeSensitivity("invalid"), .balanced)
+    }
+
+    func testExpiredWindowsUnavailable() {
+        let fastWeekly = UsageWindow(
+            usedPercent: 15,
+            windowSeconds: Int64(week),
+            resetAt: now.addingTimeInterval(-hour + week)
+        )
+        let assessment = UsagePace.assess(
+            window: fastWeekly,
+            observedAt: now,
+            now: fastWeekly.resetAt!,
+            sensitivity: .balanced
+        )
+        XCTAssertFalse(assessment.available)
+    }
+
+    func testEstimatedRemainingFormatting() {
+        XCTAssertEqual(UsageFormat.estimatedRemaining(.unavailable), "")
+        XCTAssertEqual(UsageFormat.compactDuration(90 * 60), "1h 30m")
+        XCTAssertEqual(UsageFormat.compactDuration(25 * 60), "25m")
+        XCTAssertEqual(UsageFormat.compactDuration(2 * 24 * 3_600 + 3 * 3_600), "2d 3h")
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -9,9 +9,11 @@ application lives under [`../android/`](../android/). Behavior is aligned with
 the Android app where platform APIs allow; it does not include Samsung One UI,
 Now Bar / Live Update monitors, or Android in-app APK updates.
 
-Portable notification features from Android 2.1/2.2 are included: unexpected
-refill alerts, independent reset-credit increase alerts, and configurable
-reset-credit expiry reminders.
+Portable features from recent Android releases include unexpected refill
+alerts, independent reset-credit increase alerts, configurable reset-credit
+expiry reminders, and usage-pace exhaustion estimates with sensitivity
+controls (Android 2.4). Samsung One UI, Wear OS, Now Bar / Live Updates, and
+APK self-update are intentionally not ported.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

First iOS parity tranche after the monorepo merge (#22). Ports the portable **usage-pace** feature from Android 2.4 (#47) without Samsung/Wear-specific surfaces.

- **`UsagePace`** in `ios/CodexMeterCore` — same full-window average model and Sensitive / Balanced / Relaxed policies as Android `shared/.../UsagePace.java`
- Unit tests aligned with Android `ParserSelfTest.testUsagePace`
- Dashboard meter cards show **Est. …** projections; **orange** ring/label when consumption is accelerated vs the scheduled reset
- Settings → **Usage pace** toggle + sensitivity picker
- Hide reset countdowns when a window is still **0% used** (Android 2.3 fix #23)

### Explicitly not in this PR (later phases)

| Feature | Why later |
|---------|-----------|
| Wear OS / watchOS companion | Separate target + WatchConnectivity |
| Live Activity ≈ Now Bar | Platform redesign, not a direct port |
| Settings export/import | Needs careful Keychain/auth UX |
| GitHub APK updater | App Store distribution |
| Material You / One UI chrome | Android theming only |

## Test plan

- [x] `swift test --package-path ios/CodexMeterCore` (includes `UsagePaceTests`)
- [x] `xcodebuild -project ios/CodexMeter.xcodeproj -scheme CodexMeter -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- [ ] Demo mode: enable pace, burn demo quota via refreshes, confirm Est. labels
- [ ] Toggle pace off → estimates disappear
- [ ] Sensitivity Sensitive vs Relaxed changes accelerated state on borderline windows
- [ ] Window at 0% used shows “Unused this window” without a countdown