### PR TITLE
Show reset-credit expiry and list all credits

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -8,5 +8,9 @@
             android:name="dev.bennett.codexmeter.UsagePaceDemoActivity"
             android:exported="true"
             android:theme="@style/AppTheme" />
+        <activity
+            android:name="dev.bennett.codexmeter.ResetCreditsScreenshotActivity"
+            android:exported="true"
+            android:theme="@style/AppTheme" />
     </application>
 </manifest>

--- a/android/app/src/debug/java/dev/bennett/codexmeter/ResetCreditsScreenshotActivity.java
+++ b/android/app/src/debug/java/dev/bennett/codexmeter/ResetCreditsScreenshotActivity.java
@@ -1,0 +1,235 @@
+package dev.bennett.codexmeter;
+
+import android.app.Activity;
+import android.content.res.ColorStateList;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Debug-only lightweight renderer for the reset-credit expiry UI.
+ * Avoids One UI ToolbarLayout so software emulators can still capture screenshots.
+ */
+public final class ResetCreditsScreenshotActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle state) {
+        super.onCreate(state);
+        boolean dark = true;
+        setTheme(dark ? android.R.style.Theme_DeviceDefault_NoActionBar
+                : android.R.style.Theme_DeviceDefault_Light_NoActionBar);
+
+        long now = System.currentTimeMillis();
+        seedDemoData(now);
+
+        ScrollView scroll = new ScrollView(this);
+        scroll.setBackgroundColor(Color.parseColor("#121212"));
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setPadding(dp(16), dp(24), dp(16), dp(24));
+
+        TextView title = text("Codex Meter", 28, Color.WHITE, true);
+        root.addView(title);
+        TextView subtitle = text("Reset credits demo", 14, Color.parseColor("#B0B0B0"), false);
+        LinearLayout.LayoutParams subtitleParams = new LinearLayout.LayoutParams(-1, -2);
+        subtitleParams.bottomMargin = dp(16);
+        root.addView(subtitle, subtitleParams);
+
+        root.addView(buildResetCard(dark, now));
+        LinearLayout.LayoutParams spacer = new LinearLayout.LayoutParams(1, dp(20));
+        root.addView(new View(this), spacer);
+        root.addView(buildCreditsList(dark, now));
+
+        scroll.addView(root);
+        setContentView(scroll);
+
+        new Handler(Looper.getMainLooper()).postDelayed(() -> {
+            capture(scroll, "01-reset-card-dashboard.png");
+            // Scroll to list section and capture again after a beat.
+            scroll.fullScroll(View.FOCUS_DOWN);
+            new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                capture(scroll, "02-reset-credits-list.png");
+                // Keep the activity visible long enough for an adb screencap.
+            }, 400);
+        }, 600);
+    }
+
+    private void seedDemoData(long now) {
+        try {
+            SecureTokenStore.save(this, new AuthTokens(
+                    "debug-demo-access", "debug-demo-refresh", "", Long.MAX_VALUE,
+                    "debug-demo-account", "demo@codexmeter.local"));
+            AppPreferences.saveResetCredits(this, new ResetCreditsSnapshot(2,
+                    Arrays.asList(
+                            new RateLimitResetCredit("credit-soon", "both",
+                                    RateLimitResetCredit.STATUS_AVAILABLE,
+                                    now - TimeUnit.DAYS.toMillis(1),
+                                    now + TimeUnit.DAYS.toMillis(2),
+                                    "Soonest reset credit",
+                                    "This credit expires first."),
+                            new RateLimitResetCredit("credit-later", "both",
+                                    RateLimitResetCredit.STATUS_AVAILABLE,
+                                    now - TimeUnit.DAYS.toMillis(1),
+                                    now + TimeUnit.DAYS.toMillis(9),
+                                    "Later reset credit",
+                                    "This credit expires after the soonest one.")),
+                    now));
+            AppPreferences.completeOnboarding(this);
+            AppPreferences.setRefreshOnLaunch(this, false);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Could not seed reset-credit screenshot demo",
+                    exception);
+        }
+    }
+
+    private LinearLayout buildResetCard(boolean dark, long now) {
+        ResetCreditsSnapshot snapshot = AppPreferences.loadResetCredits(this);
+        int count = snapshot == null ? 0 : snapshot.availableCount;
+        long nextExpiry = snapshot == null ? 0L : snapshot.nextExpiryMillis(now);
+
+        LinearLayout card = card();
+        LinearLayout header = new LinearLayout(this);
+        header.setOrientation(LinearLayout.HORIZONTAL);
+        header.setGravity(Gravity.CENTER_VERTICAL);
+
+        LinearLayout countBlock = new LinearLayout(this);
+        countBlock.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout countRow = new LinearLayout(this);
+        countRow.setOrientation(LinearLayout.HORIZONTAL);
+        countRow.setGravity(Gravity.CENTER_VERTICAL);
+        TextView countView = text(String.valueOf(count), 30, Color.WHITE, true);
+        countRow.addView(countView);
+        TextView label = text("Resets available", 18, Color.WHITE, true);
+        LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(-2, -2);
+        labelParams.leftMargin = dp(18);
+        countRow.addView(label, labelParams);
+        countBlock.addView(countRow);
+
+        if (nextExpiry > 0L) {
+            TextView expiry = text(
+                    "Next expires " + UsageFormat.absolute(this, nextExpiry, now)
+                            + " (" + UsageFormat.relative(nextExpiry, now) + ")",
+                    13, Color.parseColor("#B0B0B0"), false);
+            LinearLayout.LayoutParams expiryParams = new LinearLayout.LayoutParams(-1, -2);
+            expiryParams.topMargin = dp(4);
+            countBlock.addView(expiry, expiryParams);
+        }
+        header.addView(countBlock, new LinearLayout.LayoutParams(0, -2, 1f));
+
+        ImageView arrow = new ImageView(this);
+        arrow.setImageResource(R.drawable.ic_oui_keyboard_arrow_right);
+        arrow.setImageTintList(ColorStateList.valueOf(Color.parseColor("#B0B0B0")));
+        arrow.setContentDescription("View all reset credits");
+        header.addView(arrow, new LinearLayout.LayoutParams(dp(40), dp(40)));
+        card.addView(header);
+
+        Button use = new Button(this);
+        use.setText("Use 1 reset");
+        use.setAllCaps(false);
+        use.setTextColor(Color.WHITE);
+        use.setBackgroundColor(Color.parseColor("#4B8BFF"));
+        LinearLayout.LayoutParams useParams = new LinearLayout.LayoutParams(-1, dp(56));
+        useParams.topMargin = dp(12);
+        card.addView(use, useParams);
+        return card;
+    }
+
+    private LinearLayout buildCreditsList(boolean dark, long now) {
+        ResetCreditsSnapshot snapshot = AppPreferences.loadResetCredits(this);
+        List<RateLimitResetCredit> credits = snapshot == null
+                ? java.util.Collections.emptyList()
+                : snapshot.availableCreditsSortedByExpiry(now);
+
+        LinearLayout card = card();
+        card.addView(text("Credits & expiration", 16, Color.WHITE, true));
+        for (int index = 0; index < credits.size(); index++) {
+            RateLimitResetCredit credit = credits.get(index);
+            if (index > 0) {
+                View divider = new View(this);
+                divider.setBackgroundColor(Color.parseColor("#333333"));
+                LinearLayout.LayoutParams dividerParams =
+                        new LinearLayout.LayoutParams(-1, dp(1));
+                dividerParams.topMargin = dp(14);
+                dividerParams.bottomMargin = dp(14);
+                card.addView(divider, dividerParams);
+            }
+            String title = credit.title == null || credit.title.trim().isEmpty()
+                    ? "Reset credit " + (index + 1) : credit.title.trim();
+            card.addView(text(title, 16, Color.WHITE, true));
+            String expiryText = credit.expiresAtMillis > 0L
+                    ? "Expires " + UsageFormat.absolute(this, credit.expiresAtMillis, now)
+                    + " (" + UsageFormat.relative(credit.expiresAtMillis, now) + ")"
+                    : "No expiration date available";
+            TextView expiry = text(expiryText, 13, Color.parseColor("#B0B0B0"), false);
+            LinearLayout.LayoutParams expiryParams = new LinearLayout.LayoutParams(-1, -2);
+            expiryParams.topMargin = dp(4);
+            card.addView(expiry, expiryParams);
+        }
+        return card;
+    }
+
+    private LinearLayout card() {
+        LinearLayout card = new LinearLayout(this);
+        card.setOrientation(LinearLayout.VERTICAL);
+        card.setPadding(dp(16), dp(16), dp(16), dp(16));
+        card.setBackgroundColor(Color.parseColor("#1E1E1E"));
+        return card;
+    }
+
+    private TextView text(String value, float sizeSp, int color, boolean bold) {
+        TextView view = new TextView(this);
+        view.setText(value);
+        view.setTextSize(sizeSp);
+        view.setTextColor(color);
+        if (bold) {
+            view.setTypeface(view.getTypeface(), android.graphics.Typeface.BOLD);
+        }
+        return view;
+    }
+
+    private void capture(View view, String filename) {
+        int width = Math.max(view.getWidth(), 1);
+        int height = Math.max(view.getHeight(), 1);
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        view.draw(canvas);
+        File out = new File(getExternalFilesDir(null), filename);
+        if (out.getParentFile() != null) {
+            //noinspection ResultOfMethodCallIgnored
+            out.getParentFile().mkdirs();
+        }
+        try (FileOutputStream stream = new FileOutputStream(out)) {
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+            stream.flush();
+        } catch (Exception exception) {
+            // Fall back to internal files if external is unavailable.
+            File fallback = new File(getFilesDir(), filename);
+            try (FileOutputStream stream = new FileOutputStream(fallback)) {
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+                stream.flush();
+            } catch (Exception nested) {
+                throw new IllegalStateException("Could not write " + filename, nested);
+            }
+        } finally {
+            bitmap.recycle();
+        }
+    }
+
+    private int dp(int value) {
+        return Math.round(value * getResources().getDisplayMetrics().density);
+    }
+}

--- a/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
+++ b/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
@@ -32,6 +32,21 @@ public final class UsagePaceDemoActivity extends Activity {
                     "debug-demo-access", "debug-demo-refresh", "", Long.MAX_VALUE,
                     "debug-demo-account", "demo@codexmeter.local"));
             AppPreferences.saveSnapshot(this, snapshot);
+            AppPreferences.saveResetCredits(this, new ResetCreditsSnapshot(2,
+                    java.util.Arrays.asList(
+                            new RateLimitResetCredit("credit-soon", "both",
+                                    RateLimitResetCredit.STATUS_AVAILABLE,
+                                    now - TimeUnit.DAYS.toMillis(1),
+                                    now + TimeUnit.DAYS.toMillis(2),
+                                    "Soonest reset credit",
+                                    "This credit expires first."),
+                            new RateLimitResetCredit("credit-later", "both",
+                                    RateLimitResetCredit.STATUS_AVAILABLE,
+                                    now - TimeUnit.DAYS.toMillis(1),
+                                    now + TimeUnit.DAYS.toMillis(9),
+                                    "Later reset credit",
+                                    "This credit expires after the soonest one.")),
+                    now));
             AppPreferences.setRefreshOnLaunch(this, false);
             AppPreferences.completeOnboarding(this);
             UsagePacePreferences.setEnabled(this, true);

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.ColorStateList;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -430,8 +431,17 @@ public final class MainActivity extends AppCompatActivity {
         boolean zIsSignedIn = SecureTokenStore.isSignedIn(this);
         ResetCreditsSnapshot resetCreditsSnapshotLoadResetCredits = AppPreferences.loadResetCredits(this);
         int i = resetCreditsSnapshotLoadResetCredits == null ? 0 : resetCreditsSnapshotLoadResetCredits.availableCount;
+        long now = System.currentTimeMillis();
+        long nextExpiry = resetCreditsSnapshotLoadResetCredits == null
+                ? 0L : resetCreditsSnapshotLoadResetCredits.nextExpiryMillis(now);
 
-        LinearLayout countRow = Ui.horizontal(this, Gravity.CENTER);
+        LinearLayout header = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
+        header.setMinimumHeight(Ui.dp(this, 66.0f));
+        LinearLayout countBlock = new LinearLayout(this);
+        countBlock.setOrientation(LinearLayout.VERTICAL);
+        countBlock.setGravity(Gravity.CENTER_VERTICAL);
+
+        LinearLayout countRow = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
         TextView count = Ui.text(this, zIsSignedIn ? String.valueOf(i) : "—", 30.0f, Ui.mainText(this.dark));
         count.setTypeface(Ui.mediumTypeface(this));
         countRow.addView(count);
@@ -440,17 +450,51 @@ public final class MainActivity extends AppCompatActivity {
         LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(-2, -2);
         labelParams.setMargins(Ui.dp(this, 18.0f), 0, 0, 0);
         countRow.addView(label, labelParams);
-        linearLayoutCard.addView(countRow, new LinearLayout.LayoutParams(-1, Ui.dp(this, 66.0f)));
+        countBlock.addView(countRow);
+
+        if (zIsSignedIn && i > 0 && nextExpiry > 0L) {
+            TextView expiry = Ui.text(this,
+                    "Next expires " + UsageFormat.absolute(this, nextExpiry, now)
+                            + " (" + UsageFormat.relative(nextExpiry, now) + ")",
+                    13.0f, Ui.secondaryText(this.dark));
+            LinearLayout.LayoutParams expiryParams = new LinearLayout.LayoutParams(-1, -2);
+            expiryParams.setMargins(0, Ui.dp(this, 4.0f), 0, 0);
+            countBlock.addView(expiry, expiryParams);
+        } else if (zIsSignedIn && i > 0) {
+            TextView expiry = Ui.text(this, "Expiry details unavailable", 13.0f,
+                    Ui.secondaryText(this.dark));
+            LinearLayout.LayoutParams expiryParams = new LinearLayout.LayoutParams(-1, -2);
+            expiryParams.setMargins(0, Ui.dp(this, 4.0f), 0, 0);
+            countBlock.addView(expiry, expiryParams);
+        }
+
+        header.addView(countBlock, new LinearLayout.LayoutParams(0, -2, 1.0f));
+
+        ImageView detailsArrow = new ImageView(this);
+        detailsArrow.setImageResource(R.drawable.ic_oui_keyboard_arrow_right);
+        detailsArrow.setImageTintList(ColorStateList.valueOf(Ui.secondaryText(this.dark)));
+        detailsArrow.setContentDescription("View all reset credits");
+        detailsArrow.setPadding(Ui.dp(this, 8.0f), Ui.dp(this, 8.0f), Ui.dp(this, 4.0f),
+                Ui.dp(this, 8.0f));
+        header.addView(detailsArrow, new LinearLayout.LayoutParams(Ui.dp(this, 40.0f),
+                Ui.dp(this, 40.0f)));
+
+        View.OnClickListener openDetails = view ->
+                startActivity(new Intent(MainActivity.this, ResetCreditActivity.class));
+        header.setOnClickListener(openDetails);
+        header.setClickable(true);
+        header.setFocusable(true);
+        detailsArrow.setOnClickListener(openDetails);
+        linearLayoutCard.addView(header, new LinearLayout.LayoutParams(-1, -2));
 
         Button button = Ui.nativePrimaryButton(this, i > 0 ? "Use 1 reset" : "No resets available");
         button.setEnabled(zIsSignedIn && i > 0);
-        button.setOnClickListener(new View.OnClickListener() { // from class: dev.bennett.codexmeter.MainActivity.6
-            @Override // android.view.View.OnClickListener
-            public void onClick(View view) {
-                MainActivity.this.startActivity(new Intent(MainActivity.this, (Class<?>) ResetCreditActivity.class));
-            }
-        });
-        linearLayoutCard.addView(button, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60.0f)));
+        button.setOnClickListener(view ->
+                startActivity(new Intent(MainActivity.this, ResetCreditActivity.class)
+                        .putExtra(AppConstants.EXTRA_PROMPT_USE_RESET, true)));
+        LinearLayout.LayoutParams buttonParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 60.0f));
+        buttonParams.setMargins(0, Ui.dp(this, 8.0f), 0, 0);
+        linearLayoutCard.addView(button, buttonParams);
         return linearLayoutCard;
     }
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java
@@ -7,9 +7,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
-import android.widget.FrameLayout;
 import android.widget.LinearLayout;
-import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 import java.util.concurrent.ExecutorService;
@@ -52,61 +50,124 @@ public final class ResetCreditActivity extends AppCompatActivity {
     }
 
     public void rebuild() {
-        String str;
         this.content.removeAllViews();
+        ResetCreditsSnapshot snapshot = AppPreferences.loadResetCredits(this);
+        int availableCount = snapshot == null ? 0 : snapshot.availableCount;
+        long now = System.currentTimeMillis();
+        java.util.List<RateLimitResetCredit> credits = snapshot == null
+                ? java.util.Collections.emptyList()
+                : snapshot.availableCreditsSortedByExpiry(now);
+
         this.content.addView(Ui.sectionTitle(this, "Available credits", this.dark));
-        LinearLayout linearLayoutCard = Ui.card(this, this.dark);
-        ResetCreditsSnapshot resetCreditsSnapshotLoadResetCredits = AppPreferences.loadResetCredits(this);
-        int i = resetCreditsSnapshotLoadResetCredits == null ? 0 : resetCreditsSnapshotLoadResetCredits.availableCount;
-        TextView textViewText = Ui.text(this, i + " reset credit" + (i == 1 ? "" : "s") + " available", 20.0f, Ui.mainText(this.dark));
-        textViewText.setTypeface(Ui.mediumTypeface(this));
-        linearLayoutCard.addView(textViewText);
-        long jCurrentTimeMillis = System.currentTimeMillis();
-        long jNextExpiryMillis = resetCreditsSnapshotLoadResetCredits == null ? 0L : resetCreditsSnapshotLoadResetCredits.nextExpiryMillis(jCurrentTimeMillis);
-        if (jNextExpiryMillis > 0) {
-            str = "Next credit expires " + UsageFormat.absolute(this, jNextExpiryMillis, jCurrentTimeMillis) + " (" + UsageFormat.relative(jNextExpiryMillis, jCurrentTimeMillis) + ").";
-        } else if (i > 0) {
-            str = "Expiry details are unavailable; OpenAI will choose an eligible credit.";
+        LinearLayout summaryCard = Ui.card(this, this.dark);
+        TextView summary = Ui.text(this,
+                availableCount + " reset credit" + (availableCount == 1 ? "" : "s") + " available",
+                20.0f, Ui.mainText(this.dark));
+        summary.setTypeface(Ui.mediumTypeface(this));
+        summaryCard.addView(summary);
+
+        String summaryDetail;
+        long nextExpiry = snapshot == null ? 0L : snapshot.nextExpiryMillis(now);
+        if (nextExpiry > 0L) {
+            summaryDetail = "Soonest expiry "
+                    + UsageFormat.absolute(this, nextExpiry, now)
+                    + " (" + UsageFormat.relative(nextExpiry, now) + ").";
+        } else if (availableCount > 0) {
+            summaryDetail = "Expiry details are unavailable; OpenAI will choose an eligible credit.";
         } else {
-            str = "No reset credit is currently available.";
+            summaryDetail = "No reset credit is currently available.";
         }
-        View viewText = Ui.text(this, str, 13.0f, Ui.secondaryText(this.dark));
-        LinearLayout.LayoutParams layoutParams2 = new LinearLayout.LayoutParams(-1, -2);
-        layoutParams2.setMargins(0, Ui.dp(this, 8.0f), 0, Ui.dp(this, 14.0f));
-        linearLayoutCard.addView(viewText, layoutParams2);
-        View viewText2 = Ui.text(this, "Using a credit asks OpenAI to reset the currently used Codex rate-limit windows. Afterward, Codex Meter reloads both usage windows and the remaining credit inventory.", 13.0f, Ui.secondaryText(this.dark));
-        LinearLayout.LayoutParams layoutParams3 = new LinearLayout.LayoutParams(-1, -2);
-        layoutParams3.setMargins(0, 0, 0, Ui.dp(this, 16.0f));
-        linearLayoutCard.addView(viewText2, layoutParams3);
+        View summaryDetailView = Ui.text(this, summaryDetail, 13.0f, Ui.secondaryText(this.dark));
+        LinearLayout.LayoutParams summaryDetailParams = new LinearLayout.LayoutParams(-1, -2);
+        summaryDetailParams.setMargins(0, Ui.dp(this, 8.0f), 0, Ui.dp(this, 14.0f));
+        summaryCard.addView(summaryDetailView, summaryDetailParams);
+
+        View help = Ui.text(this,
+                "Using a credit asks OpenAI to reset the currently used Codex rate-limit windows. Afterward, Codex Meter reloads both usage windows and the remaining credit inventory.",
+                13.0f, Ui.secondaryText(this.dark));
+        LinearLayout.LayoutParams helpParams = new LinearLayout.LayoutParams(-1, -2);
+        helpParams.setMargins(0, 0, 0, Ui.dp(this, 16.0f));
+        summaryCard.addView(help, helpParams);
+
         String visibleResetCreditsError = AppPreferences.getVisibleResetCreditsError(this);
         if (!visibleResetCreditsError.isEmpty()) {
-            View viewText3 = Ui.text(this, visibleResetCreditsError, 12.0f, Ui.danger(this.dark));
-            LinearLayout.LayoutParams layoutParams4 = new LinearLayout.LayoutParams(-1, -2);
-            layoutParams4.setMargins(0, 0, 0, Ui.dp(this, 12.0f));
-            linearLayoutCard.addView(viewText3, layoutParams4);
+            View error = Ui.text(this, visibleResetCreditsError, 12.0f, Ui.danger(this.dark));
+            LinearLayout.LayoutParams errorParams = new LinearLayout.LayoutParams(-1, -2);
+            errorParams.setMargins(0, 0, 0, Ui.dp(this, 12.0f));
+            summaryCard.addView(error, errorParams);
         }
-        LinearLayout linearLayoutHorizontal2 = Ui.horizontal(this, 16);
-        Button button = Ui.button(this, "Cancel", false, this.dark);
-        button.setOnClickListener(new View.OnClickListener() { // from class: dev.bennett.codexmeter.ResetCreditActivity.2
-            @Override // android.view.View.OnClickListener
-            public void onClick(View view) {
-                ResetCreditActivity.this.finish();
+
+        LinearLayout actions = Ui.horizontal(this, 16);
+        Button cancel = Ui.button(this, "Cancel", false, this.dark);
+        cancel.setOnClickListener(view -> finish());
+        actions.addView(cancel, new LinearLayout.LayoutParams(0, Ui.dp(this, 52.0f), 1.0f));
+        this.useButton = Ui.button(this,
+                availableCount > 0 ? "Use reset" : "No reset available", true, this.dark);
+        this.useButton.setEnabled(availableCount > 0 && SecureTokenStore.isSignedIn(this));
+        LinearLayout.LayoutParams useParams = new LinearLayout.LayoutParams(0, Ui.dp(this, 52.0f), 1.0f);
+        useParams.setMargins(Ui.dp(this, 10.0f), 0, 0, 0);
+        actions.addView(this.useButton, useParams);
+        this.useButton.setOnClickListener(view -> confirmUse());
+        summaryCard.addView(actions);
+        this.content.addView(summaryCard);
+
+        this.content.addView(Ui.sectionTitle(this, "Credits & expiration", this.dark));
+        LinearLayout listCard = Ui.card(this, this.dark);
+        if (credits.isEmpty()) {
+            View empty = Ui.text(this,
+                    availableCount > 0
+                            ? "Individual credit expiration details are not cached yet. Pull to refresh from the dashboard, then open this screen again."
+                            : "There are no available reset credits to show.",
+                    13.0f, Ui.secondaryText(this.dark));
+            listCard.addView(empty);
+        } else {
+            for (int index = 0; index < credits.size(); index++) {
+                RateLimitResetCredit credit = credits.get(index);
+                if (index > 0) {
+                    View divider = new View(this);
+                    divider.setBackgroundColor(Ui.divider(this.dark));
+                    LinearLayout.LayoutParams dividerParams =
+                            new LinearLayout.LayoutParams(-1, Ui.dp(this, 1.0f));
+                    dividerParams.setMargins(0, Ui.dp(this, 14.0f), 0, Ui.dp(this, 14.0f));
+                    listCard.addView(divider, dividerParams);
+                }
+                listCard.addView(buildCreditRow(credit, index + 1, now));
             }
-        });
-        linearLayoutHorizontal2.addView(button, new LinearLayout.LayoutParams(0, Ui.dp(this, 52.0f), 1.0f));
-        this.useButton = Ui.button(this, i > 0 ? "Use reset" : "No reset available", true, this.dark);
-        this.useButton.setEnabled(i > 0 && SecureTokenStore.isSignedIn(this));
-        LinearLayout.LayoutParams layoutParams5 = new LinearLayout.LayoutParams(0, Ui.dp(this, 52.0f), 1.0f);
-        layoutParams5.setMargins(Ui.dp(this, 10.0f), 0, 0, 0);
-        linearLayoutHorizontal2.addView(this.useButton, layoutParams5);
-        this.useButton.setOnClickListener(new View.OnClickListener() { // from class: dev.bennett.codexmeter.ResetCreditActivity.3
-            @Override // android.view.View.OnClickListener
-            public void onClick(View view) {
-                ResetCreditActivity.this.confirmUse();
-            }
-        });
-        linearLayoutCard.addView(linearLayoutHorizontal2);
-        this.content.addView(linearLayoutCard);
+        }
+        this.content.addView(listCard);
+    }
+
+    private LinearLayout buildCreditRow(RateLimitResetCredit credit, int ordinal, long now) {
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.VERTICAL);
+        String title = credit.title == null ? "" : credit.title.trim();
+        if (title.isEmpty()) {
+            title = "Reset credit " + ordinal;
+        }
+        TextView titleView = Ui.text(this, title, 16.0f, Ui.mainText(this.dark));
+        titleView.setTypeface(Ui.mediumTypeface(this));
+        row.addView(titleView);
+
+        String expiryText;
+        if (credit.expiresAtMillis > 0L) {
+            expiryText = "Expires " + UsageFormat.absolute(this, credit.expiresAtMillis, now)
+                    + " (" + UsageFormat.relative(credit.expiresAtMillis, now) + ")";
+        } else {
+            expiryText = "No expiration date available";
+        }
+        TextView expiryView = Ui.text(this, expiryText, 13.0f, Ui.secondaryText(this.dark));
+        LinearLayout.LayoutParams expiryParams = new LinearLayout.LayoutParams(-1, -2);
+        expiryParams.setMargins(0, Ui.dp(this, 4.0f), 0, 0);
+        row.addView(expiryView, expiryParams);
+
+        String description = credit.description == null ? "" : credit.description.trim();
+        if (!description.isEmpty()) {
+            TextView descriptionView = Ui.text(this, description, 12.0f, Ui.secondaryText(this.dark));
+            LinearLayout.LayoutParams descriptionParams = new LinearLayout.LayoutParams(-1, -2);
+            descriptionParams.setMargins(0, Ui.dp(this, 4.0f), 0, 0);
+            row.addView(descriptionView, descriptionParams);
+        }
+        return row;
     }
 
     private void refreshDetailsIfNeeded() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java
@@ -30,22 +30,31 @@ public final class ResetCreditsSnapshot {
     }
 
     public RateLimitResetCredit nextExpiringAvailable(long nowMillis) {
-        RateLimitResetCredit best = null;
+        List<RateLimitResetCredit> available = availableCreditsSortedByExpiry(nowMillis);
+        return available.isEmpty() ? null : available.get(0);
+    }
+
+    /**
+     * Available, unexpired credits ordered by soonest expiry first.
+     * Credits without an expiry timestamp sort last.
+     */
+    public List<RateLimitResetCredit> availableCreditsSortedByExpiry(long nowMillis) {
+        ArrayList<RateLimitResetCredit> available = new ArrayList<>();
         for (RateLimitResetCredit credit : credits) {
             if (credit == null || !credit.isAvailable()) continue;
             long expiry = credit.expiresAtMillis;
             if (expiry > 0L && expiry <= nowMillis) continue;
-            if (best == null) {
-                best = credit;
-                continue;
-            }
-            long bestExpiry = best.expiresAtMillis;
-            // Prefer the soonest positive expiry. Credits without an expiry sort last.
-            if (expiry > 0L && (bestExpiry <= 0L || expiry < bestExpiry)) {
-                best = credit;
-            }
+            available.add(credit);
         }
-        return best;
+        Collections.sort(available, (left, right) -> {
+            long leftExpiry = left.expiresAtMillis;
+            long rightExpiry = right.expiresAtMillis;
+            if (leftExpiry <= 0L && rightExpiry <= 0L) return 0;
+            if (leftExpiry <= 0L) return 1;
+            if (rightExpiry <= 0L) return -1;
+            return Long.compare(leftExpiry, rightExpiry);
+        });
+        return Collections.unmodifiableList(available);
     }
 
     public String preferredCreditId(long j) {

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -41,6 +41,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageParser.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/RateLimitResetCredit.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditExpiryReminder.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/Pkce.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/JwtClaims.java" \

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -20,6 +20,7 @@ public final class ParserSelfTest {
         testNextResetSelection();
         testCelebrationDetection();
         testResetCreditExpiryReminders();
+        testResetCreditsSortedByExpiry();
         testFullWindowHidesResetCountdown();
         testUsagePace();
         testNowBarAutoStart();
@@ -540,6 +541,30 @@ public final class ParserSelfTest {
                 "reminder identities are unique across credits and lead times");
         System.out.println("Reset-credit expiry demo: multiple custom lead times planned for "
                 + "every available credit.");
+    }
+
+    private static void testResetCreditsSortedByExpiry() {
+        long now = 2_000_000L;
+        RateLimitResetCredit later = new RateLimitResetCredit("later", "both", "available",
+                now - 1, now + TimeUnit.DAYS.toMillis(9), "Later", "");
+        RateLimitResetCredit soon = new RateLimitResetCredit("soon", "both", "available",
+                now - 1, now + TimeUnit.DAYS.toMillis(2), "Soon", "");
+        RateLimitResetCredit noExpiry = new RateLimitResetCredit("open", "both", "available",
+                now - 1, 0L, "Open", "");
+        RateLimitResetCredit redeemed = new RateLimitResetCredit("used", "both", "redeemed",
+                now - 1, now + TimeUnit.HOURS.toMillis(1), "Used", "");
+        RateLimitResetCredit expired = new RateLimitResetCredit("expired", "both", "available",
+                now - 1, now - 1, "Expired", "");
+        ResetCreditsSnapshot snapshot = new ResetCreditsSnapshot(3,
+                Arrays.asList(later, soon, noExpiry, redeemed, expired), now);
+        List<RateLimitResetCredit> sorted = snapshot.availableCreditsSortedByExpiry(now);
+        check(sorted.size() == 3, "only available unexpired credits are listed");
+        check("soon".equals(sorted.get(0).id), "soonest expiry is first");
+        check("later".equals(sorted.get(1).id), "later expiry follows soonest");
+        check("open".equals(sorted.get(2).id), "credits without expiry sort last");
+        check(snapshot.nextExpiryMillis(now) == soon.expiresAtMillis,
+                "next expiry matches the soonest available credit");
+        System.out.println("Reset-credit list demo: available credits ordered by soonest expiry.");
     }
 
     private static UsageSnapshot snapshot(int fiveHourUsed, int weeklyUsed,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Dashboard reset card now shows the soonest available credit expiry and a top-right chevron that opens the full credits screen.
- `ResetCreditActivity` lists every available reset credit with its expiration date (soonest first).
- Debug demo seeding includes two credits with different expiries; a lightweight screenshot helper exists for soft-GPU emulators.

## Test plan
- [x] `./run-tests.sh` (includes new sorted-expiry self-test)
- [x] Emulator install + ATD AVD boot (software accel; no host `/dev/kvm`)
- [x] Debug install via `UsagePaceDemoActivity`; MainActivity UI dump shows soonest expiry + chevron
- [x] Tap chevron → `ResetCreditActivity` lists both credits with expiration dates
- [x] In-app canvas screenshots of reset card + credits list captured under `/opt/cursor/artifacts/screenshots/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9052fe65-efb2-4997-b6e6-e3dbccb6285c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9052fe65-efb2-4997-b6e6-e3dbccb6285c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

