### PR TITLE
Clean up Settings with One UI hub and drill-downs

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
@@ -83,6 +83,15 @@ public final class AboutActivity extends AppCompatActivity {
                 "https://tjg.gg"));
         content.addView(credits);
 
+        content.addView(sectionTitle("Privacy"));
+        RoundedLinearLayout privacy = Ui.cardGroup(this, dark);
+        CardItemView privacyRow = Ui.actionRow(this, "Local data and privacy",
+                "OAuth tokens are encrypted with Android Keystore. Requests go only to OpenAI for authentication and ChatGPT & Codex endpoints.",
+                R.drawable.ic_oui_privacy, null);
+        privacyRow.setShowTopDivider(false);
+        privacy.addView(privacyRow);
+        content.addView(privacy);
+
         content.addView(sectionTitle("Dependencies"));
         RoundedLinearLayout dependencies = Ui.cardGroup(this, dark);
         CardItemView oneUi = Ui.actionRow(this, "One UI Design Library", "The library that makes this app so pretty.", R.drawable.ic_oui_theme,

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -214,7 +214,7 @@ public final class SettingsActivity extends AppCompatActivity
                 if (!UpdatePreferences.automaticChecks(requireContext())) {
                     updates.setSummary("Manual");
                 } else {
-                    updates.setSummary(UpdateCheckFrequency.summary(
+                    updates.setSummary(UpdateCheckFrequency.label(
                             UpdatePreferences.checkIntervalHours(requireContext())));
                 }
             }

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -24,7 +24,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.fragment.app.Fragment;
+import androidx.preference.PreferenceCategory;
 import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 import dev.bennett.codexmeter.wear.PhoneWearSync;
 import dev.oneuiproject.oneui.layout.ToolbarLayout;
 import dev.oneuiproject.oneui.preference.HorizontalRadioPreference;
@@ -41,23 +44,73 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 /** Settings built from the One UI Design Library preference components used by its sample app. */
-public final class SettingsActivity extends AppCompatActivity {
+public final class SettingsActivity extends AppCompatActivity
+        implements PreferenceFragmentCompat.OnPreferenceStartFragmentCallback {
+    private ToolbarLayout toolbar;
+
     @Override
     protected void onCreate(Bundle bundle) {
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
         AppPreferences.setAppStyle(this, WidgetOptions.SURFACE_ONE_UI);
         setContentView(R.layout.activity_settings);
-        ToolbarLayout toolbar = findViewById(R.id.settings_toolbar_layout);
+        toolbar = findViewById(R.id.settings_toolbar_layout);
         Ui.configureReachToolbar(toolbar, "Settings", true);
+        getSupportFragmentManager().addOnBackStackChangedListener(this::syncToolbarTitle);
         if (bundle == null) {
             getSupportFragmentManager().beginTransaction()
                     .replace(R.id.settings_fragment, new SettingsFragment())
                     .commit();
+        } else {
+            syncToolbarTitle();
         }
     }
 
-    public static final class SettingsFragment extends PreferenceFragmentCompat {
+    private void syncToolbarTitle() {
+        if (getSupportFragmentManager().getBackStackEntryCount() == 0) {
+            Ui.configureReachToolbar(toolbar, "Settings", true);
+            return;
+        }
+        Fragment current = getSupportFragmentManager().findFragmentById(R.id.settings_fragment);
+        if (current instanceof CodexSettingsFragment) {
+            String title = ((CodexSettingsFragment) current).screenTitle();
+            if (title != null && !title.isEmpty()) {
+                Ui.configureReachToolbar(toolbar, title, true);
+            }
+        }
+    }
+
+    @Override
+    public boolean onPreferenceStartFragment(PreferenceFragmentCompat caller, Preference preference) {
+        if (preference.getFragment() == null) {
+            return false;
+        }
+        Fragment fragment = getSupportFragmentManager().getFragmentFactory()
+                .instantiate(getClassLoader(), preference.getFragment());
+        fragment.setArguments(preference.getExtras());
+        getSupportFragmentManager().beginTransaction()
+                .replace(R.id.settings_fragment, fragment)
+                .addToBackStack(preference.getKey())
+                .commit();
+        CharSequence title = preference.getTitle();
+        if (title != null) {
+            Ui.configureReachToolbar(toolbar, title.toString(), true);
+        }
+        return true;
+    }
+
+    public abstract static class CodexSettingsFragment extends PreferenceFragmentCompat {
+        abstract int preferenceXml();
+        abstract void bindScreen();
+        abstract String screenTitle();
+
+        @Override
+        public void onCreatePreferences(Bundle bundle, String rootKey) {
+            getPreferenceManager().setSharedPreferencesName("codex_meter_settings_v1");
+            addPreferencesFromResource(preferenceXml());
+            bindScreen();
+        }
+
         private static final int REQUEST_EXPORT_TRANSFER = 9201;
         private static final int REQUEST_IMPORT_TRANSFER = 9202;
 
@@ -84,24 +137,6 @@ public final class SettingsActivity extends AppCompatActivity {
         private SettingsTransfer.Document pendingImportDocument;
 
         @Override
-        public void onCreatePreferences(Bundle bundle, String rootKey) {
-            getPreferenceManager().setSharedPreferencesName("codex_meter_settings_v1");
-            addPreferencesFromResource(R.xml.preferences_settings);
-            bindAccount();
-            bindAppearance();
-            bindRefresh();
-            bindUsagePace();
-            bindUpdates();
-            bindNotifications();
-            bindNowBar();
-            bindTransfer();
-            findPreference("about_codex_meter").setOnPreferenceClickListener(preference -> {
-                Ui.startSecondaryActivity(requireActivity(), AboutActivity.class);
-                return true;
-            });
-        }
-
-        @Override
         public void onActivityResult(int requestCode, int resultCode, Intent data) {
             super.onActivityResult(requestCode, resultCode, data);
             if (resultCode != Activity.RESULT_OK || data == null || data.getData() == null) {
@@ -121,17 +156,72 @@ public final class SettingsActivity extends AppCompatActivity {
             view.setBackgroundColor(Ui.background(requireContext(), Ui.isDark(requireContext())));
         }
 
-        @Override
-        public void onResume() {
-            super.onResume();
-            if (!NowBarManager.refreshActiveNotificationContract(requireContext())) {
-                Toast.makeText(requireContext(),
-                        "Could not refresh the live notification, so the monitor was stopped.",
-                        Toast.LENGTH_LONG).show();
+
+
+        protected void bindHub() {
+            bindAccount();
+            Preference about = findPreference("about_codex_meter");
+            if (about != null) {
+                about.setOnPreferenceClickListener(preference -> {
+                    Ui.startSecondaryActivity(requireActivity(), AboutActivity.class);
+                    return true;
+                });
             }
-            updatePermissionSummary();
-            updateNowBarSummary();
-            updateUpdateSummary();
+            updateHubSummaries();
+        }
+
+        protected void updateHubSummaries() {
+            Preference appearance = findPreference("open_appearance");
+            if (appearance != null) {
+                String theme = AppPreferences.getAppTheme(requireContext());
+                if (WidgetOptions.THEME_SYSTEM.equals(theme)) {
+                    appearance.setSummary("System default");
+                } else if (WidgetOptions.THEME_DARK.equals(theme)) {
+                    appearance.setSummary("Dark");
+                } else {
+                    appearance.setSummary("Light");
+                }
+            }
+            Preference refresh = findPreference("open_refresh");
+            if (refresh != null) {
+                int minutes = AppPreferences.getRefreshMinutes(requireContext());
+                String interval = minutes >= 120 ? "Every 2 hours"
+                        : minutes == 60 ? "Every 60 minutes"
+                        : "Every " + minutes + " minutes";
+                if (UsagePacePreferences.isEnabled(requireContext())) {
+                    refresh.setSummary(interval + " · Pace on");
+                } else {
+                    refresh.setSummary(interval);
+                }
+            }
+            Preference notifications = findPreference("open_notifications");
+            if (notifications != null) {
+                notifications.setSummary(ResetAlertPreferences.enabled(requireContext())
+                        ? "On" : "Off");
+            }
+            Preference nowBar = findPreference("open_now_bar");
+            if (nowBar != null) {
+                if (NowBarManager.isActive(requireContext())) {
+                    nowBar.setSummary("Monitoring");
+                } else if (NowBarPreferences.isAutoStartEnabled(requireContext())) {
+                    nowBar.setSummary("Auto-start");
+                } else {
+                    nowBar.setSummary("Off");
+                }
+            }
+            Preference updates = findPreference("open_updates");
+            if (updates != null) {
+                if (!UpdatePreferences.automaticChecks(requireContext())) {
+                    updates.setSummary("Manual");
+                } else {
+                    updates.setSummary(UpdateCheckFrequency.summary(
+                            UpdatePreferences.checkIntervalHours(requireContext())));
+                }
+            }
+            Preference transfer = findPreference("open_transfer");
+            if (transfer != null) {
+                transfer.setSummary("Export or import");
+            }
         }
 
         private void bindAccount() {
@@ -381,7 +471,7 @@ public final class SettingsActivity extends AppCompatActivity {
                 return;
             }
             if (!UpdatePreferences.automaticChecks(requireContext())) {
-                automaticUpdatePreference.setSummary("Automatic GitHub release checks are off");
+                automaticUpdatePreference.setSummary("Off");
                 return;
             }
             automaticUpdatePreference.setSummary(UpdateCheckFrequency.summary(
@@ -454,11 +544,12 @@ public final class SettingsActivity extends AppCompatActivity {
         }
 
         private void bindNotifications() {
-            SwitchPreferenceCompat allow = findPreference("notifications_allowed_ui");
-            allow.setEnabled(true);
+            TwoStatePreference allow = findPreference("notifications_allowed_ui");
+            allow.setPersistent(false);
             allow.setChecked(ResetAlertPreferences.enabled(requireContext()));
             allow.setOnPreferenceChangeListener((preference, value) -> {
                 setNotificationsEnabled((Boolean) value);
+                updateNotificationChildrenEnabled((Boolean) value);
                 return true;
             });
 
@@ -532,6 +623,23 @@ public final class SettingsActivity extends AppCompatActivity {
                 return true;
             });
             updatePermissionSummary();
+            updateNotificationChildrenEnabled(ResetAlertPreferences.enabled(requireContext()));
+        }
+
+        private void updateNotificationChildrenEnabled(boolean enabled) {
+            PreferenceCategory lowUsage = findPreference("notifications_low_usage_category");
+            PreferenceCategory credits = findPreference("notifications_credits_category");
+            if (lowUsage != null) lowUsage.setEnabled(enabled);
+            if (credits != null) credits.setEnabled(enabled);
+            if (testNotificationPreference != null) {
+                NotificationManager manager = (NotificationManager) requireContext()
+                        .getSystemService(NOTIFICATION_SERVICE);
+                boolean allowed = manager != null && manager.areNotificationsEnabled()
+                        && (Build.VERSION.SDK_INT < 33
+                        || requireContext().checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+                        == PackageManager.PERMISSION_GRANTED);
+                testNotificationPreference.setEnabled(enabled && allowed);
+            }
         }
 
         private void showExpiryReminderTimesDialog() {
@@ -943,8 +1051,7 @@ public final class SettingsActivity extends AppCompatActivity {
                 nowBarMonitorPreference.setSummary(
                         "Waiting for a low allowance or accelerated usage trigger");
             } else {
-                nowBarMonitorPreference.setSummary(
-                        "Show remaining Codex allowance until the next available usage reset");
+                nowBarMonitorPreference.setSummary("Off");
             }
             if (nowBarAutoStartPreference != null) {
                 nowBarAutoStartPreference.setChecked(
@@ -1024,9 +1131,7 @@ public final class SettingsActivity extends AppCompatActivity {
                     || requireContext().checkSelfPermission("android.permission.POST_NOTIFICATIONS")
                     == PackageManager.PERMISSION_GRANTED);
             permissionPreference.setSummary(allowed ? "Allowed" : "Not allowed");
-            if (testNotificationPreference != null) {
-                testNotificationPreference.setEnabled(allowed && ResetAlertPreferences.enabled(requireContext()));
-            }
+            updateNotificationChildrenEnabled(ResetAlertPreferences.enabled(requireContext()));
         }
 
         private void bindTransfer() {
@@ -1271,6 +1376,155 @@ public final class SettingsActivity extends AppCompatActivity {
                                 : exception.getMessage(),
                         Toast.LENGTH_LONG).show();
             }
+        }
+    }
+
+    public static final class SettingsFragment extends CodexSettingsFragment {
+        @Override
+        int preferenceXml() {
+            return R.xml.preferences_settings;
+        }
+
+        @Override
+        String screenTitle() {
+            return "Settings";
+        }
+
+        @Override
+        void bindScreen() {
+            bindHub();
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            updateHubSummaries();
+        }
+    }
+
+    public static final class AppearanceFragment extends CodexSettingsFragment {
+        @Override
+        int preferenceXml() {
+            return R.xml.preferences_appearance;
+        }
+
+        @Override
+        String screenTitle() {
+            return "Appearance";
+        }
+
+        @Override
+        void bindScreen() {
+            bindAppearance();
+        }
+    }
+
+    public static final class RefreshFragment extends CodexSettingsFragment {
+        @Override
+        int preferenceXml() {
+            return R.xml.preferences_refresh;
+        }
+
+        @Override
+        String screenTitle() {
+            return "Refresh & usage";
+        }
+
+        @Override
+        void bindScreen() {
+            bindRefresh();
+            bindUsagePace();
+        }
+    }
+
+    public static final class NotificationsFragment extends CodexSettingsFragment {
+        @Override
+        int preferenceXml() {
+            return R.xml.preferences_notifications;
+        }
+
+        @Override
+        String screenTitle() {
+            return "Notifications";
+        }
+
+        @Override
+        void bindScreen() {
+            bindNotifications();
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            updatePermissionSummary();
+        }
+    }
+
+    public static final class NowBarFragment extends CodexSettingsFragment {
+        @Override
+        int preferenceXml() {
+            return R.xml.preferences_now_bar;
+        }
+
+        @Override
+        String screenTitle() {
+            return "Now Bar";
+        }
+
+        @Override
+        void bindScreen() {
+            bindNowBar();
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            if (!NowBarManager.refreshActiveNotificationContract(requireContext())) {
+                Toast.makeText(requireContext(),
+                        "Could not refresh the live notification, so the monitor was stopped.",
+                        Toast.LENGTH_LONG).show();
+            }
+            updateNowBarSummary();
+        }
+    }
+
+    public static final class UpdatesFragment extends CodexSettingsFragment {
+        @Override
+        int preferenceXml() {
+            return R.xml.preferences_updates;
+        }
+
+        @Override
+        String screenTitle() {
+            return "App updates";
+        }
+
+        @Override
+        void bindScreen() {
+            bindUpdates();
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            updateUpdateSummary();
+        }
+    }
+
+    public static final class TransferFragment extends CodexSettingsFragment {
+        @Override
+        int preferenceXml() {
+            return R.xml.preferences_transfer;
+        }
+
+        @Override
+        String screenTitle() {
+            return "Transfer";
+        }
+
+        @Override
+        void bindScreen() {
+            bindTransfer();
         }
     }
 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -224,7 +224,7 @@ public final class SettingsActivity extends AppCompatActivity
             }
         }
 
-        private void bindAccount() {
+        protected void bindAccount() {
             boolean dark = Ui.isDark(requireContext());
             LayoutPreference preference = findPreference("account_card");
             RoundedLinearLayout card = preference.findViewById(R.id.settings_account_card);
@@ -297,7 +297,7 @@ public final class SettingsActivity extends AppCompatActivity
             dialog.show();
         }
 
-        private void bindAppearance() {
+        protected void bindAppearance() {
             String selected = AppPreferences.getAppTheme(requireContext());
             boolean useSystem = WidgetOptions.THEME_SYSTEM.equals(selected);
             HorizontalRadioPreference theme = findPreference("app_theme");
@@ -338,7 +338,7 @@ public final class SettingsActivity extends AppCompatActivity
             });
         }
 
-        private void bindRefresh() {
+        protected void bindRefresh() {
             SwitchPreferenceCompat onLaunch = findPreference("refresh_on_launch");
             onLaunch.setEnabled(true);
             onLaunch.setChecked(AppPreferences.getRefreshOnLaunch(requireContext()));
@@ -357,7 +357,7 @@ public final class SettingsActivity extends AppCompatActivity
             });
         }
 
-        private void bindUsagePace() {
+        protected void bindUsagePace() {
             SwitchPreferenceCompat enabled = findPreference("usage_pace_enabled_ui");
             enabled.setPersistent(false);
             enabled.setChecked(UsagePacePreferences.isEnabled(requireContext()));
@@ -388,7 +388,7 @@ public final class SettingsActivity extends AppCompatActivity
             });
         }
 
-        private void bindUpdates() {
+        protected void bindUpdates() {
             automaticUpdatePreference = findPreference("automatic_update_checks_ui");
             automaticUpdatePreference.setPersistent(false);
             automaticUpdatePreference.setChecked(UpdatePreferences.automaticChecks(requireContext()));
@@ -499,7 +499,7 @@ public final class SettingsActivity extends AppCompatActivity
             return false;
         }
 
-        private void updateUpdateSummary() {
+        protected void updateUpdateSummary() {
             if (updateStatusPreference == null || getContext() == null) {
                 return;
             }
@@ -543,7 +543,7 @@ public final class SettingsActivity extends AppCompatActivity
             updateStatusPreference.setSummary(summary.toString());
         }
 
-        private void bindNotifications() {
+        protected void bindNotifications() {
             TwoStatePreference allow = findPreference("notifications_allowed_ui");
             allow.setPersistent(false);
             allow.setChecked(ResetAlertPreferences.enabled(requireContext()));
@@ -626,7 +626,7 @@ public final class SettingsActivity extends AppCompatActivity
             updateNotificationChildrenEnabled(ResetAlertPreferences.enabled(requireContext()));
         }
 
-        private void updateNotificationChildrenEnabled(boolean enabled) {
+        protected void updateNotificationChildrenEnabled(boolean enabled) {
             PreferenceCategory lowUsage = findPreference("notifications_low_usage_category");
             PreferenceCategory credits = findPreference("notifications_credits_category");
             if (lowUsage != null) lowUsage.setEnabled(enabled);
@@ -797,7 +797,7 @@ public final class SettingsActivity extends AppCompatActivity
                     AppPreferences.loadResetCredits(requireContext()));
         }
 
-        private void bindNowBar() {
+        protected void bindNowBar() {
             nowBarDisplayModePreference = findPreference("now_bar_display_mode_ui");
             nowBarDisplayModePreference.setPersistent(false);
             nowBarDisplayModePreference.setValue(
@@ -1027,7 +1027,7 @@ public final class SettingsActivity extends AppCompatActivity
             return false;
         }
 
-        private void updateNowBarSummary() {
+        protected void updateNowBarSummary() {
             if (nowBarMonitorPreference == null || getContext() == null) return;
             boolean active = NowBarManager.isActive(requireContext());
             nowBarMonitorPreference.setChecked(active);
@@ -1123,7 +1123,7 @@ public final class SettingsActivity extends AppCompatActivity
             scheduleResetCreditExpiryReminders();
         }
 
-        private void updatePermissionSummary() {
+        protected void updatePermissionSummary() {
             if (permissionPreference == null || getContext() == null) return;
             NotificationManager manager = (NotificationManager) requireContext().getSystemService(NOTIFICATION_SERVICE);
             boolean allowed = manager != null && manager.areNotificationsEnabled()
@@ -1134,7 +1134,7 @@ public final class SettingsActivity extends AppCompatActivity
             updateNotificationChildrenEnabled(ResetAlertPreferences.enabled(requireContext()));
         }
 
-        private void bindTransfer() {
+        protected void bindTransfer() {
             findPreference("export_settings_transfer").setOnPreferenceClickListener(preference -> {
                 showExportSectionDialog();
                 return true;

--- a/android/app/src/main/res/xml/preferences_appearance.xml
+++ b/android/app/src/main/res/xml/preferences_appearance.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory android:title="Theme">
+        <dev.oneuiproject.oneui.preference.HorizontalRadioPreference
+            android:key="app_theme"
+            app:entries="@array/preferences_darkmode_entries"
+            app:entriesImage="@array/preferences_darkmode_entries_image"
+            app:entryValues="@array/preferences_darkmode_values"
+            app:viewType="image" />
+        <SwitchPreferenceCompat
+            android:key="theme_system_ui"
+            android:title="System default" />
+        <SwitchPreferenceCompat
+            android:key="material_you"
+            android:title="Material You"
+            android:summary="System colors when available"
+            android:defaultValue="false" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/android/app/src/main/res/xml/preferences_notifications.xml
+++ b/android/app/src/main/res/xml/preferences_notifications.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <dev.oneuiproject.oneui.preference.SwitchBarPreference
+        android:key="notifications_allowed_ui"
+        android:title="Allow notifications" />
+
+    <PreferenceCategory
+        android:key="notifications_low_usage_category"
+        android:title="Low usage">
+        <ListPreference
+            android:entries="@array/settings_metric_entries"
+            android:entryValues="@array/settings_metric_values"
+            android:key="notification_metric_ui"
+            android:title="Alert for"
+            app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:entries="@array/settings_threshold_entries"
+            android:entryValues="@array/settings_threshold_values"
+            android:key="notification_threshold_ui"
+            android:title="When remaining reaches"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="notifications_credits_category"
+        android:title="Reset credits">
+        <SwitchPreferenceCompat
+            android:key="unexpected_refills_ui"
+            android:title="Surprise limit refills" />
+        <SwitchPreferenceCompat
+            android:key="reset_credit_increases_ui"
+            android:title="New reset credits" />
+        <SwitchPreferenceCompat
+            android:key="reset_credit_expiry_ui"
+            android:title="Expiring reset credits" />
+        <Preference
+            android:key="reset_credit_expiry_times_ui"
+            android:title="Reminder times"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Status">
+        <Preference
+            android:key="notification_permission"
+            android:title="Notification permission"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="notification_test"
+            android:title="Send test notification"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/android/app/src/main/res/xml/preferences_now_bar.xml
+++ b/android/app/src/main/res/xml/preferences_now_bar.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <dev.oneuiproject.oneui.preference.DescriptionPreference
+        android:title="Show remaining Codex allowance on Lock screen and Always On Display."
+        app:positionMode="1" />
+
+    <PreferenceCategory android:title="Monitor">
+        <SwitchPreferenceCompat
+            android:key="now_bar_monitor_ui"
+            android:title="Monitor until reset" />
+        <SwitchPreferenceCompat
+            android:key="now_bar_auto_start_ui"
+            android:title="Auto-start when low" />
+        <ListPreference
+            android:entries="@array/settings_metric_entries"
+            android:entryValues="@array/settings_metric_values"
+            android:key="now_bar_metric_ui"
+            android:title="Auto-start for"
+            app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:entries="@array/settings_threshold_entries"
+            android:entryValues="@array/settings_threshold_values"
+            android:key="now_bar_threshold_ui"
+            android:title="Start when remaining reaches"
+            app:useSimpleSummaryProvider="true" />
+        <SwitchPreferenceCompat
+            android:key="now_bar_accelerated_ui"
+            android:title="Auto-start for accelerated usage" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Display">
+        <ListPreference
+            android:entries="@array/now_bar_display_mode_entries"
+            android:entryValues="@array/now_bar_display_mode_values"
+            android:key="now_bar_display_mode_ui"
+            android:title="Display compatibility"
+            app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:entries="@array/now_bar_percent_mode_entries"
+            android:entryValues="@array/now_bar_percent_mode_values"
+            android:key="now_bar_percent_mode_ui"
+            android:title="Percentage left"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Setup">
+        <Preference
+            android:key="now_bar_permission"
+            android:title="Live notification access"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="now_bar_setup_help"
+            android:title="Samsung setup help"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="now_bar_preview"
+            android:title="Start sample preview"
+            android:summary="20-minute sample for device testing"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/android/app/src/main/res/xml/preferences_refresh.xml
+++ b/android/app/src/main/res/xml/preferences_refresh.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory android:title="Refresh">
+        <SwitchPreferenceCompat
+            android:key="refresh_on_launch"
+            android:title="Refresh on launch" />
+        <ListPreference
+            android:entries="@array/settings_refresh_entries"
+            android:entryValues="@array/settings_refresh_values"
+            android:key="refresh_interval_ui"
+            android:title="Refresh interval"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Usage pace">
+        <SwitchPreferenceCompat
+            android:key="usage_pace_enabled_ui"
+            android:title="Estimated usage time" />
+        <ListPreference
+            android:entries="@array/usage_pace_sensitivity_entries"
+            android:entryValues="@array/usage_pace_sensitivity_values"
+            android:key="usage_pace_sensitivity_ui"
+            android:title="Warning sensitivity"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/android/app/src/main/res/xml/preferences_settings.xml
+++ b/android/app/src/main/res/xml/preferences_settings.xml
@@ -8,202 +8,43 @@
         app:allowDividerAbove="false"
         app:allowDividerBelow="false" />
 
-    <PreferenceCategory android:title="Appearance">
-        <dev.oneuiproject.oneui.preference.HorizontalRadioPreference
-            android:key="app_theme"
-            app:entries="@array/preferences_darkmode_entries"
-            app:entriesImage="@array/preferences_darkmode_entries_image"
-            app:entryValues="@array/preferences_darkmode_values"
-            app:viewType="image" />
-        <SwitchPreferenceCompat
-            android:key="theme_system_ui"
-            android:title="System default" />
-        <SwitchPreferenceCompat
-            android:key="material_you"
-            android:title="Material You"
-            android:summary="Use the system color palette when available. Falls back to One UI blue."
-            android:defaultValue="false" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="Refresh">
-        <SwitchPreferenceCompat
-            android:key="refresh_on_launch"
-            android:title="Refresh on launch" />
-        <ListPreference
-            android:entries="@array/settings_refresh_entries"
-            android:entryValues="@array/settings_refresh_values"
-            android:key="refresh_interval_ui"
-            android:title="Refresh interval"
-            app:useSimpleSummaryProvider="true" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="Usage pace">
-        <SwitchPreferenceCompat
-            android:key="usage_pace_enabled_ui"
-            android:title="Estimated usage time"
-            android:summary="Show projected allowance life and warn when it may run out well before reset" />
-        <ListPreference
-            android:entries="@array/usage_pace_sensitivity_entries"
-            android:entryValues="@array/usage_pace_sensitivity_values"
-            android:key="usage_pace_sensitivity_ui"
-            android:title="Warning sensitivity"
-            app:useSimpleSummaryProvider="true" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="App updates">
-        <SwitchPreferenceCompat
-            android:key="automatic_update_checks_ui"
-            android:title="Check automatically"
-            android:summary="Check signed GitHub releases on a schedule" />
-        <ListPreference
-            android:entries="@array/settings_update_interval_entries"
-            android:entryValues="@array/settings_update_interval_values"
-            android:key="update_check_interval_ui"
-            android:title="Check frequency"
-            app:useSimpleSummaryProvider="true" />
-        <SwitchPreferenceCompat
-            android:key="notify_update_available_ui"
-            android:title="Notify when update available"
-            android:summary="Show a notification with Open and Update actions" />
+    <PreferenceCategory android:title="General">
         <Preference
-            android:key="update_status"
-            android:title="Installed version"
-            app:iconSpaceReserved="false"
-            app:selectable="false" />
-        <Preference
-            android:key="check_for_updates"
-            android:title="Check for updates"
-            android:summary="Check GitHub now"
+            android:key="open_appearance"
+            android:title="Appearance"
+            app:fragment="dev.bennett.codexmeter.SettingsActivity$AppearanceFragment"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="release_history"
-            android:title="Advanced release history"
-            android:summary="View available versions and downgrade requirements"
+            android:key="open_refresh"
+            android:title="Refresh &amp; usage"
+            app:fragment="dev.bennett.codexmeter.SettingsActivity$RefreshFragment"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="Notifications">
-        <SwitchPreferenceCompat
-            android:key="notifications_allowed_ui"
-            android:title="Allow notifications" />
-        <ListPreference
-            android:entries="@array/settings_metric_entries"
-            android:entryValues="@array/settings_metric_values"
-            android:key="notification_metric_ui"
-            android:title="Low usage alerts"
-            app:useSimpleSummaryProvider="true" />
-        <ListPreference
-            android:entries="@array/settings_threshold_entries"
-            android:entryValues="@array/settings_threshold_values"
-            android:key="notification_threshold_ui"
-            android:title="Low when remaining reaches"
-            app:useSimpleSummaryProvider="true" />
-        <SwitchPreferenceCompat
-            android:key="unexpected_refills_ui"
-            android:title="Surprise limit refills"
-            android:summary="Celebrate when an allowance reaches 100% before its scheduled reset" />
-        <SwitchPreferenceCompat
-            android:key="reset_credit_increases_ui"
-            android:title="New reset credits"
-            android:summary="Notify when your available reset-credit count increases" />
-        <SwitchPreferenceCompat
-            android:key="reset_credit_expiry_ui"
-            android:title="Expiring reset credits"
-            android:summary="Remind me before an available reset credit expires" />
+    <PreferenceCategory android:title="Alerts &amp; live">
         <Preference
-            android:key="reset_credit_expiry_times_ui"
-            android:title="Reminder times"
+            android:key="open_notifications"
+            android:title="Notifications"
+            app:fragment="dev.bennett.codexmeter.SettingsActivity$NotificationsFragment"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="notification_permission"
-            android:title="Notification permission"
-            app:iconSpaceReserved="false" />
-        <Preference
-            android:key="notification_test"
-            android:title="Send test notification"
-            android:summary="Verify alert delivery now"
+            android:key="open_now_bar"
+            android:title="Now Bar"
+            app:fragment="dev.bennett.codexmeter.SettingsActivity$NowBarFragment"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="Now Bar">
-        <ListPreference
-            android:entries="@array/now_bar_display_mode_entries"
-            android:entryValues="@array/now_bar_display_mode_values"
-            android:key="now_bar_display_mode_ui"
-            android:title="Display compatibility"
-            app:useSimpleSummaryProvider="true" />
-        <ListPreference
-            android:entries="@array/now_bar_percent_mode_entries"
-            android:entryValues="@array/now_bar_percent_mode_values"
-            android:key="now_bar_percent_mode_ui"
-            android:title="Percentage left"
-            app:useSimpleSummaryProvider="true" />
-        <SwitchPreferenceCompat
-            android:key="now_bar_monitor_ui"
-            android:title="Monitor until reset"
-            android:summary="Show remaining Codex allowance until the next available usage reset" />
-        <SwitchPreferenceCompat
-            android:key="now_bar_auto_start_ui"
-            android:title="Auto-start when low"
-            android:summary="Start the live monitor when remaining allowance hits the threshold below" />
-        <SwitchPreferenceCompat
-            android:key="now_bar_accelerated_ui"
-            android:title="Auto-start for accelerated usage"
-            android:summary="Keep the live monitor active until this pace improves or the affected limit resets" />
-        <ListPreference
-            android:entries="@array/settings_metric_entries"
-            android:entryValues="@array/settings_metric_values"
-            android:key="now_bar_metric_ui"
-            android:title="Auto-start for"
-            app:useSimpleSummaryProvider="true" />
-        <ListPreference
-            android:entries="@array/settings_threshold_entries"
-            android:entryValues="@array/settings_threshold_values"
-            android:key="now_bar_threshold_ui"
-            android:title="Start when remaining reaches"
-            app:useSimpleSummaryProvider="true" />
+    <PreferenceCategory android:title="App">
         <Preference
-            android:key="now_bar_preview"
-            android:title="Start sample preview"
-            android:summary="Show a 20-minute sample activity for device testing"
+            android:key="open_updates"
+            android:title="App updates"
+            app:fragment="dev.bennett.codexmeter.SettingsActivity$UpdatesFragment"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="now_bar_permission"
-            android:title="Live notification access"
+            android:key="open_transfer"
+            android:title="Transfer"
+            app:fragment="dev.bennett.codexmeter.SettingsActivity$TransferFragment"
             app:iconSpaceReserved="false" />
-        <Preference
-            android:key="now_bar_setup_help"
-            android:title="Samsung setup help"
-            android:summary="Developer options and firmware troubleshooting"
-            app:iconSpaceReserved="false" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="Transfer">
-        <Preference
-            android:key="export_settings_transfer"
-            android:title="Export"
-            android:summary="Save selected settings and optional sign-in data to a file"
-            app:iconSpaceReserved="false" />
-        <Preference
-            android:key="import_settings_transfer"
-            android:title="Import"
-            android:summary="Restore selected sections from a Codex Meter transfer file"
-            app:iconSpaceReserved="false" />
-        <Preference
-            android:key="transfer_security_notice"
-            android:title="Do not share transfer files with authentication"
-            android:summary="Exported authentication includes ChatGPT tokens. Anyone with that file can use your account. Keep it private."
-            app:iconSpaceReserved="false"
-            app:selectable="false" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="Privacy">
-        <Preference
-            android:icon="@drawable/ic_oui_privacy"
-            android:summary="OAuth tokens are encrypted with Android Keystore. Requests go only to OpenAI for authentication and ChatGPT &amp; Codex endpoints."
-            android:title="Local data and privacy"
-            app:iconSpaceReserved="false"
-            app:selectable="false" />
     </PreferenceCategory>
 
     <dev.oneuiproject.oneui.preference.InsetPreferenceCategory app:height="20dp" />

--- a/android/app/src/main/res/xml/preferences_transfer.xml
+++ b/android/app/src/main/res/xml/preferences_transfer.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <dev.oneuiproject.oneui.preference.DescriptionPreference
+        android:title="Move settings between devices. Authentication exports require an extra confirmation."
+        app:positionMode="1" />
+
+    <PreferenceCategory android:title="Transfer">
+        <Preference
+            android:key="export_settings_transfer"
+            android:title="Export"
+            android:summary="Save selected settings to a file"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="import_settings_transfer"
+            android:title="Import"
+            android:summary="Restore from a Codex Meter transfer file"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/android/app/src/main/res/xml/preferences_updates.xml
+++ b/android/app/src/main/res/xml/preferences_updates.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory android:title="Automatic checks">
+        <SwitchPreferenceCompat
+            android:key="automatic_update_checks_ui"
+            android:title="Check automatically" />
+        <ListPreference
+            android:entries="@array/settings_update_interval_entries"
+            android:entryValues="@array/settings_update_interval_values"
+            android:key="update_check_interval_ui"
+            android:title="Check frequency"
+            app:useSimpleSummaryProvider="true" />
+        <SwitchPreferenceCompat
+            android:key="notify_update_available_ui"
+            android:title="Notify when update available" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Status">
+        <Preference
+            android:key="update_status"
+            android:title="Installed version"
+            app:iconSpaceReserved="false"
+            app:selectable="false" />
+        <Preference
+            android:key="check_for_updates"
+            android:title="Check for updates"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="release_history"
+            android:title="Release history"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -103,10 +103,8 @@ grep -q 'Open on GitHub' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java"
 grep -q 'UpdateCheckFrequency' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateScheduler.java"
-grep -q 'notify_update_available_ui' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
-grep -q 'update_check_interval_ui' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -Rq 'notify_update_available_ui' "$ROOT/app/src/main/res/xml/"
+grep -Rq 'update_check_interval_ui' "$ROOT/app/src/main/res/xml/"
 grep -q 'settings_update_interval_entries' \
   "$ROOT/app/src/main/res/values/settings_arrays.xml"
 grep -q 'EXTRA_START_INSTALL' \
@@ -123,12 +121,10 @@ test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManage
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
 grep -q 'testSettingsTransfer' "$ROOT/tests/ParserSelfTest.java"
-grep -q 'export_settings_transfer' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
-grep -q 'import_settings_transfer' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
-grep -q 'transfer_security_notice' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -Rq 'export_settings_transfer' "$ROOT/app/src/main/res/xml/"
+grep -Rq 'import_settings_transfer' "$ROOT/app/src/main/res/xml/"
+grep -q 'confirmSensitiveExport' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 grep -q 'SECURITY_WARNING' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
 grep -q 'bindTransfer' \
@@ -137,10 +133,15 @@ grep -q 'SettingsTransferStore.collect' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 grep -q 'SettingsTransferStore.apply' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
-grep -q 'Do not share transfer files with authentication' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
-grep -q 'material_you' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -q 'OnPreferenceStartFragmentCallback' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'preferences_appearance' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'SwitchBarPreference' \
+  "$ROOT/app/src/main/res/xml/preferences_notifications.xml"
+grep -q 'DescriptionPreference' \
+  "$ROOT/app/src/main/res/xml/preferences_now_bar.xml"
+grep -Rq 'material_you' "$ROOT/app/src/main/res/xml/"
 grep -q 'isMaterialYouEnabled' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java"
 grep -q 'AppTheme_MaterialYou' \
@@ -273,8 +274,7 @@ grep -q 'NowBarManager.onUsageUpdated' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageApi.java"
 grep -q 'maybeAutoStart' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
-grep -q 'now_bar_auto_start_ui' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -Rq 'now_bar_auto_start_ui' "$ROOT/app/src/main/res/xml/"
 grep -q 'now_bar_threshold_ui' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 grep -q 'NowBarPreferences.isAutoStartEnabled' \
@@ -310,10 +310,8 @@ assert "stop(context, false);" in block
 assert "return false;" in block
 print("applyPercentModeChange stops on post failure.")
 PY
-grep -q 'now_bar_display_mode_ui' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
-grep -q 'now_bar_percent_mode_ui' \
-  "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -Rq 'now_bar_display_mode_ui' "$ROOT/app/src/main/res/xml/"
+grep -Rq 'now_bar_percent_mode_ui' "$ROOT/app/src/main/res/xml/"
 grep -q 'NowBarPreferences.getPercentMode' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'applyPercentModeChange' \
@@ -381,9 +379,9 @@ test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsagePacePreferences.java"
 test -f "$ROOT/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java"
 grep -q 'UsagePaceDemoActivity' "$ROOT/app/src/debug/AndroidManifest.xml"
-grep -q 'usage_pace_enabled_ui' "$ROOT/app/src/main/res/xml/preferences_settings.xml"
-grep -q 'usage_pace_sensitivity_ui' "$ROOT/app/src/main/res/xml/preferences_settings.xml"
-grep -q 'now_bar_accelerated_ui' "$ROOT/app/src/main/res/xml/preferences_settings.xml"
+grep -Rq 'usage_pace_enabled_ui' "$ROOT/app/src/main/res/xml/"
+grep -Rq 'usage_pace_sensitivity_ui' "$ROOT/app/src/main/res/xml/"
+grep -Rq 'now_bar_accelerated_ui' "$ROOT/app/src/main/res/xml/"
 grep -q 'accelerated_enabled' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
 grep -q 'START_ACCELERATED' \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Settings was a single mega-scroll of every toggle, status row, and essay-length summary. This restructures it the AndroidX / One UI way:

- Compact hub screen with account + drill-in rows (Appearance, Refresh & usage, Notifications, Now Bar, App updates, Transfer, About)
- `PreferenceFragmentCompat.OnPreferenceStartFragmentCallback` navigation inside `SettingsActivity` with toolbar title sync
- One UI `SwitchBarPreference` for the notifications master switch
- One UI `DescriptionPreference` intros on Now Bar and Transfer
- Verbose summaries stripped; hub rows show short live summaries
- Privacy copy moved to About; transfer token warning stays in export confirmation dialogs only

## Demo (illustrative mockups — no emulator in this VM)
Hub, Notifications (SwitchBar), and Now Bar drill-downs:

[Settings hub](https://cursor.com/agents/bc-dee0f6eb-cccc-4f65-89c4-cbc78dfe443b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsettings-hub.png)
[Notifications](https://cursor.com/agents/bc-dee0f6eb-cccc-4f65-89c4-cbc78dfe443b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsettings-notifications.png)
[Now Bar](https://cursor.com/agents/bc-dee0f6eb-cccc-4f65-89c4-cbc78dfe443b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsettings-now-bar.png)

## Test plan
- [x] `./run-tests.sh`
- [x] `./build.sh` (phone + Wear release APKs)
- [x] `./lint.sh`
- [ ] Manual on device: hub drill-ins, back title restore, notifications SwitchBar, auth export confirm, About privacy

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dee0f6eb-cccc-4f65-89c4-cbc78dfe443b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dee0f6eb-cccc-4f65-89c4-cbc78dfe443b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

