### PR TITLE
ios: 1.2.0 — transfer, onboarding, Live Activity, watchOS, CI

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,53 @@
+name: Build Codex Meter iOS
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ios:
+    name: Core tests + simulator build
+    runs-on: macos-15
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: ios
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          # Prefer the newest installed Xcode; fall back to default.
+          if [[ -d /Applications/Xcode.app ]]; then
+            sudo xcode-select -s /Applications/Xcode.app
+          fi
+          xcodebuild -version
+
+      - name: Run CodexMeterCore tests
+        run: |
+          set -euo pipefail
+          swift test --package-path CodexMeterCore
+
+      - name: Build iOS app (Simulator, no signing)
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project CodexMeter.xcodeproj \
+            -scheme CodexMeter \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   ios:
-    name: Core tests + simulator build
+    name: Core tests + iPhone Simulator build
     runs-on: macos-15
     timeout-minutes: 45
     defaults:
@@ -31,7 +31,6 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          # Prefer the newest installed Xcode; fall back to default.
           if [[ -d /Applications/Xcode.app ]]; then
             sudo xcode-select -s /Applications/Xcode.app
           fi
@@ -49,5 +48,34 @@ jobs:
             -project CodexMeter.xcodeproj \
             -scheme CodexMeter \
             -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+  watch:
+    name: watchOS Simulator build
+    runs-on: macos-15
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: ios
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          if [[ -d /Applications/Xcode.app ]]; then
+            sudo xcode-select -s /Applications/Xcode.app
+          fi
+          xcodebuild -version
+
+      - name: Build watch app (Simulator, no signing)
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project CodexMeter.xcodeproj \
+            -target CodexMeterWatch \
+            -destination 'generic/platform=watchOS Simulator' \
             CODE_SIGNING_ALLOWED=NO \
             build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Codex Meter is a **monorepo** with native clients and no backend:
 |------|--------|-------------------|
 | Repository root | Shared docs, license, changelog, CI entrypoints | — |
 | `android/` | Android (Gradle `:app`, `:shared`, `:wear`) | `dev.bennett.codexmeter` (+ Wear companion) |
-| `ios/` | SwiftUI / WidgetKit (Xcode) | `CodexMeter` app + widgets + `CodexMeterCore` package |
+| `ios/` | SwiftUI / WidgetKit / watchOS (Xcode) | `CodexMeter` app + widgets + `CodexMeterWatch` + `CodexMeterCore` (marketing **1.2.0**) |
 
 Clients talk directly to OpenAI/ChatGPT remote endpoints. Tokens stay on-device (Android Keystore / iOS Keychain).
 
@@ -39,7 +39,8 @@ iOS build instructions are in `ios/README.md`.
 ## iOS notes for agents
 
 - Work under `ios/`. Keep Android changes under `android/`. Do not flatten either tree into the repo root.
-- Prefer native SwiftUI / WidgetKit patterns; do not port Samsung One UI or Android update installers.
-- Core pure logic for the iOS app lives in `ios/CodexMeterCore`.
-- Fast checks: `swift test --package-path ios/CodexMeterCore` (from repo root) or from `ios/` as documented in `ios/README.md`.
-- Full Xcode builds need a macOS host; Linux cloud VMs typically cannot build the iOS target.
+- Prefer native SwiftUI / WidgetKit / WatchConnectivity patterns; do not port Samsung One UI or Android update installers.
+- Core pure logic lives in `ios/CodexMeterCore` (iOS + watchOS platforms). ActivityKit types stay behind `os(iOS)`.
+- Fast checks: `swift test --package-path ios/CodexMeterCore`; iPhone Simulator build of scheme `CodexMeter`; watchOS Simulator build of target `CodexMeterWatch` (see `ios/README.md`).
+- CI: `.github/workflows/ios.yml` (phone + watch unsigned builds).
+- Full Xcode builds need a macOS host; Linux cloud VMs typically cannot build the iOS/watch targets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### iOS (marketing version 1.2.0)
+
+Independent of Android `versionName` / GitHub `v*` APK tags. Lives under `ios/`.
+
+#### Added
+
+- Settings transfer: export/import JSON for app + notification preferences; optional ChatGPT credentials with double confirmation and security warnings.
+- First-run onboarding (what it is / privacy / connect) with sign-in, demo, or skip.
+- Live Activity usage monitor (Lock Screen + Dynamic Island) with optional low-remaining auto-start; ends on next reset, stop, or sign-out.
+- watchOS companion app: phone→watch sanitized snapshot sync via WatchConnectivity; watch UI for five-hour / weekly remaining, credits, and next reset.
+- macOS CI for `CodexMeterCore` tests, iPhone Simulator build, and watchOS Simulator build (`.github/workflows/ios.yml`).
+- About → GitHub Releases link (read-only; no in-app APK installer).
+
+#### Notes
+
+- Samsung One UI, Wear-only surfaces, Material You, and Android in-app APK updates are not ported.
+- Watch face complication WidgetKit views are included; a dedicated watch Widget extension for face-picker registration may still be required depending on Xcode tooling.
+
 ## 2.4.0 — 2026-07-18
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
   -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
 ```
 
-See [`ios/README.md`](ios/README.md) for device signing, App Groups, and release
-checklist notes. CI for iOS is `.github/workflows/ios.yml` (runs when `ios/`
-changes).
+See [`ios/README.md`](ios/README.md) for device signing, App Groups, Watch
+embedding, and release checklist notes. CI for iOS/watchOS is
+`.github/workflows/ios.yml` (runs when `ios/` changes): Core tests, iPhone
+Simulator build, and watchOS Simulator build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,4 +42,5 @@ xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
 ```
 
 See [`ios/README.md`](ios/README.md) for device signing, App Groups, and release
-checklist notes.
+checklist notes. CI for iOS is `.github/workflows/ios.yml` (runs when `ios/`
+changes).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Or from `android/` directly. `build.sh` assembles the release APKs with Gradle a
 ### iOS
 
 See [`ios/README.md`](ios/README.md). Requires Xcode 26+ and iOS/iPadOS 26+.
+iOS app marketing version is independent of the Android APK `versionName`.
 
 ```bash
 cd ios
@@ -90,6 +91,9 @@ swift test --package-path CodexMeterCore
 xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
   -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
 ```
+
+PRs that change `ios/` run GitHub Actions workflow **Build Codex Meter iOS**
+(`.github/workflows/ios.yml`) for core tests and an unsigned Simulator build.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 |------|----------|--------|
 | Repository root | Shared | Docs, license, changelog, CI, convenience script wrappers |
 | [`android/`](android/) | **Android** | Phone app + Wear companion: One UI dashboard, home widgets, Samsung lock/AOD, notifications, optional live usage monitor |
-| [`ios/`](ios/) | **iPhone / iPad** | Native SwiftUI + WidgetKit client with portable behavior (meters, reset credits, notifications, demo mode) |
+| [`ios/`](ios/) | **iPhone / iPad / Apple Watch** | Native SwiftUI + WidgetKit client (meters, reset credits, notifications, demo, Live Activity, watch companion). Marketing version **1.2.0** (independent of Android `versionName`) |
 
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
@@ -82,18 +82,22 @@ Or from `android/` directly. `build.sh` assembles the release APKs with Gradle a
 
 ### iOS
 
-See [`ios/README.md`](ios/README.md). Requires Xcode 26+ and iOS/iPadOS 26+.
-iOS app marketing version is independent of the Android APK `versionName`.
+See [`ios/README.md`](ios/README.md). Requires Xcode 26+ and iOS/iPadOS 26+
+(watchOS 11+ companion). Marketing version **1.2.0** is independent of the
+Android APK `versionName`.
 
 ```bash
 cd ios
 swift test --package-path CodexMeterCore
 xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
   -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project CodexMeter.xcodeproj -target CodexMeterWatch \
+  -destination 'generic/platform=watchOS Simulator' CODE_SIGNING_ALLOWED=NO build
 ```
 
 PRs that change `ios/` run GitHub Actions workflow **Build Codex Meter iOS**
-(`.github/workflows/ios.yml`) for core tests and an unsigned Simulator build.
+(`.github/workflows/ios.yml`) for core tests, an unsigned iPhone Simulator build,
+and an unsigned watchOS Simulator build.
 
 ## Releases
 

--- a/ios/CodexMeter.xcodeproj/project.pbxproj
+++ b/ios/CodexMeter.xcodeproj/project.pbxproj
@@ -623,7 +623,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -657,7 +657,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -687,7 +687,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -717,7 +717,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -738,7 +738,7 @@
 				DEVELOPMENT_TEAM = C2U9S337H8;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 6.0;
@@ -755,7 +755,7 @@
 				DEVELOPMENT_TEAM = C2U9S337H8;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 6.0;
@@ -778,7 +778,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 6.0;
@@ -801,7 +801,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 6.0;
@@ -824,7 +824,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -851,7 +851,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/ios/CodexMeter.xcodeproj/project.pbxproj
+++ b/ios/CodexMeter.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		A10000000000000000000001 /* CodexMeterCore in Frameworks */ = {isa = PBXBuildFile; productRef = E10000000000000000000001 /* CodexMeterCore */; };
 		A10000000000000000000002 /* CodexMeterCore in Frameworks */ = {isa = PBXBuildFile; productRef = E10000000000000000000002 /* CodexMeterCore */; };
 		A10000000000000000000003 /* CodexMeterWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A40000000000000000000001 /* CodexMeterWidgets.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A10000000000000000000004 /* CodexMeterWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = A40000000000000000000004 /* CodexMeterWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A10000000000000000000005 /* CodexMeterCore in Frameworks */ = {isa = PBXBuildFile; productRef = E10000000000000000000003 /* CodexMeterCore */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +36,13 @@
 			remoteGlobalIDString = 81D08CD130041D77000759C6;
 			remoteInfo = CodexMeter;
 		};
+		A20000000000000000000004 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81D08CCA30041D77000759C6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A70000000000000000000004;
+			remoteInfo = CodexMeterWatch;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -48,6 +57,17 @@
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A30000000000000000000002 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				A10000000000000000000004 /* CodexMeterWatch.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -55,6 +75,7 @@
 		A40000000000000000000001 /* CodexMeterWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = CodexMeterWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A40000000000000000000002 /* CodexMeterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CodexMeterUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A40000000000000000000003 /* CodexMeterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CodexMeterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A40000000000000000000004 /* CodexMeterWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodexMeterWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -71,6 +92,13 @@
 				Info.plist,
 			);
 			target = A70000000000000000000001 /* CodexMeterWidgets */;
+		};
+		A45000000000000000000003 /* Exceptions for "CodexMeterWatch" folder in "CodexMeterWatch" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = A70000000000000000000004 /* CodexMeterWatch */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -99,6 +127,14 @@
 		A50000000000000000000003 /* CodexMeterTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = CodexMeterTests;
+			sourceTree = "<group>";
+		};
+		A50000000000000000000004 /* CodexMeterWatch */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				A45000000000000000000003 /* Exceptions for "CodexMeterWatch" folder in "CodexMeterWatch" target */,
+			);
+			path = CodexMeterWatch;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -134,6 +170,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A60000000000000000000004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000005 /* CodexMeterCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -142,6 +186,7 @@
 			children = (
 				81D08CD430041D77000759C6 /* CodexMeter */,
 				A50000000000000000000001 /* CodexMeterWidgets */,
+				A50000000000000000000004 /* CodexMeterWatch */,
 				A50000000000000000000002 /* CodexMeterUITests */,
 				A50000000000000000000003 /* CodexMeterTests */,
 				81D08CD330041D77000759C6 /* Products */,
@@ -153,6 +198,7 @@
 			children = (
 				81D08CD230041D77000759C6 /* CodexMeter.app */,
 				A40000000000000000000001 /* CodexMeterWidgets.appex */,
+				A40000000000000000000004 /* CodexMeterWatch.app */,
 				A40000000000000000000002 /* CodexMeterUITests.xctest */,
 				A40000000000000000000003 /* CodexMeterTests.xctest */,
 			);
@@ -170,11 +216,13 @@
 				81D08CCF30041D77000759C6 /* Frameworks */,
 				81D08CD030041D77000759C6 /* Resources */,
 				A30000000000000000000001 /* Embed App Extensions */,
+				A30000000000000000000002 /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				A90000000000000000000001 /* PBXTargetDependency */,
+				A90000000000000000000004 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				81D08CD430041D77000759C6 /* CodexMeter */,
@@ -256,6 +304,29 @@
 			productReference = A40000000000000000000003 /* CodexMeterTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		A70000000000000000000004 /* CodexMeterWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C10000000000000000000004 /* Build configuration list for PBXNativeTarget "CodexMeterWatch" */;
+			buildPhases = (
+				A80000000000000000000007 /* Sources */,
+				A60000000000000000000004 /* Frameworks */,
+				A80000000000000000000008 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A50000000000000000000004 /* CodexMeterWatch */,
+			);
+			name = CodexMeterWatch;
+			packageProductDependencies = (
+				E10000000000000000000003 /* CodexMeterCore */,
+			);
+			productName = CodexMeterWatch;
+			productReference = A40000000000000000000004 /* CodexMeterWatch.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -293,6 +364,9 @@
 						CreatedOnToolsVersion = 26.5;
 						TestTargetID = 81D08CD130041D77000759C6;
 					};
+					A70000000000000000000004 = {
+						CreatedOnToolsVersion = 26.5;
+					};
 				};
 			};
 			buildConfigurationList = 81D08CCD30041D77000759C6 /* Build configuration list for PBXProject "CodexMeter" */;
@@ -314,6 +388,7 @@
 			targets = (
 				81D08CD130041D77000759C6 /* CodexMeter */,
 				A70000000000000000000001 /* CodexMeterWidgets */,
+				A70000000000000000000004 /* CodexMeterWatch */,
 				A70000000000000000000002 /* CodexMeterUITests */,
 				A70000000000000000000003 /* CodexMeterTests */,
 			);
@@ -397,6 +472,11 @@
 			isa = PBXTargetDependency;
 			target = 81D08CD130041D77000759C6 /* CodexMeter */;
 			targetProxy = A20000000000000000000003 /* PBXContainerItemProxy */;
+		};
+		A90000000000000000000004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A70000000000000000000004 /* CodexMeterWatch */;
+			targetProxy = A20000000000000000000004 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -730,6 +810,60 @@
 			};
 			name = Release;
 		};
+		B10000000000000000000007 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C2U9S337H8;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CodexMeterWatch/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 11.0;
+			};
+			name = Debug;
+		};
+		B10000000000000000000008 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C2U9S337H8;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CodexMeterWatch/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 11.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -778,6 +912,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C10000000000000000000004 /* Build configuration list for PBXNativeTarget "CodexMeterWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B10000000000000000000007 /* Debug */,
+				B10000000000000000000008 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -794,6 +937,11 @@
 			productName = CodexMeterCore;
 		};
 		E10000000000000000000002 /* CodexMeterCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D10000000000000000000001 /* XCLocalSwiftPackageReference "CodexMeterCore" */;
+			productName = CodexMeterCore;
+		};
+		E10000000000000000000003 /* CodexMeterCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D10000000000000000000001 /* XCLocalSwiftPackageReference "CodexMeterCore" */;
 			productName = CodexMeterCore;

--- a/ios/CodexMeter/AppModel.swift
+++ b/ios/CodexMeter/AppModel.swift
@@ -53,6 +53,7 @@ extension NotificationPermissionState {
 @Observable
 final class AppModel {
     private static let modeDefaultsKey = "codex-meter.session-mode-v1"
+    private static let onboardingCompletedKey = "codex-meter.onboarding-completed-v1"
 
     var mode: AppMode = .signedOut
     var usage: UsageSnapshot?
@@ -73,6 +74,8 @@ final class AppModel {
     var isShowingSettings = false
     var isShowingReset = false
     var isShowingSignIn = false
+    var hasCompletedOnboarding = false
+    var transferStatusMessage: String?
 
     private let liveService: LiveCodexService
     private var demoService: DemoCodexService
@@ -114,6 +117,8 @@ final class AppModel {
         self.defaults = defaults
         self.settings = settingsStore.settings
         self.isPreview = preview
+        self.hasCompletedOnboarding = preview
+            || defaults.bool(forKey: Self.onboardingCompletedKey)
 
         if preview {
             let now = Date()
@@ -167,6 +172,12 @@ final class AppModel {
         if ProcessInfo.processInfo.arguments.contains("-ui-testing-reset-settings") {
             settingsStore.reset()
             settings = settingsStore.settings
+        }
+
+        if ProcessInfo.processInfo.arguments.contains("-ui-testing-skip-onboarding")
+            || ProcessInfo.processInfo.arguments.contains("-ui-testing-demo")
+            || ProcessInfo.processInfo.arguments.contains("-ui-testing-signed-out") {
+            completeOnboarding()
         }
 
         if ProcessInfo.processInfo.arguments.contains("-ui-testing-signed-out") {
@@ -406,6 +417,53 @@ final class AppModel {
 
     func refreshNotificationPermissionState() async {
         notificationPermissionState = await notificationCoordinator.permissionState()
+    }
+
+    func completeOnboarding() {
+        hasCompletedOnboarding = true
+        defaults.set(true, forKey: Self.onboardingCompletedKey)
+    }
+
+    func exportTransferData(
+        options: SettingsTransfer.ExportOptions = .init()
+    ) async throws -> Data {
+        let tokens: AuthTokens?
+        if options.includeAuthentication {
+            tokens = try await liveService.currentTokens()
+        } else {
+            tokens = nil
+        }
+        let document = SettingsTransfer.makeDocument(
+            settings: settings,
+            tokens: tokens,
+            options: options
+        )
+        return try SettingsTransfer.encode(document)
+    }
+
+    func importTransferData(
+        _ data: Data,
+        options: SettingsTransfer.ImportOptions
+    ) async throws {
+        let document = try SettingsTransfer.parse(data)
+        let applied = try SettingsTransfer.apply(
+            document: document,
+            to: settings,
+            options: options
+        )
+        save(settings: applied.settings)
+
+        if let tokens = applied.tokens {
+            try await liveService.storeImportedTokens(tokens)
+            mode = .live
+            defaults.set(AppMode.live.rawValue, forKey: Self.modeDefaultsKey)
+            apply(tokens: tokens)
+            await refresh()
+        } else if applied.settings.notificationsEnabled {
+            await applyNotificationSettings()
+        }
+
+        transferStatusMessage = "Settings imported successfully."
     }
 
     func save(settings: AppSettings) {

--- a/ios/CodexMeter/AppModel.swift
+++ b/ios/CodexMeter/AppModel.swift
@@ -76,12 +76,15 @@ final class AppModel {
     var isShowingSignIn = false
     var hasCompletedOnboarding = false
     var transferStatusMessage: String?
+    var isLiveMonitorActive = false
+    var liveMonitorMessage: String?
 
     private let liveService: LiveCodexService
     private var demoService: DemoCodexService
     private let cache: AppCacheStore
     private let settingsStore: AppSettingsStore
     private let notificationCoordinator: NotificationCoordinator
+    private let liveActivityCoordinator: LiveActivityCoordinator
     private let defaults: UserDefaults
     private var hasStarted = false
     private var hasFinishedStartup = false
@@ -106,6 +109,7 @@ final class AppModel {
         cache: AppCacheStore = .shared,
         settingsStore: AppSettingsStore = AppSettingsStore(),
         notificationCoordinator: NotificationCoordinator = NotificationCoordinator(),
+        liveActivityCoordinator: LiveActivityCoordinator = .shared,
         defaults: UserDefaults = .standard,
         preview: Bool = false
     ) {
@@ -114,11 +118,13 @@ final class AppModel {
         self.cache = cache
         self.settingsStore = settingsStore
         self.notificationCoordinator = notificationCoordinator
+        self.liveActivityCoordinator = liveActivityCoordinator
         self.defaults = defaults
         self.settings = settingsStore.settings
         self.isPreview = preview
         self.hasCompletedOnboarding = preview
             || defaults.bool(forKey: Self.onboardingCompletedKey)
+        self.isLiveMonitorActive = liveActivityCoordinator.isActive
 
         if preview {
             let now = Date()
@@ -266,6 +272,7 @@ final class AppModel {
     func leaveDemo() async {
         await demoService.signOut()
         await notificationCoordinator.clearAll()
+        await stopLiveMonitor(dismissed: true)
         backgroundRefreshCoordinator.cancel()
         clearSessionState()
     }
@@ -275,8 +282,44 @@ final class AppModel {
         signInTask = nil
         await activeService.signOut()
         await notificationCoordinator.clearAll()
+        await stopLiveMonitor(dismissed: true)
         backgroundRefreshCoordinator.cancel()
         clearSessionState()
+    }
+
+    func startLiveMonitor() async {
+        guard mode != .signedOut else {
+            liveMonitorMessage = "Sign in or open demo mode first."
+            return
+        }
+        guard let usage else {
+            liveMonitorMessage = LiveActivityError.noUsage.localizedDescription
+            return
+        }
+        do {
+            try await liveActivityCoordinator.start(
+                usage: usage,
+                creditCount: credits?.availableCount ?? usage.resetCreditsAvailable ?? 0,
+                planLabel: accountPlan,
+                isDemo: mode == .demo,
+                isCached: isUsingCachedData
+            )
+            isLiveMonitorActive = liveActivityCoordinator.isActive
+            liveMonitorMessage = isLiveMonitorActive
+                ? "Usage monitor is running on the Lock Screen and Dynamic Island."
+                : nil
+        } catch {
+            liveMonitorMessage = error.localizedDescription
+            isLiveMonitorActive = liveActivityCoordinator.isActive
+        }
+    }
+
+    func stopLiveMonitor(dismissed: Bool = true) async {
+        await liveActivityCoordinator.end(dismissed: dismissed, usage: usage)
+        isLiveMonitorActive = liveActivityCoordinator.isActive
+        if dismissed {
+            liveMonitorMessage = "Usage monitor stopped."
+        }
     }
 
     func beginSignIn() async {
@@ -538,6 +581,7 @@ final class AppModel {
 
     func sceneBecameActive() async {
         await refreshNotificationPermissionState()
+        isLiveMonitorActive = liveActivityCoordinator.isActive
         guard hasStarted else {
             await startIfNeeded()
             return
@@ -545,6 +589,8 @@ final class AppModel {
         guard mode != .signedOut, settings.refreshOnLaunch else { return }
         if usage == nil || usage?.isStale(at: .now, maxAge: 5 * 60) == true {
             await refresh()
+        } else if let usage {
+            await syncLiveMonitor(with: usage)
         }
     }
 
@@ -572,7 +618,30 @@ final class AppModel {
             credits: refresh.credits,
             settings: settings
         )
+        await syncLiveMonitor(with: refresh.usage)
         scheduleBackgroundRefresh()
+    }
+
+    private func syncLiveMonitor(with usage: UsageSnapshot) async {
+        let creditCount = credits?.availableCount ?? usage.resetCreditsAvailable ?? 0
+        if liveActivityCoordinator.isActive {
+            await liveActivityCoordinator.update(
+                usage: usage,
+                creditCount: creditCount,
+                planLabel: accountPlan,
+                isDemo: mode == .demo,
+                isCached: isUsingCachedData
+            )
+        } else if liveActivityCoordinator.shouldAutoStart(settings: settings, usage: usage) {
+            try? await liveActivityCoordinator.start(
+                usage: usage,
+                creditCount: creditCount,
+                planLabel: accountPlan,
+                isDemo: mode == .demo,
+                isCached: isUsingCachedData
+            )
+        }
+        isLiveMonitorActive = liveActivityCoordinator.isActive
     }
 
     private func apply(

--- a/ios/CodexMeter/CodexMeterApp.swift
+++ b/ios/CodexMeter/CodexMeterApp.swift
@@ -11,6 +11,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        Task { @MainActor in
+            PhoneWatchBridge.shared.activateIfNeeded()
+        }
         return true
     }
 

--- a/ios/CodexMeter/ContentView.swift
+++ b/ios/CodexMeter/ContentView.swift
@@ -6,8 +6,14 @@ struct ContentView: View {
     var body: some View {
         @Bindable var model = model
 
-        NavigationStack {
-            DashboardView()
+        Group {
+            if model.hasCompletedOnboarding {
+                NavigationStack {
+                    DashboardView()
+                }
+            } else {
+                OnboardingView()
+            }
         }
         .sheet(isPresented: $model.isShowingSettings) {
             NavigationStack {

--- a/ios/CodexMeter/Info.plist
+++ b/ios/CodexMeter/Info.plist
@@ -37,6 +37,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
+++ b/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
@@ -52,6 +52,10 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
     public var creditExpiryRemindersEnabled: Bool
     /// Minutes before expiry. Multiple values schedule one reminder each (2.2 parity).
     public var creditExpiryLeadMinutes: [Int]
+    /// Auto-start Live Activity when remaining allowance hits the threshold.
+    public var liveMonitorAutoStartEnabled: Bool
+    public var liveMonitorAutoStartMetric: AlertMetric
+    public var liveMonitorAutoStartThreshold: Int
 
     public init(
         appearance: AppAppearance = .system,
@@ -63,7 +67,10 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         creditIncreaseAlertsEnabled: Bool = true,
         unexpectedRefillAlertsEnabled: Bool = true,
         creditExpiryRemindersEnabled: Bool = true,
-        creditExpiryLeadMinutes: [Int] = AppSettings.defaultCreditExpiryLeadMinutes
+        creditExpiryLeadMinutes: [Int] = AppSettings.defaultCreditExpiryLeadMinutes,
+        liveMonitorAutoStartEnabled: Bool = false,
+        liveMonitorAutoStartMetric: AlertMetric = .both,
+        liveMonitorAutoStartThreshold: Int = 25
     ) {
         self.appearance = appearance
         self.refreshOnLaunch = refreshOnLaunch
@@ -75,6 +82,11 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         self.unexpectedRefillAlertsEnabled = unexpectedRefillAlertsEnabled
         self.creditExpiryRemindersEnabled = creditExpiryRemindersEnabled
         self.creditExpiryLeadMinutes = Self.sanitizedLeadMinutes(creditExpiryLeadMinutes)
+        self.liveMonitorAutoStartEnabled = liveMonitorAutoStartEnabled
+        self.liveMonitorAutoStartMetric = liveMonitorAutoStartMetric
+        self.liveMonitorAutoStartThreshold = Self.allowedAlertThresholds.contains(liveMonitorAutoStartThreshold)
+            ? liveMonitorAutoStartThreshold
+            : 25
     }
 
     public var effectiveCreditExpiryLeadMinutes: [Int] {
@@ -108,6 +120,9 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         case unexpectedRefillAlertsEnabled
         case creditExpiryRemindersEnabled
         case creditExpiryLeadMinutes
+        case liveMonitorAutoStartEnabled
+        case liveMonitorAutoStartMetric
+        case liveMonitorAutoStartThreshold
     }
 
     public init(from decoder: any Decoder) throws {
@@ -123,7 +138,10 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
             unexpectedRefillAlertsEnabled: try container.decodeIfPresent(Bool.self, forKey: .unexpectedRefillAlertsEnabled) ?? true,
             creditExpiryRemindersEnabled: try container.decodeIfPresent(Bool.self, forKey: .creditExpiryRemindersEnabled) ?? true,
             creditExpiryLeadMinutes: try container.decodeIfPresent([Int].self, forKey: .creditExpiryLeadMinutes)
-                ?? Self.defaultCreditExpiryLeadMinutes
+                ?? Self.defaultCreditExpiryLeadMinutes,
+            liveMonitorAutoStartEnabled: try container.decodeIfPresent(Bool.self, forKey: .liveMonitorAutoStartEnabled) ?? false,
+            liveMonitorAutoStartMetric: try container.decodeIfPresent(AlertMetric.self, forKey: .liveMonitorAutoStartMetric) ?? .both,
+            liveMonitorAutoStartThreshold: try container.decodeIfPresent(Int.self, forKey: .liveMonitorAutoStartThreshold) ?? 25
         )
     }
 }

--- a/ios/CodexMeter/Infrastructure/LiveActivityCoordinator.swift
+++ b/ios/CodexMeter/Infrastructure/LiveActivityCoordinator.swift
@@ -1,0 +1,154 @@
+import ActivityKit
+import CodexMeterCore
+import Foundation
+
+/// Starts, updates, and ends the Codex usage Live Activity.
+@MainActor
+final class LiveActivityCoordinator {
+    static let shared = LiveActivityCoordinator()
+
+    private static let dismissedWindowTokenKey = "codex-meter.live-monitor.dismissed-window"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var isSupported: Bool {
+        ActivityAuthorizationInfo().areActivitiesEnabled
+    }
+
+    var isActive: Bool {
+        !Activity<UsageLiveMonitorAttributes>.activities.isEmpty
+    }
+
+    var activeCount: Int {
+        Activity<UsageLiveMonitorAttributes>.activities.count
+    }
+
+    func start(
+        usage: UsageSnapshot,
+        creditCount: Int,
+        planLabel: String,
+        isDemo: Bool,
+        isCached: Bool
+    ) async throws {
+        guard isSupported else {
+            throw LiveActivityError.disabled
+        }
+        let state = UsageLiveMonitorState.from(
+            usage: usage,
+            creditCount: creditCount,
+            planLabel: planLabel,
+            isDemo: isDemo,
+            isCached: isCached
+        )
+        defaults.removeObject(forKey: Self.dismissedWindowTokenKey)
+
+        if let existing = Activity<UsageLiveMonitorAttributes>.activities.first {
+            let content = ActivityContent(state: state, staleDate: state.nextResetAt)
+            await existing.update(content)
+            return
+        }
+
+        let attributes = UsageLiveMonitorAttributes(startedAt: Date())
+        let content = ActivityContent(state: state, staleDate: state.nextResetAt)
+        _ = try Activity.request(
+            attributes: attributes,
+            content: content,
+            pushType: nil
+        )
+    }
+
+    func update(
+        usage: UsageSnapshot,
+        creditCount: Int,
+        planLabel: String,
+        isDemo: Bool,
+        isCached: Bool,
+        now: Date = Date()
+    ) async {
+        let activities = Activity<UsageLiveMonitorAttributes>.activities
+        guard !activities.isEmpty else { return }
+
+        let state = UsageLiveMonitorState.from(
+            usage: usage,
+            creditCount: creditCount,
+            planLabel: planLabel,
+            isDemo: isDemo,
+            isCached: isCached,
+            now: now
+        )
+
+        if let next = state.nextResetAt, next <= now {
+            await end(dismissed: false)
+            return
+        }
+
+        let content = ActivityContent(state: state, staleDate: state.nextResetAt)
+        for activity in activities {
+            await activity.update(content)
+        }
+    }
+
+    /// Ends all usage monitor activities.
+    /// - Parameter dismissed: when true, suppress auto-start for the current window token.
+    func end(
+        dismissed: Bool,
+        usage: UsageSnapshot? = nil
+    ) async {
+        if dismissed, let usage {
+            let five = usage.fiveHour?.effectiveResetDate(relativeTo: usage.fetchedAt)
+            let weekly = usage.weekly?.effectiveResetDate(relativeTo: usage.fetchedAt)
+            defaults.set(
+                LiveMonitorAutoStart.windowToken(fiveHourReset: five, weeklyReset: weekly),
+                forKey: Self.dismissedWindowTokenKey
+            )
+        }
+        for activity in Activity<UsageLiveMonitorAttributes>.activities {
+            let content = ActivityContent(
+                state: activity.content.state,
+                staleDate: nil
+            )
+            await activity.end(content, dismissalPolicy: .immediate)
+        }
+    }
+
+    func shouldAutoStart(
+        settings: AppSettings,
+        usage: UsageSnapshot
+    ) -> Bool {
+        guard settings.liveMonitorAutoStartEnabled else { return false }
+        guard !isActive else { return false }
+
+        let five = usage.fiveHour?.effectiveResetDate(relativeTo: usage.fetchedAt)
+        let weekly = usage.weekly?.effectiveResetDate(relativeTo: usage.fetchedAt)
+        let token = LiveMonitorAutoStart.windowToken(fiveHourReset: five, weeklyReset: weekly)
+        if defaults.string(forKey: Self.dismissedWindowTokenKey) == token {
+            return false
+        }
+
+        return LiveMonitorAutoStart.shouldStart(
+            enabled: true,
+            metric: settings.liveMonitorAutoStartMetric.rawValue,
+            threshold: settings.liveMonitorAutoStartThreshold,
+            fiveHour: usage.fiveHour,
+            weekly: usage.weekly
+        )
+    }
+}
+
+enum LiveActivityError: LocalizedError {
+    case disabled
+    case noUsage
+
+    var errorDescription: String? {
+        switch self {
+        case .disabled:
+            return "Live Activities are disabled. Enable them in Settings → Codex Meter."
+        case .noUsage:
+            return "No usage data available to start the monitor."
+        }
+    }
+}

--- a/ios/CodexMeter/Infrastructure/PhoneWatchBridge.swift
+++ b/ios/CodexMeter/Infrastructure/PhoneWatchBridge.swift
@@ -1,0 +1,82 @@
+import CodexMeterCore
+import Foundation
+import WatchConnectivity
+
+/// Pushes sanitized usage snapshots to a paired Apple Watch.
+@MainActor
+final class PhoneWatchBridge: NSObject, WCSessionDelegate {
+    static let shared = PhoneWatchBridge()
+
+    private var lastSnapshot: SharedWidgetSnapshot?
+    private var didActivate = false
+
+    func activateIfNeeded() {
+        guard WCSession.isSupported() else { return }
+        let session = WCSession.default
+        if session.delegate == nil {
+            session.delegate = self
+        }
+        if session.activationState != .activated && !didActivate {
+            didActivate = true
+            session.activate()
+        }
+    }
+
+    /// Best-effort push. Safe to call after every widget snapshot write.
+    func push(snapshot: SharedWidgetSnapshot) {
+        lastSnapshot = snapshot
+        activateIfNeeded()
+        guard WCSession.isSupported() else { return }
+        let session = WCSession.default
+        guard session.activationState == .activated else { return }
+        guard session.isPaired else { return }
+
+        do {
+            let context = try WatchSyncPayload.applicationContext(for: snapshot)
+            try session.updateApplicationContext(context)
+            if session.isComplicationEnabled {
+                session.transferCurrentComplicationUserInfo(context)
+            }
+        } catch {
+            // Watch is optional; never fail phone refresh paths.
+        }
+    }
+
+    // MARK: - WCSessionDelegate
+
+    nonisolated func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        Task { @MainActor in
+            if activationState == .activated, let lastSnapshot {
+                push(snapshot: lastSnapshot)
+            }
+        }
+    }
+
+    nonisolated func sessionDidBecomeInactive(_ session: WCSession) {}
+
+    nonisolated func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+
+    nonisolated func session(
+        _ session: WCSession,
+        didReceiveMessage message: [String: Any],
+        replyHandler: @escaping ([String: Any]) -> Void
+    ) {
+        // Acknowledge on the WCSession queue, then re-push last snapshot on main.
+        replyHandler(["ok": true])
+        Task { @MainActor in
+            PhoneWatchBridge.shared.repushLastSnapshot()
+        }
+    }
+
+    fileprivate func repushLastSnapshot() {
+        if let lastSnapshot {
+            push(snapshot: lastSnapshot)
+        }
+    }
+}

--- a/ios/CodexMeter/Infrastructure/SettingsTransfer.swift
+++ b/ios/CodexMeter/Infrastructure/SettingsTransfer.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+/// Portable Codex Meter transfer document for iOS.
+///
+/// Inspired by Android `SettingsTransfer` (format + sections). Authentication
+/// sections contain usable ChatGPT OAuth tokens and must never be shared.
+enum SettingsTransfer {
+    static let format = "codex_meter_transfer"
+    static let version = 1
+    static let platform = "ios"
+
+    static let sectionAppSettings = "app_settings"
+    static let sectionNotifications = "notifications"
+    static let sectionAuthentication = "authentication"
+
+    static let securityWarning =
+        "IMPORTANT: This file contains ChatGPT authentication tokens. "
+        + "Anyone with this file can access your ChatGPT account. "
+        + "Do not share it, upload it, or send it to anyone. "
+        + "Keep it only on devices you trust."
+
+    struct Document: Codable, Equatable, Sendable {
+        var format: String
+        var version: Int
+        var platform: String?
+        var exportedAt: Date
+        var securityWarning: String?
+        var sections: Sections
+
+        struct Sections: Codable, Equatable, Sendable {
+            var appSettings: AppSettingsPayload?
+            var notifications: NotificationsPayload?
+            var authentication: AuthenticationPayload?
+
+            enum CodingKeys: String, CodingKey {
+                case appSettings = "app_settings"
+                case notifications
+                case authentication
+            }
+
+            var hasAnySection: Bool {
+                appSettings != nil || notifications != nil || authentication != nil
+            }
+        }
+    }
+
+    struct AppSettingsPayload: Codable, Equatable, Sendable {
+        var appearance: String?
+        var refreshOnLaunch: Bool?
+        var refreshMinutes: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case appearance
+            case refreshOnLaunch = "refresh_on_launch"
+            case refreshMinutes = "refresh_minutes"
+        }
+    }
+
+    struct NotificationsPayload: Codable, Equatable, Sendable {
+        var notificationsEnabled: Bool?
+        var alertMetric: String?
+        var alertThreshold: Int?
+        var creditIncreaseAlertsEnabled: Bool?
+        var unexpectedRefillAlertsEnabled: Bool?
+        var creditExpiryRemindersEnabled: Bool?
+        var creditExpiryLeadMinutes: [Int]?
+
+        enum CodingKeys: String, CodingKey {
+            case notificationsEnabled = "notifications_enabled"
+            case alertMetric = "alert_metric"
+            case alertThreshold = "alert_threshold"
+            case creditIncreaseAlertsEnabled = "credit_increase_alerts_enabled"
+            case unexpectedRefillAlertsEnabled = "unexpected_refill_alerts_enabled"
+            case creditExpiryRemindersEnabled = "credit_expiry_reminders_enabled"
+            case creditExpiryLeadMinutes = "credit_expiry_lead_minutes"
+        }
+    }
+
+    struct AuthenticationPayload: Codable, Equatable, Sendable {
+        var accessToken: String
+        var refreshToken: String
+        var idToken: String
+        var expiresAt: Date
+        var accountID: String?
+        var email: String?
+
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case refreshToken = "refresh_token"
+            case idToken = "id_token"
+            case expiresAt = "expires_at"
+            case accountID = "account_id"
+            case email
+        }
+    }
+
+    struct ExportOptions: Equatable, Sendable {
+        var includeAppSettings = true
+        var includeNotifications = true
+        var includeAuthentication = false
+    }
+
+    struct ImportOptions: Equatable, Sendable {
+        var importAppSettings = true
+        var importNotifications = true
+        var importAuthentication = false
+    }
+
+    enum TransferError: LocalizedError {
+        case empty
+        case invalidFormat
+        case unsupportedVersion(Int)
+        case noSections
+        case noSelectedSections
+        case invalidAuthentication
+
+        var errorDescription: String? {
+            switch self {
+            case .empty:
+                return "Transfer file is empty."
+            case .invalidFormat:
+                return "Not a Codex Meter transfer file."
+            case .unsupportedVersion(let version):
+                return "Unsupported transfer file version: \(version)."
+            case .noSections:
+                return "Transfer file does not contain any sections."
+            case .noSelectedSections:
+                return "Choose at least one section to import."
+            case .invalidAuthentication:
+                return "Authentication section is incomplete or unusable."
+            }
+        }
+    }
+
+    // MARK: - Build / parse
+
+    static func makeDocument(
+        settings: AppSettings,
+        tokens: AuthTokens?,
+        options: ExportOptions,
+        exportedAt: Date = Date()
+    ) -> Document {
+        var sections = Document.Sections()
+        if options.includeAppSettings {
+            sections.appSettings = AppSettingsPayload(
+                appearance: settings.appearance.rawValue,
+                refreshOnLaunch: settings.refreshOnLaunch,
+                refreshMinutes: settings.refreshMinutes
+            )
+        }
+        if options.includeNotifications {
+            sections.notifications = NotificationsPayload(
+                notificationsEnabled: settings.notificationsEnabled,
+                alertMetric: settings.alertMetric.rawValue,
+                alertThreshold: settings.alertThreshold,
+                creditIncreaseAlertsEnabled: settings.creditIncreaseAlertsEnabled,
+                unexpectedRefillAlertsEnabled: settings.unexpectedRefillAlertsEnabled,
+                creditExpiryRemindersEnabled: settings.creditExpiryRemindersEnabled,
+                creditExpiryLeadMinutes: settings.creditExpiryLeadMinutes
+            )
+        }
+        var warning: String?
+        if options.includeAuthentication, let tokens, tokens.isUsable {
+            sections.authentication = AuthenticationPayload(
+                accessToken: tokens.accessToken,
+                refreshToken: tokens.refreshToken,
+                idToken: tokens.idToken,
+                expiresAt: tokens.expiresAt,
+                accountID: tokens.accountID,
+                email: tokens.email
+            )
+            warning = securityWarning
+        }
+        return Document(
+            format: format,
+            version: version,
+            platform: platform,
+            exportedAt: exportedAt,
+            securityWarning: warning,
+            sections: sections
+        )
+    }
+
+    static func encode(_ document: Document) throws -> Data {
+        guard document.sections.hasAnySection else {
+            throw TransferError.noSections
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(document)
+    }
+
+    static func parse(_ data: Data) throws -> Document {
+        guard !data.isEmpty else { throw TransferError.empty }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let document: Document
+        do {
+            document = try decoder.decode(Document.self, from: data)
+        } catch {
+            throw TransferError.invalidFormat
+        }
+        guard document.format == format else {
+            throw TransferError.invalidFormat
+        }
+        guard document.version >= 1, document.version <= version else {
+            throw TransferError.unsupportedVersion(document.version)
+        }
+        guard document.sections.hasAnySection else {
+            throw TransferError.noSections
+        }
+        return document
+    }
+
+    static func apply(
+        document: Document,
+        to settings: AppSettings,
+        options: ImportOptions
+    ) throws -> (settings: AppSettings, tokens: AuthTokens?) {
+        if !options.importAppSettings && !options.importNotifications && !options.importAuthentication {
+            throw TransferError.noSelectedSections
+        }
+
+        var next = settings
+        if options.importAppSettings, let app = document.sections.appSettings {
+            if let raw = app.appearance, let appearance = AppAppearance(rawValue: raw) {
+                next.appearance = appearance
+            }
+            if let refreshOnLaunch = app.refreshOnLaunch {
+                next.refreshOnLaunch = refreshOnLaunch
+            }
+            if let minutes = app.refreshMinutes,
+               AppSettings.allowedRefreshMinutes.contains(minutes) {
+                next.refreshMinutes = minutes
+            }
+        }
+
+        if options.importNotifications, let notes = document.sections.notifications {
+            if let enabled = notes.notificationsEnabled {
+                next.notificationsEnabled = enabled
+            }
+            if let raw = notes.alertMetric, let metric = AlertMetric(rawValue: raw) {
+                next.alertMetric = metric
+            }
+            if let threshold = notes.alertThreshold,
+               AppSettings.allowedAlertThresholds.contains(threshold) {
+                next.alertThreshold = threshold
+            }
+            if let value = notes.creditIncreaseAlertsEnabled {
+                next.creditIncreaseAlertsEnabled = value
+            }
+            if let value = notes.unexpectedRefillAlertsEnabled {
+                next.unexpectedRefillAlertsEnabled = value
+            }
+            if let value = notes.creditExpiryRemindersEnabled {
+                next.creditExpiryRemindersEnabled = value
+            }
+            if let leads = notes.creditExpiryLeadMinutes {
+                next.creditExpiryLeadMinutes = leads.filter {
+                    AppSettings.allowedCreditExpiryLeadMinutes.contains($0)
+                }.sorted()
+                if next.creditExpiryLeadMinutes.isEmpty {
+                    next.creditExpiryLeadMinutes = AppSettings.defaultCreditExpiryLeadMinutes
+                }
+            }
+        }
+
+        var tokens: AuthTokens?
+        if options.importAuthentication {
+            guard let auth = document.sections.authentication else {
+                throw TransferError.invalidAuthentication
+            }
+            let candidate = AuthTokens(
+                accessToken: auth.accessToken,
+                refreshToken: auth.refreshToken,
+                idToken: auth.idToken,
+                expiresAt: auth.expiresAt,
+                accountID: auth.accountID ?? "",
+                email: auth.email ?? ""
+            )
+            guard candidate.isUsable else {
+                throw TransferError.invalidAuthentication
+            }
+            tokens = candidate
+        }
+
+        return (next, tokens)
+    }
+
+    static func defaultFileName(date: Date = Date()) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return "codex-meter-transfer-\(formatter.string(from: date)).json"
+    }
+}

--- a/ios/CodexMeter/Infrastructure/WidgetSnapshotCache.swift
+++ b/ios/CodexMeter/Infrastructure/WidgetSnapshotCache.swift
@@ -42,6 +42,9 @@ public actor WidgetSnapshotCache {
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(snapshot)
         try data.write(to: fileURL, options: [.atomic])
+        await MainActor.run {
+            PhoneWatchBridge.shared.push(snapshot: snapshot)
+        }
     }
 
     public func publish(

--- a/ios/CodexMeter/Services/LiveCodexService.swift
+++ b/ios/CodexMeter/Services/LiveCodexService.swift
@@ -204,6 +204,12 @@ public actor LiveCodexService: CodexService {
         try await authSession.currentTokens()
     }
 
+    /// Writes credentials from a transfer import. Caller must only invoke after
+    /// an explicit user confirmation.
+    public func storeImportedTokens(_ tokens: AuthTokens) async throws {
+        try await authSession.store(tokens)
+    }
+
     public func signOut() async {
         activeRefresh?.cancel()
         activeRefresh = nil

--- a/ios/CodexMeter/Views/AboutView.swift
+++ b/ios/CodexMeter/Views/AboutView.swift
@@ -29,12 +29,20 @@ struct AboutView: View {
 
             Section("Source and credits") {
                 Link("BenItBuhner/Codex-Meter", destination: URL(string: "https://github.com/BenItBuhner/Codex-Meter")!)
+                Link("GitHub Releases (what’s new)", destination: URL(string: "https://github.com/BenItBuhner/Codex-Meter/releases")!)
                 LabeledContent("Original project", value: "Bennett")
                 LabeledContent("License", value: "MIT")
+                LabeledContent("iOS marketing version", value: version)
                 NavigationLink("Open-source notices") {
                     OpenSourceNoticesView()
                 }
                 Link("OpenAI", destination: URL(string: "https://openai.com")!)
+            }
+
+            Section {
+                Text("Release notes and Android APKs are published on GitHub. This iOS app is not updated via in-app APK install; use TestFlight or the App Store when available.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Important") {

--- a/ios/CodexMeter/Views/DashboardView.swift
+++ b/ios/CodexMeter/Views/DashboardView.swift
@@ -59,6 +59,15 @@ struct DashboardView: View {
                     }
 
                     ResetCreditsCard()
+
+                    if model.isLiveMonitorActive {
+                        StatusBanner(
+                            message: "Usage monitor is live on Lock Screen / Dynamic Island",
+                            systemImage: "dot.radiowaves.left.and.right",
+                            tint: .mint
+                        )
+                    }
+
                     PrivacyFootnote()
                 }
             }

--- a/ios/CodexMeter/Views/OnboardingView.swift
+++ b/ios/CodexMeter/Views/OnboardingView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @Environment(AppModel.self) private var model
+    @State private var page = 0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $page) {
+                onboardingPage(
+                    tag: 0,
+                    systemImage: "gauge.with.dots.needle.67percent",
+                    title: "Codex allowance at a glance",
+                    bodyText: "See your five-hour and weekly Codex windows, reset times, and earned reset credits on iPhone and iPad."
+                )
+                onboardingPage(
+                    tag: 1,
+                    systemImage: "lock.shield.fill",
+                    title: "Local and private",
+                    bodyText: "OAuth tokens stay in the device Keychain. There is no analytics relay. Demo mode never contacts OpenAI."
+                )
+                onboardingPage(
+                    tag: 2,
+                    systemImage: "person.badge.key.fill",
+                    title: "Connect when you are ready",
+                    bodyText: "Sign in with ChatGPT using OpenAI’s device-code flow, or explore offline demo data first."
+                )
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .animation(.snappy, value: page)
+
+            VStack(spacing: 12) {
+                if page < 2 {
+                    Button("Continue") {
+                        withAnimation { page += 1 }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity)
+                } else {
+                    Button("Sign in with ChatGPT") {
+                        model.completeOnboarding()
+                        model.isShowingSignIn = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity)
+
+                    Button("Explore demo") {
+                        model.completeOnboarding()
+                        Task { await model.enterDemo() }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity)
+
+                    Button("Skip for now") {
+                        model.completeOnboarding()
+                    }
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 28)
+            .padding(.top, 8)
+        }
+        .background(Color(.systemGroupedBackground))
+    }
+
+    private func onboardingPage(
+        tag: Int,
+        systemImage: String,
+        title: String,
+        bodyText: String
+    ) -> some View {
+        VStack(spacing: 22) {
+            Spacer(minLength: 24)
+            Image(systemName: systemImage)
+                .font(.system(size: 56, weight: .medium))
+                .foregroundStyle(.tint)
+                .symbolRenderingMode(.hierarchical)
+                .accessibilityHidden(true)
+            Text(title)
+                .font(.title2.bold())
+                .multilineTextAlignment(.center)
+            Text(bodyText)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 12)
+            Spacer(minLength: 24)
+        }
+        .padding(28)
+        .tag(tag)
+    }
+}
+
+#Preview {
+    OnboardingView()
+        .environment(AppModel.preview)
+}

--- a/ios/CodexMeter/Views/SettingsView.swift
+++ b/ios/CodexMeter/Views/SettingsView.swift
@@ -1,10 +1,21 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @Environment(AppModel.self) private var model
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
     @State private var confirmingSignOut = false
+    @State private var exportIncludeAuth = false
+    @State private var importIncludeAuth = false
+    @State private var confirmingAuthExport = false
+    @State private var confirmingAuthImport = false
+    @State private var isExporting = false
+    @State private var isImporting = false
+    @State private var exportDocument: TransferFileDocument?
+    @State private var showExporter = false
+    @State private var showImporter = false
+    @State private var transferError: String?
 
     var body: some View {
         @Bindable var model = model
@@ -110,6 +121,55 @@ struct SettingsView: View {
             .disabled(model.mode == .signedOut)
 
             Section {
+                Toggle("Include ChatGPT credentials", isOn: $exportIncludeAuth)
+                Button {
+                    if exportIncludeAuth {
+                        confirmingAuthExport = true
+                    } else {
+                        Task { await prepareExport(includeAuth: false) }
+                    }
+                } label: {
+                    if isExporting {
+                        ProgressView()
+                    } else {
+                        Text("Export settings…")
+                    }
+                }
+                .disabled(isExporting)
+
+                Toggle("Import ChatGPT credentials", isOn: $importIncludeAuth)
+                Button {
+                    if importIncludeAuth {
+                        confirmingAuthImport = true
+                    } else {
+                        showImporter = true
+                    }
+                } label: {
+                    if isImporting {
+                        ProgressView()
+                    } else {
+                        Text("Import settings…")
+                    }
+                }
+                .disabled(isImporting)
+
+                if let transferError {
+                    Text(transferError)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+                if let status = model.transferStatusMessage {
+                    Text(status)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Transfer")
+            } footer: {
+                Text("Exports a JSON file with app and notification preferences. Including credentials embeds live OAuth tokens — only store that file on devices you trust.")
+            }
+
+            Section {
                 NavigationLink("About Codex Meter") {
                     AboutView()
                 }
@@ -146,6 +206,97 @@ struct SettingsView: View {
         } message: {
             Text("Credentials and cached account data will be removed from this device and its widgets.")
         }
+        .confirmationDialog(
+            "Export credentials?",
+            isPresented: $confirmingAuthExport,
+            titleVisibility: .visible
+        ) {
+            Button("Export with credentials", role: .destructive) {
+                Task { await prepareExport(includeAuth: true) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(SettingsTransfer.securityWarning)
+        }
+        .confirmationDialog(
+            "Import credentials?",
+            isPresented: $confirmingAuthImport,
+            titleVisibility: .visible
+        ) {
+            Button("Import including credentials", role: .destructive) {
+                showImporter = true
+            }
+            Button("Cancel", role: .cancel) {
+                importIncludeAuth = false
+            }
+        } message: {
+            Text(SettingsTransfer.securityWarning + " Imported tokens replace any account currently signed in on this device.")
+        }
+        .fileExporter(
+            isPresented: $showExporter,
+            document: exportDocument,
+            contentType: .json,
+            defaultFilename: SettingsTransfer.defaultFileName()
+        ) { result in
+            if case .failure(let error) = result {
+                transferError = error.localizedDescription
+            } else {
+                model.transferStatusMessage = "Settings exported."
+            }
+        }
+        .fileImporter(
+            isPresented: $showImporter,
+            allowedContentTypes: [.json, .data],
+            allowsMultipleSelection: false
+        ) { result in
+            Task { await handleImport(result) }
+        }
+    }
+
+    private func prepareExport(includeAuth: Bool) async {
+        isExporting = true
+        transferError = nil
+        model.transferStatusMessage = nil
+        defer { isExporting = false }
+        do {
+            let data = try await model.exportTransferData(
+                options: SettingsTransfer.ExportOptions(
+                    includeAppSettings: true,
+                    includeNotifications: true,
+                    includeAuthentication: includeAuth
+                )
+            )
+            exportDocument = TransferFileDocument(data: data)
+            showExporter = true
+        } catch {
+            transferError = error.localizedDescription
+        }
+    }
+
+    private func handleImport(_ result: Result<[URL], Error>) async {
+        isImporting = true
+        transferError = nil
+        model.transferStatusMessage = nil
+        defer { isImporting = false }
+        do {
+            let urls = try result.get()
+            guard let url = urls.first else { return }
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessed { url.stopAccessingSecurityScopedResource() }
+            }
+            let data = try Data(contentsOf: url)
+            try await model.importTransferData(
+                data,
+                options: SettingsTransfer.ImportOptions(
+                    importAppSettings: true,
+                    importNotifications: true,
+                    importAuthentication: importIncludeAuth
+                )
+            )
+        } catch {
+            transferError = error.localizedDescription
+        }
     }
 
     private func leadTimeBinding(_ minutes: Int, model: AppModel) -> Binding<Bool> {
@@ -157,7 +308,6 @@ struct SettingsView: View {
                 if isOn != currentlyOn {
                     settings.toggleCreditExpiryLeadMinutes(minutes)
                 }
-                // Keep at least the default when the user clears every lead time.
                 if settings.creditExpiryLeadMinutes.isEmpty {
                     settings.creditExpiryLeadMinutes = AppSettings.defaultCreditExpiryLeadMinutes
                 }
@@ -185,5 +335,23 @@ struct SettingsView: View {
             }
             return "Remind \(minutes) minutes before"
         }
+    }
+}
+
+private struct TransferFileDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.json] }
+
+    var data: Data
+
+    init(data: Data) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        data = configuration.file.regularFileContents ?? Data()
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
     }
 }

--- a/ios/CodexMeter/Views/SettingsView.swift
+++ b/ios/CodexMeter/Views/SettingsView.swift
@@ -121,6 +121,48 @@ struct SettingsView: View {
             .disabled(model.mode == .signedOut)
 
             Section {
+                LabeledContent(
+                    "Live Activities",
+                    value: model.isLiveMonitorActive
+                        ? "Running"
+                        : (LiveActivityCoordinator.shared.isSupported ? "Off" : "Disabled")
+                )
+                if model.isLiveMonitorActive {
+                    Button("Stop usage monitor") {
+                        Task { await model.stopLiveMonitor(dismissed: true) }
+                    }
+                } else {
+                    Button("Start usage monitor") {
+                        Task { await model.startLiveMonitor() }
+                    }
+                    .disabled(model.mode == .signedOut || model.usage == nil)
+                }
+                Toggle("Auto-start when low", isOn: $model.settings.liveMonitorAutoStartEnabled)
+                if model.settings.liveMonitorAutoStartEnabled {
+                    Picker("Auto-start windows", selection: $model.settings.liveMonitorAutoStartMetric) {
+                        ForEach(AlertMetric.allCases) { metric in
+                            Text(metric.title).tag(metric)
+                        }
+                    }
+                    Picker("Auto-start at remaining", selection: $model.settings.liveMonitorAutoStartThreshold) {
+                        ForEach([10, 25, 50, 75, 100], id: \.self) { value in
+                            Text(value == 100 ? "Always when data exists" : "\(value)% or lower").tag(value)
+                        }
+                    }
+                }
+                if let liveMonitorMessage = model.liveMonitorMessage {
+                    Text(liveMonitorMessage)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Usage monitor")
+            } footer: {
+                Text("Shows five-hour and weekly remaining on the Lock Screen and Dynamic Island until the next reset, you stop it, or you sign out. iOS cannot guarantee exact background timing like Android alarms.")
+            }
+            .disabled(model.mode == .signedOut)
+
+            Section {
                 Toggle("Include ChatGPT credentials", isOn: $exportIncludeAuth)
                 Button {
                     if exportIncludeAuth {

--- a/ios/CodexMeterCore/Package.swift
+++ b/ios/CodexMeterCore/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     name: "CodexMeterCore",
     platforms: [
         .iOS("26.0"),
+        .watchOS("11.0"),
     ],
     products: [
         .library(

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsageLiveMonitorAttributes.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsageLiveMonitorAttributes.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+#if canImport(ActivityKit) && os(iOS)
+import ActivityKit
+#endif
+
+/// Pure helpers for live-monitor auto-start decisions (Android `NowBarAutoStart` parity).
+public enum LiveMonitorAutoStart {
+    public static func shouldStart(
+        enabled: Bool,
+        metric: String,
+        threshold: Int,
+        fiveHour: UsageWindow?,
+        weekly: UsageWindow?
+    ) -> Bool {
+        guard enabled else { return false }
+        guard [10, 25, 50, 75, 100].contains(threshold) else { return false }
+        let normalized = normalizeMetric(metric)
+        if normalized != "weekly",
+           let fiveHour,
+           fiveHour.remainingPercent <= threshold {
+            return true
+        }
+        if normalized != "fiveHour",
+           let weekly,
+           weekly.remainingPercent <= threshold {
+            return true
+        }
+        return false
+    }
+
+    public static func normalizeMetric(_ metric: String) -> String {
+        switch metric {
+        case "fiveHour", "five_hour": return "fiveHour"
+        case "weekly": return "weekly"
+        default: return "both"
+        }
+    }
+
+    /// Token that identifies the current monitor window pair for dismiss suppression.
+    public static func windowToken(
+        fiveHourReset: Date?,
+        weeklyReset: Date?
+    ) -> String {
+        let five = fiveHourReset.map { Int($0.timeIntervalSince1970) } ?? 0
+        let week = weeklyReset.map { Int($0.timeIntervalSince1970) } ?? 0
+        return "\(five).\(week)"
+    }
+}
+
+/// Content rendered by the usage Live Activity (and unit-testable without ActivityKit).
+public struct UsageLiveMonitorState: Codable, Hashable, Sendable {
+    public var planLabel: String
+    public var fiveHourRemainingPercent: Int?
+    public var weeklyRemainingPercent: Int?
+    public var fiveHourResetAt: Date?
+    public var weeklyResetAt: Date?
+    public var nextResetAt: Date?
+    public var creditCount: Int
+    public var isDemo: Bool
+    public var isCached: Bool
+    public var updatedAt: Date
+
+    public init(
+        planLabel: String = "",
+        fiveHourRemainingPercent: Int? = nil,
+        weeklyRemainingPercent: Int? = nil,
+        fiveHourResetAt: Date? = nil,
+        weeklyResetAt: Date? = nil,
+        nextResetAt: Date? = nil,
+        creditCount: Int = 0,
+        isDemo: Bool = false,
+        isCached: Bool = false,
+        updatedAt: Date = Date()
+    ) {
+        self.planLabel = planLabel
+        self.fiveHourRemainingPercent = fiveHourRemainingPercent
+        self.weeklyRemainingPercent = weeklyRemainingPercent
+        self.fiveHourResetAt = fiveHourResetAt
+        self.weeklyResetAt = weeklyResetAt
+        self.nextResetAt = nextResetAt
+        self.creditCount = max(0, creditCount)
+        self.isDemo = isDemo
+        self.isCached = isCached
+        self.updatedAt = updatedAt
+    }
+
+    public var primaryRemainingPercent: Int? {
+        [fiveHourRemainingPercent, weeklyRemainingPercent].compactMap { $0 }.min()
+    }
+
+    public static func from(
+        usage: UsageSnapshot,
+        creditCount: Int,
+        planLabel: String,
+        isDemo: Bool,
+        isCached: Bool,
+        now: Date = Date()
+    ) -> Self {
+        let fiveReset = usage.fiveHour?.effectiveResetDate(relativeTo: usage.fetchedAt)
+        let weeklyReset = usage.weekly?.effectiveResetDate(relativeTo: usage.fetchedAt)
+        let next = usage.nextReset(after: now)
+        return Self(
+            planLabel: planLabel,
+            fiveHourRemainingPercent: usage.fiveHour?.remainingPercent,
+            weeklyRemainingPercent: usage.weekly?.remainingPercent,
+            fiveHourResetAt: fiveReset,
+            weeklyResetAt: weeklyReset,
+            nextResetAt: next,
+            creditCount: creditCount,
+            isDemo: isDemo,
+            isCached: isCached,
+            updatedAt: now
+        )
+    }
+}
+
+#if canImport(ActivityKit) && os(iOS)
+/// Live Activity attributes for the ongoing Codex usage monitor.
+public struct UsageLiveMonitorAttributes: ActivityAttributes {
+    public typealias ContentState = UsageLiveMonitorState
+
+    public var startedAt: Date
+
+    public init(startedAt: Date = Date()) {
+        self.startedAt = startedAt
+    }
+}
+#endif

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/WatchSyncPayload.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/WatchSyncPayload.swift
@@ -4,6 +4,8 @@ import Foundation
 /// Phone and watch exchange only this sanitized schema — never tokens.
 public enum WatchSyncPayload {
     public static let contextKey = "codex_meter_watch_snapshot_v1"
+    /// UserDefaults key on the watch for the last received snapshot (app + complications).
+    public static let watchDefaultsKey = "codex-meter.watch.snapshot-v1"
     public static let format = "codex_meter_watch_snapshot"
     public static let version = 1
 

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/WatchSyncPayload.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/WatchSyncPayload.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Property-list-safe WatchConnectivity payload wrapping `SharedWidgetSnapshot`.
+/// Phone and watch exchange only this sanitized schema — never tokens.
+public enum WatchSyncPayload {
+    public static let contextKey = "codex_meter_watch_snapshot_v1"
+    public static let format = "codex_meter_watch_snapshot"
+    public static let version = 1
+
+    public static func encode(_ snapshot: SharedWidgetSnapshot) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(Envelope(format: format, version: version, snapshot: snapshot))
+    }
+
+    public static func decode(_ data: Data) throws -> SharedWidgetSnapshot {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(Envelope.self, from: data)
+        guard envelope.format == format, envelope.version == version else {
+            throw WatchSyncError.invalidFormat
+        }
+        return envelope.snapshot
+    }
+
+    /// `WCSession` applicationContext / userInfo entry.
+    public static func applicationContext(for snapshot: SharedWidgetSnapshot) throws -> [String: Any] {
+        [contextKey: try encode(snapshot)]
+    }
+
+    public static func snapshot(fromApplicationContext context: [String: Any]) throws -> SharedWidgetSnapshot {
+        guard let data = context[contextKey] as? Data else {
+            throw WatchSyncError.missingPayload
+        }
+        return try decode(data)
+    }
+
+    private struct Envelope: Codable, Sendable {
+        var format: String
+        var version: Int
+        var snapshot: SharedWidgetSnapshot
+    }
+
+    public enum WatchSyncError: Error, LocalizedError {
+        case invalidFormat
+        case missingPayload
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat: "Invalid watch snapshot format."
+            case .missingPayload: "Watch payload missing."
+            }
+        }
+    }
+}

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/LiveMonitorAutoStartTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/LiveMonitorAutoStartTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import CodexMeterCore
+
+final class LiveMonitorAutoStartTests: XCTestCase {
+    func testDisabledNeverStarts() {
+        let window = UsageWindow(usedPercent: 90, windowSeconds: 18_000, resetAt: Date().addingTimeInterval(3_600))
+        XCTAssertFalse(
+            LiveMonitorAutoStart.shouldStart(
+                enabled: false,
+                metric: "both",
+                threshold: 25,
+                fiveHour: window,
+                weekly: nil
+            )
+        )
+    }
+
+    func testThresholdOnFiveHourOnly() {
+        let high = UsageWindow(usedPercent: 10, windowSeconds: 18_000, resetAt: Date().addingTimeInterval(3_600)) // 90% remaining
+        let low = UsageWindow(usedPercent: 80, windowSeconds: 18_000, resetAt: Date().addingTimeInterval(3_600)) // 20% remaining
+        XCTAssertFalse(
+            LiveMonitorAutoStart.shouldStart(
+                enabled: true,
+                metric: "both",
+                threshold: 25,
+                fiveHour: high,
+                weekly: high
+            )
+        )
+        XCTAssertTrue(
+            LiveMonitorAutoStart.shouldStart(
+                enabled: true,
+                metric: "fiveHour",
+                threshold: 25,
+                fiveHour: low,
+                weekly: high
+            )
+        )
+        XCTAssertFalse(
+            LiveMonitorAutoStart.shouldStart(
+                enabled: true,
+                metric: "weekly",
+                threshold: 25,
+                fiveHour: low,
+                weekly: high
+            )
+        )
+    }
+
+    func testContentStateFromUsage() {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let usage = UsageSnapshot(
+            planType: "plus",
+            allowed: true,
+            limitReached: false,
+            fiveHour: UsageWindow(usedPercent: 40, windowSeconds: 18_000, resetAt: now.addingTimeInterval(3_600)),
+            weekly: UsageWindow(usedPercent: 70, windowSeconds: 604_800, resetAt: now.addingTimeInterval(86_400)),
+            resetCreditsAvailable: 2,
+            fetchedAt: now
+        )
+        let state = UsageLiveMonitorState.from(
+            usage: usage,
+            creditCount: 2,
+            planLabel: "Plus",
+            isDemo: true,
+            isCached: false,
+            now: now
+        )
+        XCTAssertEqual(state.fiveHourRemainingPercent, 60)
+        XCTAssertEqual(state.weeklyRemainingPercent, 30)
+        XCTAssertEqual(state.creditCount, 2)
+        XCTAssertEqual(state.planLabel, "Plus")
+        XCTAssertTrue(state.isDemo)
+        XCTAssertEqual(state.primaryRemainingPercent, 30)
+    }
+
+    func testWindowTokenStable() {
+        let a = Date(timeIntervalSince1970: 100)
+        let b = Date(timeIntervalSince1970: 200)
+        XCTAssertEqual(
+            LiveMonitorAutoStart.windowToken(fiveHourReset: a, weeklyReset: b),
+            LiveMonitorAutoStart.windowToken(fiveHourReset: a, weeklyReset: b)
+        )
+        XCTAssertNotEqual(
+            LiveMonitorAutoStart.windowToken(fiveHourReset: a, weeklyReset: b),
+            LiveMonitorAutoStart.windowToken(fiveHourReset: b, weeklyReset: a)
+        )
+    }
+}

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/WatchSyncPayloadTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/WatchSyncPayloadTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import CodexMeterCore
+
+final class WatchSyncPayloadTests: XCTestCase {
+    func testRoundTripApplicationContext() throws {
+        let snapshot = SharedWidgetSnapshot(
+            mode: .demo,
+            fetchedAt: Date(timeIntervalSince1970: 2_000_000_000),
+            planType: "plus",
+            fiveHour: UsageWindow(usedPercent: 40, windowSeconds: 18_000),
+            weekly: UsageWindow(usedPercent: 70, windowSeconds: 604_800),
+            resetCreditsAvailable: 2,
+            freshness: .fresh
+        )
+        let context = try WatchSyncPayload.applicationContext(for: snapshot)
+        let decoded = try WatchSyncPayload.snapshot(fromApplicationContext: context)
+        XCTAssertEqual(decoded.mode, .demo)
+        XCTAssertEqual(decoded.fiveHour?.usedPercent, 40)
+        XCTAssertEqual(decoded.resetCreditsAvailable, 2)
+        XCTAssertEqual(decoded.planType, "plus")
+    }
+
+    func testMissingPayloadThrows() {
+        XCTAssertThrowsError(try WatchSyncPayload.snapshot(fromApplicationContext: [:]))
+    }
+}

--- a/ios/CodexMeterTests/NotificationPlanningTests.swift
+++ b/ios/CodexMeterTests/NotificationPlanningTests.swift
@@ -160,7 +160,8 @@ final class NotificationPlanningTests: XCTestCase {
             credits: .summary(availableCount: 1, fetchedAt: now),
             now: now
         )
-        XCTAssertNotNil(try await cache.load())
+        let published = try await cache.load()
+        XCTAssertNotNil(published)
 
         // Turn the snapshot path into a directory so the signed-out write fails.
         try FileManager.default.removeItem(at: fileURL)
@@ -173,7 +174,8 @@ final class NotificationPlanningTests: XCTestCase {
             // Expected — previous authenticated snapshot must still be wiped.
         }
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
-        XCTAssertNil(try await cache.load())
+        let afterFailure = try await cache.load()
+        XCTAssertNil(afterFailure)
     }
 
     func testAppSettingsDecodesMissing22FieldsWithDefaults() throws {

--- a/ios/CodexMeterTests/SettingsTransferTests.swift
+++ b/ios/CodexMeterTests/SettingsTransferTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import CodexMeter
+
+final class SettingsTransferTests: XCTestCase {
+    func testRoundTripAppAndNotificationSettings() throws {
+        var settings = AppSettings.defaults
+        settings.appearance = .dark
+        settings.refreshOnLaunch = false
+        settings.refreshMinutes = 60
+        settings.notificationsEnabled = true
+        settings.alertMetric = .fiveHour
+        settings.alertThreshold = 50
+        settings.creditIncreaseAlertsEnabled = false
+        settings.unexpectedRefillAlertsEnabled = false
+        settings.creditExpiryRemindersEnabled = true
+        settings.creditExpiryLeadMinutes = [60, 1_440]
+
+        let document = SettingsTransfer.makeDocument(
+            settings: settings,
+            tokens: nil,
+            options: .init(includeAppSettings: true, includeNotifications: true, includeAuthentication: false)
+        )
+        let data = try SettingsTransfer.encode(document)
+        let parsed = try SettingsTransfer.parse(data)
+        let applied = try SettingsTransfer.apply(
+            document: parsed,
+            to: .defaults,
+            options: .init(importAppSettings: true, importNotifications: true, importAuthentication: false)
+        )
+
+        XCTAssertEqual(applied.settings.appearance, .dark)
+        XCTAssertEqual(applied.settings.refreshOnLaunch, false)
+        XCTAssertEqual(applied.settings.refreshMinutes, 60)
+        XCTAssertEqual(applied.settings.notificationsEnabled, true)
+        XCTAssertEqual(applied.settings.alertMetric, .fiveHour)
+        XCTAssertEqual(applied.settings.alertThreshold, 50)
+        XCTAssertEqual(applied.settings.creditIncreaseAlertsEnabled, false)
+        XCTAssertEqual(applied.settings.unexpectedRefillAlertsEnabled, false)
+        XCTAssertEqual(applied.settings.creditExpiryLeadMinutes, [60, 1_440])
+        XCTAssertNil(applied.tokens)
+        XCTAssertNil(parsed.securityWarning)
+    }
+
+    func testAuthenticationExportIncludesSecurityWarning() throws {
+        let tokens = AuthTokens(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: "id",
+            expiresAt: Date(timeIntervalSince1970: 2_000_000_000),
+            accountID: "acct",
+            email: "user@example.com"
+        )
+        let document = SettingsTransfer.makeDocument(
+            settings: .defaults,
+            tokens: tokens,
+            options: .init(includeAppSettings: false, includeNotifications: false, includeAuthentication: true)
+        )
+        XCTAssertEqual(document.securityWarning, SettingsTransfer.securityWarning)
+        let data = try SettingsTransfer.encode(document)
+        let parsed = try SettingsTransfer.parse(data)
+        let applied = try SettingsTransfer.apply(
+            document: parsed,
+            to: .defaults,
+            options: .init(importAppSettings: false, importNotifications: false, importAuthentication: true)
+        )
+        XCTAssertEqual(applied.tokens?.accessToken, "access")
+        XCTAssertEqual(applied.tokens?.email, "user@example.com")
+    }
+
+    func testRejectsInvalidFormat() {
+        let junk = Data(#"{"format":"nope","version":1,"sections":{}}"#.utf8)
+        XCTAssertThrowsError(try SettingsTransfer.parse(junk))
+    }
+
+    func testRejectsEmptySelection() throws {
+        let document = SettingsTransfer.makeDocument(
+            settings: .defaults,
+            tokens: nil,
+            options: .init(includeAppSettings: true, includeNotifications: false, includeAuthentication: false)
+        )
+        XCTAssertThrowsError(
+            try SettingsTransfer.apply(
+                document: document,
+                to: .defaults,
+                options: .init(
+                    importAppSettings: false,
+                    importNotifications: false,
+                    importAuthentication: false
+                )
+            )
+        )
+    }
+}

--- a/ios/CodexMeterUITests/CodexMeterUITests.swift
+++ b/ios/CodexMeterUITests/CodexMeterUITests.swift
@@ -25,7 +25,11 @@ final class CodexMeterUITests: XCTestCase {
 
     func testSignedOutAndSignInPresentation() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-ui-testing-signed-out", "-ui-testing-reset-settings"]
+        app.launchArguments = [
+            "-ui-testing-signed-out",
+            "-ui-testing-reset-settings",
+            "-ui-testing-skip-onboarding"
+        ]
         app.launch()
 
         XCTAssertTrue(app.buttons["Sign in with ChatGPT"].waitForExistence(timeout: 5))
@@ -60,6 +64,7 @@ final class CodexMeterUITests: XCTestCase {
         app.launchArguments = [
             "-ui-testing-demo",
             "-ui-testing-reset-settings",
+            "-ui-testing-skip-onboarding",
             "-ui-testing-refresh-failure"
         ]
         app.launch()
@@ -83,7 +88,11 @@ final class CodexMeterUITests: XCTestCase {
 
     private func launchDemo() -> XCUIApplication {
         let app = XCUIApplication()
-        app.launchArguments = ["-ui-testing-demo", "-ui-testing-reset-settings"]
+        app.launchArguments = [
+            "-ui-testing-demo",
+            "-ui-testing-reset-settings",
+            "-ui-testing-skip-onboarding"
+        ]
         app.launch()
         return app
     }

--- a/ios/CodexMeterWatch/CodexMeterWatchApp.swift
+++ b/ios/CodexMeterWatch/CodexMeterWatchApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@main
+struct CodexMeterWatchApp: App {
+    @WKApplicationDelegateAdaptor(WatchAppDelegate.self) private var appDelegate
+    @State private var store = WatchSnapshotStore.shared
+
+    var body: some Scene {
+        WindowGroup {
+            WatchRootView()
+                .environment(store)
+        }
+    }
+}
+
+final class WatchAppDelegate: NSObject, WKApplicationDelegate {
+    func applicationDidFinishLaunching() {
+        WatchSessionReceiver.shared.activate()
+    }
+}

--- a/ios/CodexMeterWatch/Info.plist
+++ b/ios/CodexMeterWatch/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Codex Meter</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.bukovinafilip.CodexMeter</string>
+	<key>WKApplication</key>
+	<true/>
+	<key>WKRunsIndependentlyOfCompanionApp</key>
+	<false/>
+</dict>
+</plist>

--- a/ios/CodexMeterWatch/WatchComplications.swift
+++ b/ios/CodexMeterWatch/WatchComplications.swift
@@ -64,7 +64,7 @@ struct WatchSnapshotProvider: TimelineProvider {
     }
 
     private func loadSnapshot() -> SharedWidgetSnapshot {
-        guard let data = UserDefaults.standard.data(forKey: "codex-meter.watch.snapshot-v1"),
+        guard let data = UserDefaults.standard.data(forKey: WatchSyncPayload.watchDefaultsKey),
               let snapshot = try? WatchSyncPayload.decode(data)
         else {
             return .signedOut

--- a/ios/CodexMeterWatch/WatchComplications.swift
+++ b/ios/CodexMeterWatch/WatchComplications.swift
@@ -1,0 +1,111 @@
+import CodexMeterCore
+import SwiftUI
+import WidgetKit
+
+/// Watch face complication widgets (WidgetKit accessory families).
+/// Timelines read the last WCSession snapshot from UserDefaults.
+///
+/// Note: face complications require these widgets to be part of a WidgetKit
+/// extension target in some Xcode versions; the same views power previews and
+/// can be wired as a watch widget extension later without schema changes.
+struct DualUsageComplication: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "CodexMeter.Watch.Dual", provider: WatchSnapshotProvider()) { entry in
+            DualUsageComplicationView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Codex both")
+        .description("Five-hour and weekly remaining.")
+        .supportedFamilies([.accessoryRectangular, .accessoryCorner])
+    }
+}
+
+struct FiveHourComplication: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "CodexMeter.Watch.FiveHour", provider: WatchSnapshotProvider()) { entry in
+            SingleUsageComplicationView(title: "5h", remaining: entry.snapshot.fiveHour?.remainingPercent)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Codex 5-hour")
+        .description("Five-hour remaining percent.")
+        .supportedFamilies([.accessoryCircular, .accessoryInline, .accessoryCorner])
+    }
+}
+
+struct WeeklyComplication: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "CodexMeter.Watch.Weekly", provider: WatchSnapshotProvider()) { entry in
+            SingleUsageComplicationView(title: "Wk", remaining: entry.snapshot.weekly?.remainingPercent)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Codex weekly")
+        .description("Weekly remaining percent.")
+        .supportedFamilies([.accessoryCircular, .accessoryInline, .accessoryCorner])
+    }
+}
+
+struct WatchSnapshotEntry: TimelineEntry {
+    let date: Date
+    let snapshot: SharedWidgetSnapshot
+}
+
+struct WatchSnapshotProvider: TimelineProvider {
+    func placeholder(in context: Context) -> WatchSnapshotEntry {
+        WatchSnapshotEntry(date: .now, snapshot: .signedOut)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (WatchSnapshotEntry) -> Void) {
+        completion(WatchSnapshotEntry(date: .now, snapshot: loadSnapshot()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WatchSnapshotEntry>) -> Void) {
+        let entry = WatchSnapshotEntry(date: .now, snapshot: loadSnapshot())
+        completion(Timeline(entries: [entry], policy: .after(.now.addingTimeInterval(15 * 60))))
+    }
+
+    private func loadSnapshot() -> SharedWidgetSnapshot {
+        guard let data = UserDefaults.standard.data(forKey: "codex-meter.watch.snapshot-v1"),
+              let snapshot = try? WatchSyncPayload.decode(data)
+        else {
+            return .signedOut
+        }
+        return snapshot
+    }
+}
+
+struct DualUsageComplicationView: View {
+    let entry: WatchSnapshotEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Codex")
+                .font(.caption2.weight(.semibold))
+            HStack {
+                Text("5h \(percent(entry.snapshot.fiveHour?.remainingPercent))")
+                Spacer(minLength: 2)
+                Text("Wk \(percent(entry.snapshot.weekly?.remainingPercent))")
+            }
+            .font(.caption2.monospacedDigit())
+        }
+    }
+
+    private func percent(_ value: Int?) -> String {
+        value.map { "\($0)%" } ?? "—"
+    }
+}
+
+struct SingleUsageComplicationView: View {
+    let title: String
+    let remaining: Int?
+
+    var body: some View {
+        VStack(spacing: 1) {
+            Text(title)
+                .font(.caption2)
+            Text(remaining.map { "\($0)" } ?? "—")
+                .font(.headline.bold().monospacedDigit())
+            Text("%")
+                .font(.caption2)
+        }
+    }
+}

--- a/ios/CodexMeterWatch/WatchRootView.swift
+++ b/ios/CodexMeterWatch/WatchRootView.swift
@@ -1,0 +1,107 @@
+import CodexMeterCore
+import SwiftUI
+
+struct WatchRootView: View {
+    @Environment(WatchSnapshotStore.self) private var store
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                header
+
+                if store.snapshot.mode == .signedOut {
+                    ContentUnavailableView(
+                        "Not connected",
+                        systemImage: "iphone.slash",
+                        description: Text("Open Codex Meter on iPhone and sign in or use demo.")
+                    )
+                    .frame(maxWidth: .infinity)
+                } else {
+                    meterRow(
+                        title: "5-hour",
+                        window: store.snapshot.fiveHour
+                    )
+                    meterRow(
+                        title: "Weekly",
+                        window: store.snapshot.weekly
+                    )
+
+                    HStack {
+                        Label(
+                            "\(store.snapshot.resetCreditsAvailable ?? 0) credits",
+                            systemImage: "bolt.fill"
+                        )
+                        Spacer()
+                        if store.snapshot.freshness == .stale {
+                            Text("Cached")
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                    .font(.caption2)
+
+                    if let next = nextReset {
+                        Label {
+                            Text(next, style: .timer)
+                                .monospacedDigit()
+                        } icon: {
+                            Image(systemName: "clock.arrow.circlepath")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+
+                Button {
+                    store.requestPhoneRefresh()
+                } label: {
+                    Label("Ask iPhone to refresh", systemImage: "arrow.clockwise")
+                }
+                .font(.caption2)
+            }
+            .padding(.horizontal, 4)
+        }
+        .navigationTitle("Codex")
+    }
+
+    private var header: some View {
+        HStack {
+            Image(systemName: "gauge.with.dots.needle.67percent")
+            Text("Codex Meter")
+                .font(.headline)
+            Spacer()
+            if store.snapshot.mode == .demo {
+                Text("Demo")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.blue)
+            }
+        }
+    }
+
+    private var nextReset: Date? {
+        [store.snapshot.fiveHour?.resetAt, store.snapshot.weekly?.resetAt]
+            .compactMap { $0 }
+            .filter { $0 > .now }
+            .min()
+    }
+
+    private func meterRow(title: String, window: UsageWindow?) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(window.map { "\($0.remainingPercent)%" } ?? "—")
+                    .font(.title3.bold().monospacedDigit())
+            }
+            ProgressView(value: Double(window?.remainingPercent ?? 0), total: 100)
+                .tint((window?.remainingPercent ?? 100) <= 25 ? .orange : .accentColor)
+        }
+        .padding(8)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}
+
+#Preview {
+    WatchRootView()
+        .environment(WatchSnapshotStore.shared)
+}

--- a/ios/CodexMeterWatch/WatchSessionReceiver.swift
+++ b/ios/CodexMeterWatch/WatchSessionReceiver.swift
@@ -1,0 +1,71 @@
+import CodexMeterCore
+import Foundation
+import WatchConnectivity
+
+/// Receives sanitized snapshots from the iPhone app.
+@MainActor
+final class WatchSessionReceiver: NSObject, WCSessionDelegate {
+    static let shared = WatchSessionReceiver()
+
+    private var didActivate = false
+
+    func activate() {
+        guard WCSession.isSupported() else { return }
+        let session = WCSession.default
+        if session.delegate == nil {
+            session.delegate = self
+        }
+        if session.activationState != .activated && !didActivate {
+            didActivate = true
+            session.activate()
+        }
+    }
+
+    func requestRefreshFromPhone() {
+        activate()
+        let session = WCSession.default
+        guard session.activationState == .activated, session.isReachable else { return }
+        session.sendMessage(["action": "refresh_snapshot"], replyHandler: { _ in }, errorHandler: { _ in })
+    }
+
+    private func ingest(context: [String: Any]) {
+        guard let snapshot = try? WatchSyncPayload.snapshot(fromApplicationContext: context) else {
+            return
+        }
+        WatchSnapshotStore.shared.apply(snapshot)
+    }
+
+    // MARK: - WCSessionDelegate
+
+    nonisolated func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        guard activationState == .activated else { return }
+        let context = session.receivedApplicationContext
+        Task { @MainActor in
+            if !context.isEmpty {
+                ingest(context: context)
+            }
+        }
+    }
+
+    nonisolated func session(
+        _ session: WCSession,
+        didReceiveApplicationContext applicationContext: [String: Any]
+    ) {
+        Task { @MainActor in
+            ingest(context: applicationContext)
+        }
+    }
+
+    nonisolated func session(
+        _ session: WCSession,
+        didReceiveUserInfo userInfo: [String: Any] = [:]
+    ) {
+        Task { @MainActor in
+            ingest(context: userInfo)
+        }
+    }
+}

--- a/ios/CodexMeterWatch/WatchSnapshotStore.swift
+++ b/ios/CodexMeterWatch/WatchSnapshotStore.swift
@@ -8,8 +8,6 @@ import WidgetKit
 final class WatchSnapshotStore {
     static let shared = WatchSnapshotStore()
 
-    private static let defaultsKey = "codex-meter.watch.snapshot-v1"
-
     var snapshot: SharedWidgetSnapshot
     var lastUpdated: Date?
 
@@ -17,7 +15,7 @@ final class WatchSnapshotStore {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        if let data = defaults.data(forKey: Self.defaultsKey),
+        if let data = defaults.data(forKey: WatchSyncPayload.watchDefaultsKey),
            let decoded = try? WatchSyncPayload.decode(data) {
             self.snapshot = decoded
             self.lastUpdated = Date()
@@ -30,7 +28,7 @@ final class WatchSnapshotStore {
         self.snapshot = snapshot
         self.lastUpdated = Date()
         if let data = try? WatchSyncPayload.encode(snapshot) {
-            defaults.set(data, forKey: Self.defaultsKey)
+            defaults.set(data, forKey: WatchSyncPayload.watchDefaultsKey)
         }
         WidgetCenter.shared.reloadAllTimelines()
     }

--- a/ios/CodexMeterWatch/WatchSnapshotStore.swift
+++ b/ios/CodexMeterWatch/WatchSnapshotStore.swift
@@ -1,0 +1,41 @@
+import CodexMeterCore
+import Foundation
+import Observation
+import WidgetKit
+
+@MainActor
+@Observable
+final class WatchSnapshotStore {
+    static let shared = WatchSnapshotStore()
+
+    private static let defaultsKey = "codex-meter.watch.snapshot-v1"
+
+    var snapshot: SharedWidgetSnapshot
+    var lastUpdated: Date?
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.defaultsKey),
+           let decoded = try? WatchSyncPayload.decode(data) {
+            self.snapshot = decoded
+            self.lastUpdated = Date()
+        } else {
+            self.snapshot = .signedOut
+        }
+    }
+
+    func apply(_ snapshot: SharedWidgetSnapshot) {
+        self.snapshot = snapshot
+        self.lastUpdated = Date()
+        if let data = try? WatchSyncPayload.encode(snapshot) {
+            defaults.set(data, forKey: Self.defaultsKey)
+        }
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    func requestPhoneRefresh() {
+        WatchSessionReceiver.shared.requestRefreshFromPhone()
+    }
+}

--- a/ios/CodexMeterWidgets/CodexMeterWidgetsBundle.swift
+++ b/ios/CodexMeterWidgets/CodexMeterWidgetsBundle.swift
@@ -8,6 +8,7 @@ struct CodexMeterWidgetsBundle: WidgetBundle {
         FiveHourAccessoryWidget()
         WeeklyAccessoryWidget()
         DualAllowanceAccessoryWidget()
+        UsageLiveActivityWidget()
     }
 }
 

--- a/ios/CodexMeterWidgets/Info.plist
+++ b/ios/CodexMeterWidgets/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/CodexMeterWidgets/UsageLiveActivityWidget.swift
+++ b/ios/CodexMeterWidgets/UsageLiveActivityWidget.swift
@@ -1,0 +1,155 @@
+import ActivityKit
+import CodexMeterCore
+import SwiftUI
+import WidgetKit
+
+struct UsageLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: UsageLiveMonitorAttributes.self) { context in
+            lockScreenView(context: context)
+                .widgetURL(URL(string: "codexmeter://dashboard"))
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("5h")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(percentLabel(context.state.fiveHourRemainingPercent))
+                            .font(.title3.bold().monospacedDigit())
+                    }
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text("Week")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(percentLabel(context.state.weeklyRemainingPercent))
+                            .font(.title3.bold().monospacedDigit())
+                    }
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "gauge.with.dots.needle.67percent")
+                        Text("Codex Meter")
+                            .font(.headline)
+                        if context.state.isDemo {
+                            Text("Demo")
+                                .font(.caption2.weight(.semibold))
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(.blue.opacity(0.2), in: Capsule())
+                        }
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack {
+                        if let next = context.state.nextResetAt, next > .now {
+                            Label {
+                                Text(next, style: .timer)
+                                    .monospacedDigit()
+                            } icon: {
+                                Image(systemName: "clock.arrow.circlepath")
+                            }
+                        } else {
+                            Text("No upcoming reset")
+                        }
+                        Spacer()
+                        Label("\(context.state.creditCount)", systemImage: "bolt.fill")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            } compactLeading: {
+                Image(systemName: "gauge.with.dots.needle.67percent")
+            } compactTrailing: {
+                Text(percentLabel(context.state.primaryRemainingPercent))
+                    .font(.caption.bold().monospacedDigit())
+                    .minimumScaleFactor(0.7)
+            } minimal: {
+                Text(shortPercent(context.state.primaryRemainingPercent))
+                    .font(.caption2.bold().monospacedDigit())
+            }
+            .widgetURL(URL(string: "codexmeter://dashboard"))
+        }
+    }
+
+    private func lockScreenView(
+        context: ActivityViewContext<UsageLiveMonitorAttributes>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: "gauge.with.dots.needle.67percent")
+                    .foregroundStyle(.tint)
+                Text("Codex Meter")
+                    .font(.headline)
+                if !context.state.planLabel.isEmpty {
+                    Text(context.state.planLabel)
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.tint.opacity(0.14), in: Capsule())
+                }
+                Spacer()
+                if context.state.isDemo {
+                    Text("Demo")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.blue)
+                } else if context.state.isCached {
+                    Text("Cached")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            HStack(spacing: 16) {
+                meterColumn(title: "5-hour", remaining: context.state.fiveHourRemainingPercent)
+                meterColumn(title: "Weekly", remaining: context.state.weeklyRemainingPercent)
+            }
+
+            HStack {
+                if let next = context.state.nextResetAt, next > .now {
+                    Label {
+                        Text(next, style: .timer)
+                            .monospacedDigit()
+                    } icon: {
+                        Image(systemName: "clock.arrow.circlepath")
+                    }
+                    .font(.caption)
+                } else {
+                    Text("Reset unavailable")
+                        .font(.caption)
+                }
+                Spacer()
+                Label("\(context.state.creditCount) credits", systemImage: "bolt.fill")
+                    .font(.caption)
+            }
+            .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .activityBackgroundTint(Color(.secondarySystemBackground).opacity(0.85))
+    }
+
+    private func meterColumn(title: String, remaining: Int?) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(percentLabel(remaining))
+                .font(.title2.bold().monospacedDigit())
+            ProgressView(value: Double(remaining ?? 0), total: 100)
+                .tint(remaining.map { $0 <= 25 ? Color.orange : Color.accentColor } ?? .secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func percentLabel(_ value: Int?) -> String {
+        guard let value else { return "—" }
+        return "\(value)%"
+    }
+
+    private func shortPercent(_ value: Int?) -> String {
+        guard let value else { return "—" }
+        return "\(value)"
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -20,6 +20,17 @@ reset-credit expiry reminders.
 - An Apple development team for device builds, App Groups, and the widget
   extension
 
+## Versioning
+
+The iOS app uses `MARKETING_VERSION` in the Xcode project (currently **1.0**).
+That is independent of the Android `versionName` / GitHub `v*` release tags,
+which still track the Android APK pipeline.
+
+## Continuous integration
+
+Pull requests that touch `ios/` run `.github/workflows/ios.yml` on macOS:
+`swift test` for `CodexMeterCore` and an unsigned Simulator build of the app.
+
 ## Build and test
 
 From this `ios/` directory:

--- a/ios/README.md
+++ b/ios/README.md
@@ -31,6 +31,14 @@ which still track the Android APK pipeline.
 Pull requests that touch `ios/` run `.github/workflows/ios.yml` on macOS:
 `swift test` for `CodexMeterCore` and an unsigned Simulator build of the app.
 
+## Live Activity usage monitor
+
+Settings → **Usage monitor** can start a Live Activity (Lock Screen + Dynamic
+Island) showing five-hour and weekly remaining percent, next reset timer, and
+credits. Optional auto-start fires when remaining hits a threshold (similar to
+Android Now Bar auto-start). The activity ends at the next reset, on stop, or
+on sign-out. iOS cannot match Android exact-alarm / reboot alarm parity.
+
 ## Build and test
 
 From this `ios/` directory:

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,35 +1,47 @@
-# Codex Meter for iPhone and iPad
+# Codex Meter for iPhone, iPad, and Apple Watch
 
 Native SwiftUI client for viewing the Codex allowance attached to a signed-in
 ChatGPT account. It shows the short and weekly usage windows, reset times,
-earned reset credits, local notifications, and WidgetKit widgets.
+earned reset credits, local notifications, WidgetKit widgets, an optional Live
+Activity monitor, and a watchOS companion.
 
-This directory is the **iOS** package of the Codex Meter monorepo. The Android
-application lives under [`../android/`](../android/). Behavior is aligned with
-the Android app where platform APIs allow; it does not include Samsung One UI,
-Now Bar / Live Update monitors, or Android in-app APK updates.
+This directory is the **iOS / watchOS** package of the Codex Meter monorepo. The
+Android application lives under [`../android/`](../android/). Behavior is aligned
+with the Android app where platform APIs allow; it does not include Samsung One
+UI, Now Bar private APIs, Material You, or Android in-app APK updates.
 
-Portable notification features from Android 2.1/2.2 are included: unexpected
-refill alerts, independent reset-credit increase alerts, and configurable
-reset-credit expiry reminders.
+## Versioning
+
+**iOS marketing version: 1.2.0** (`MARKETING_VERSION` in the Xcode project).
+
+That is independent of the Android `versionName` / GitHub `v*` APK release tags.
+
+### What’s in 1.2.0 (phases A–C + D maturity)
+
+| Area | Features |
+|------|----------|
+| Core | Meters, reset credits, Keychain device-code auth, demo mode, widgets |
+| Notifications | Low usage, scheduled resets, credit increases, unexpected refills, credit-expiry lead times |
+| Transfer | Settings export/import (optional auth with warnings) |
+| Onboarding | Three-page first run |
+| Live Activity | Lock Screen / Dynamic Island usage monitor + auto-start |
+| watchOS | Companion app + WCSession snapshot sync |
+| CI | Core tests, iPhone Simulator build, watchOS Simulator build |
 
 ## Requirements
 
 - Xcode 26 or newer
-- iOS or iPadOS 26 or newer
-- An Apple development team for device builds, App Groups, and the widget
-  extension
-
-## Versioning
-
-The iOS app uses `MARKETING_VERSION` in the Xcode project (currently **1.0**).
-That is independent of the Android `versionName` / GitHub `v*` release tags,
-which still track the Android APK pipeline.
+- iOS or iPadOS 26 or newer; watchOS 11+ for the companion
+- An Apple development team for device builds, App Groups, Watch embedding, and
+  the widget extension
 
 ## Continuous integration
 
-Pull requests that touch `ios/` run `.github/workflows/ios.yml` on macOS:
-`swift test` for `CodexMeterCore` and an unsigned Simulator build of the app.
+PRs that touch `ios/` run `.github/workflows/ios.yml` on `macos-15`:
+
+1. `swift test --package-path CodexMeterCore`
+2. Unsigned iPhone Simulator build of `CodexMeter`
+3. Unsigned watchOS Simulator build of `CodexMeterWatch`
 
 ## Live Activity usage monitor
 
@@ -46,9 +58,13 @@ on sign-out. iOS cannot match Android exact-alarm / reboot alarm parity.
 tokens, no network on the watch). The watch UI shows five-hour / weekly
 remaining, credits, and next reset, and can request a re-push from the phone.
 
-Watch face **complication WidgetKit definitions** live in
-`CodexMeterWatch/WatchComplications.swift` (reload when a snapshot arrives).
-Signing: enable the Watch target with the same team as the iPhone app; bundle id
+Complication **WidgetKit view definitions** live in
+`CodexMeterWatch/WatchComplications.swift` and reload when a snapshot arrives.
+A separate watch WidgetKit **extension** target may still be required for face
+picker discovery depending on Xcode; the snapshot schema and defaults key are
+shared via `WatchSyncPayload.watchDefaultsKey`.
+
+Signing: same team as the iPhone app; bundle id
 `com.bukovinafilip.CodexMeter.watchkitapp`.
 
 ## Build and test
@@ -59,6 +75,8 @@ From this `ios/` directory:
 swift test --package-path CodexMeterCore
 xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
   -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project CodexMeter.xcodeproj -target CodexMeterWatch \
+  -destination 'generic/platform=watchOS Simulator' CODE_SIGNING_ALLOWED=NO build
 xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
   -destination 'platform=iOS Simulator,name=iPhone 17e' \
   -parallel-testing-enabled NO test
@@ -72,16 +90,18 @@ contact OpenAI.
 | Path | Role |
 |------|------|
 | `CodexMeter/` | Main app target |
-| `CodexMeterWidgets/` | WidgetKit extension |
+| `CodexMeterWidgets/` | Home / Lock Screen WidgetKit extension |
+| `CodexMeterWatch/` | watchOS companion app |
 | `CodexMeterCore/` | Shared models/parsers (local Swift package) |
 | `CodexMeterTests/` | Unit tests |
 | `CodexMeterUITests/` | UI tests |
 
 ## Data and stability
 
-OAuth credentials are stored only in the device Keychain. Widgets receive a
-sanitized usage snapshot through an App Group and never receive credentials.
-The app has no analytics, advertisements, or application relay server.
+OAuth credentials are stored only in the device Keychain. Widgets and the watch
+receive a sanitized usage snapshot only (App Group / WatchConnectivity) and
+never receive credentials. The app has no analytics, advertisements, or
+application relay server.
 
 The ChatGPT usage and reset-credit routes are implementation details and may
 change without notice. This app is not affiliated with or endorsed by OpenAI.

--- a/ios/README.md
+++ b/ios/README.md
@@ -39,6 +39,18 @@ credits. Optional auto-start fires when remaining hits a threshold (similar to
 Android Now Bar auto-start). The activity ends at the next reset, on stop, or
 on sign-out. iOS cannot match Android exact-alarm / reboot alarm parity.
 
+## watchOS companion
+
+`CodexMeterWatch` is embedded in the iPhone app. The phone pushes a sanitized
+`SharedWidgetSnapshot` over **WatchConnectivity** whenever widgets update (no
+tokens, no network on the watch). The watch UI shows five-hour / weekly
+remaining, credits, and next reset, and can request a re-push from the phone.
+
+Watch face **complication WidgetKit definitions** live in
+`CodexMeterWatch/WatchComplications.swift` (reload when a snapshot arrives).
+Signing: enable the Watch target with the same team as the iPhone app; bundle id
+`com.bukovinafilip.CodexMeter.watchkitapp`.
+
 ## Build and test
 
 From this `ios/` directory:


### PR DESCRIPTION
## Summary

Brings the iOS tree to **marketing version 1.2.0** with portable feature work and maturity tooling (phases A–D). Android APK `versionName` / `v*` tags are unchanged.

Branch: `FBukovina:feature/ios-phase-a` (includes all commits below tip `b6b9a55`).

### Phase A — foundation
- Settings **export/import** JSON (`app_settings` + `notifications`; optional **authentication** with double confirmation + security warning)
- First-run **onboarding** (what / privacy / connect → sign-in, demo, or skip)
- macOS CI: Core tests + iPhone Simulator build (`.github/workflows/ios.yml`)

### Phase B — Live Activity monitor
- Lock Screen + Dynamic Island usage monitor (5h / weekly remaining, next reset, credits)
- Optional **auto-start** when remaining hits a threshold (Now Bar auto-start analog)
- Ends on next reset, user stop, or sign-out

### Phase C — watchOS companion
- Embedded `CodexMeterWatch` target
- Phone → watch **WatchConnectivity** sync of sanitized `SharedWidgetSnapshot` only (no tokens)
- Watch UI + request re-push from iPhone
- Complication WidgetKit view definitions (face-picker extension optional follow-up)

### Phase D — maturity
- `MARKETING_VERSION` **1.2.0**
- Root `CHANGELOG` **Unreleased → iOS 1.2.0** notes
- CI **watchOS Simulator** build job
- About → **GitHub Releases** link (read-only; no APK installer)
- Docs: `ios/README`, root README, CONTRIBUTING, AGENTS

### Explicitly not included
- Samsung One UI / lock-AOD / private Now Bar APIs
- Material You
- In-app APK updater/installer
- Lowering iOS deployment target below 26 (possible follow-up)

## Related

- Usage-pace estimates may still be tracked separately as #49 if not yet merged into this branch/`main`
- Prior monorepo iOS land: #22

## Test plan

- [x] `swift test --package-path ios/CodexMeterCore`
- [x] `xcodebuild -scheme CodexMeter -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- [x] `xcodebuild -target CodexMeterWatch -destination 'generic/platform=watchOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- [ ] Fresh install: onboarding → demo → Settings export/import
- [ ] Live Activity start/stop + auto-start threshold (device with Live Activities enabled)
- [ ] Paired Watch: usage appears after phone refresh; “Ask iPhone to refresh”
- [ ] CI green on this PR (ios + watch jobs)