### PR TITLE
Fix onboarding card gaps and settings bottom padding

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java
@@ -204,6 +204,7 @@ public final class OnboardingActivity extends AppCompatActivity {
                         + "quick One UI view.",
                 R.drawable.ic_oui_battery);
 
+        Ui.addSpacer(this.content, 20);
         RoundedLinearLayout card = Ui.seslCard(this, this.dark);
         TextView title = Ui.text(this, "Built to feel at home on Galaxy", 18.0f,
                 Ui.mainText(this.dark));
@@ -264,13 +265,12 @@ public final class OnboardingActivity extends AppCompatActivity {
         this.content.addView(privacy);
 
         if (!this.authMessage.isEmpty()) {
+            Ui.addSpacer(this.content, 16);
             RoundedLinearLayout status = Ui.seslCard(this, this.dark);
             TextView message = Ui.text(this, this.authMessage, 14.0f,
                     Ui.secondaryText(this.dark));
             status.addView(message);
-            LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(-1, -2);
-            statusParams.setMargins(0, Ui.dp(this, 16), 0, 0);
-            this.content.addView(status, statusParams);
+            this.content.addView(status);
         }
 
         String signInLabel = AppPreferences.isOAuthPending(this)
@@ -293,6 +293,7 @@ public final class OnboardingActivity extends AppCompatActivity {
                         : "You can connect ChatGPT later from the Codex Meter dashboard.",
                 signedIn ? R.drawable.ic_oui_samsung_account : R.drawable.ic_oui_info_outline);
 
+        Ui.addSpacer(this.content, 20);
         RoundedLinearLayout account = Ui.seslRowCard(this, this.dark);
         AuthTokens tokens = SecureTokenStore.load(this);
         account.addView(Ui.actionRow(this,

--- a/android/app/src/main/res/xml/preferences_settings.xml
+++ b/android/app/src/main/res/xml/preferences_settings.xml
@@ -212,4 +212,6 @@
         android:key="about_codex_meter"
         android:title="About Codex Meter"
         app:iconSpaceReserved="false" />
+
+    <dev.oneuiproject.oneui.preference.InsetPreferenceCategory app:height="28dp" />
 </PreferenceScreen>

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -367,6 +367,17 @@ grep -q 'dev.oneuiproject.oneui.widget.CardItemView' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java"
 grep -q 'Ui.nativePrimaryButton' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java"
+grep -q 'Ui.addSpacer(this.content, 20)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/OnboardingActivity.java"
+python3 - <<PY
+from pathlib import Path
+text = (Path(r"""$ROOT""") / "app/src/main/res/xml/preferences_settings.xml").read_text()
+about = text.index('android:key="about_codex_meter"')
+assert text.rfind('InsetPreferenceCategory', 0, about) != -1, "missing inset before About"
+assert text.find('InsetPreferenceCategory', about) != -1, "missing bottom inset after About"
+assert 'app:height="28dp"' in text[about:], "bottom settings inset should be 28dp"
+print("settings list keeps spacing before About and bottom padding after it.")
+PY
 grep -q 'OAuthBrowserPage.render' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OAuthService.java"
 grep -q 'titlePaint.setColor(foreground);' \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Restore 20dp spacing between stacked onboarding cards (welcome hero/body and complete “You’re all set” / “ChatGPT connected”), matching the dashboard spacer pattern.
- Add a trailing 28dp `InsetPreferenceCategory` after About so Settings no longer ends flush against the bottom edge.
- Lock both invariants in `android/run-tests.sh`.

## Test plan
- [x] `./run-tests.sh`
- [ ] Visually confirm onboarding steps 1 and 4 show a clear gap between white cards
- [ ] Scroll Settings to the bottom and confirm gray padding below About Codex Meter

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05d73282-72f5-4432-ab34-65095f19fac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05d73282-72f5-4432-ab34-65095f19fac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

