### PR TITLE
Add Off state for accelerated usage warnings

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -156,7 +156,7 @@ public final class NowBarManager {
     public static synchronized boolean maybeAutoStart(Context context, UsageSnapshot snapshot) {
         if (context == null || isActive(context) || isPreview(context)) return false;
         boolean lowEnabled = NowBarPreferences.isAutoStartEnabled(context);
-        boolean paceEnabled = UsagePacePreferences.isEnabled(context)
+        boolean paceEnabled = UsagePacePreferences.areWarningsEnabled(context)
                 && NowBarPreferences.isAcceleratedStartEnabled(context);
         if (!lowEnabled && !paceEnabled) return false;
         if (NowBarPreferences.isSuppressed(context)) return false;
@@ -662,7 +662,7 @@ public final class NowBarManager {
     }
 
     private static int acceleratedWindow(Context context, UsageSnapshot snapshot, long now) {
-        if (!UsagePacePreferences.isEnabled(context)
+        if (!UsagePacePreferences.areWarningsEnabled(context)
                 || !NowBarPreferences.isAcceleratedStartEnabled(context)) {
             return UsagePace.WINDOW_NONE;
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -262,8 +262,16 @@ public final class SettingsActivity extends AppCompatActivity {
             String refreshLabel = refreshMinutes < 60
                     ? refreshMinutes + " minutes"
                     : refreshMinutes == 60 ? "Hourly" : "Every " + (refreshMinutes / 60) + " hours";
-            findPreference("settings_refresh_usage").setSummary(refreshLabel + " · Estimates "
-                    + (UsagePacePreferences.isEnabled(requireContext()) ? "on" : "off"));
+            String estimatesSummary;
+            if (!UsagePacePreferences.isEnabled(requireContext())) {
+                estimatesSummary = "Estimates off";
+            } else if (!UsagePacePreferences.areWarningsEnabled(requireContext())) {
+                estimatesSummary = "Estimates on · Warnings off";
+            } else {
+                estimatesSummary = "Estimates on";
+            }
+            findPreference("settings_refresh_usage").setSummary(
+                    refreshLabel + " · " + estimatesSummary);
 
             findPreference("settings_notifications").setSummary(
                     ResetAlertPreferences.enabled(requireContext())
@@ -427,9 +435,7 @@ public final class SettingsActivity extends AppCompatActivity {
                 boolean isEnabled = (Boolean) value;
                 UsagePacePreferences.setEnabled(requireContext(), isEnabled);
                 usagePaceSensitivityPreference.setEnabled(isEnabled);
-                if (nowBarAcceleratedPreference != null) {
-                    nowBarAcceleratedPreference.setEnabled(isEnabled);
-                }
+                updateNowBarAcceleratedEnabledState();
                 NowBarManager.onPaceSettingsChanged(requireContext());
                 return true;
             });
@@ -437,6 +443,7 @@ public final class SettingsActivity extends AppCompatActivity {
                 String sensitivity = UsagePace.normalizeSensitivity(String.valueOf(value));
                 UsagePacePreferences.setSensitivity(requireContext(), sensitivity);
                 usagePaceSensitivityPreference.setValue(sensitivity);
+                updateNowBarAcceleratedEnabledState();
                 NowBarManager.onPaceSettingsChanged(requireContext());
                 return true;
             });
@@ -1041,6 +1048,12 @@ public final class SettingsActivity extends AppCompatActivity {
             if (nowBarThresholdPreference != null) nowBarThresholdPreference.setVisible(enabled);
         }
 
+        private void updateNowBarAcceleratedEnabledState() {
+            if (nowBarAcceleratedPreference == null || getContext() == null) return;
+            nowBarAcceleratedPreference.setEnabled(
+                    UsagePacePreferences.areWarningsEnabled(requireContext()));
+        }
+
         private boolean ensureNotificationPermission() {
             if (Build.VERSION.SDK_INT >= 33
                     && requireContext().checkSelfPermission("android.permission.POST_NOTIFICATIONS")
@@ -1076,7 +1089,7 @@ public final class SettingsActivity extends AppCompatActivity {
                         + UsageFormat.absolute(requireContext(), NowBarManager.activeUntil(requireContext()),
                         System.currentTimeMillis()));
             } else if (NowBarPreferences.isAutoStartEnabled(requireContext())
-                    || (UsagePacePreferences.isEnabled(requireContext())
+                    || (UsagePacePreferences.areWarningsEnabled(requireContext())
                     && NowBarPreferences.isAcceleratedStartEnabled(requireContext()))) {
                 nowBarMonitorPreference.setSummary(
                         "Waiting for a low allowance or accelerated usage trigger");
@@ -1091,8 +1104,7 @@ public final class SettingsActivity extends AppCompatActivity {
             if (nowBarAcceleratedPreference != null) {
                 nowBarAcceleratedPreference.setChecked(
                         NowBarPreferences.isAcceleratedStartEnabled(requireContext()));
-                nowBarAcceleratedPreference.setEnabled(
-                        UsagePacePreferences.isEnabled(requireContext()));
+                updateNowBarAcceleratedEnabledState();
             }
             if (nowBarDisplayModePreference != null) {
                 nowBarDisplayModePreference.setValue(

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsagePacePreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsagePacePreferences.java
@@ -34,6 +34,11 @@ public final class UsagePacePreferences {
                 UsagePace.normalizeSensitivity(sensitivity)).apply();
     }
 
+    /** Estimates may still show when this is false; only accelerated warnings are suppressed. */
+    public static boolean areWarningsEnabled(Context context) {
+        return isEnabled(context) && UsagePace.warningsEnabled(getSensitivity(context));
+    }
+
     public static UsagePace.Assessment assess(Context context, UsageSnapshot snapshot,
             UsageWindow window, long nowMillis) {
         if (!isEnabled(context) || snapshot == null) {

--- a/android/app/src/main/res/values/settings_arrays.xml
+++ b/android/app/src/main/res/values/settings_arrays.xml
@@ -46,11 +46,13 @@
         <item>100</item><item>10</item><item>25</item><item>50</item><item>75</item>
     </string-array>
     <string-array name="usage_pace_sensitivity_entries">
+        <item>Off</item>
         <item>Sensitive</item>
         <item>Balanced</item>
         <item>Relaxed</item>
     </string-array>
     <string-array name="usage_pace_sensitivity_values">
+        <item>off</item>
         <item>sensitive</item>
         <item>balanced</item>
         <item>relaxed</item>

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -397,6 +397,12 @@ grep -q 'usage_pace_enabled_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
 grep -q 'usage_pace_sensitivity_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
+grep -q '<item>off</item>' \
+  "$ROOT/app/src/main/res/values/settings_arrays.xml"
+grep -q 'public static final String OFF = "off"' \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java"
+grep -q 'areWarningsEnabled' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsagePacePreferences.java"
 grep -q 'now_bar_accelerated_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings_now_bar.xml"
 grep -q 'accelerated_enabled' \

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
  * remain part of the average instead of making a later burst look permanently representative.
  */
 public final class UsagePace {
+    public static final String OFF = "off";
     public static final String SENSITIVE = "sensitive";
     public static final String BALANCED = "balanced";
     public static final String RELAXED = "relaxed";
@@ -37,7 +38,8 @@ public final class UsagePace {
             return Assessment.unavailable();
         }
 
-        Policy policy = policy(sensitivity, windowMillis);
+        String normalized = normalizeSensitivity(sensitivity);
+        Policy policy = policy(normalized, windowMillis);
         if (elapsedMillis < policy.minimumElapsedMillis
                 || window.usedPercent < policy.minimumUsedPercent) {
             return Assessment.unavailable();
@@ -49,7 +51,8 @@ public final class UsagePace {
         long estimatedExhaustionAtMillis = safeAdd(observedAtMillis,
                 estimatedRemainingAtObservation);
         long actualRemainingAtObservation = resetAtMillis - observedAtMillis;
-        boolean accelerated = safeMultiply(estimatedRemainingAtObservation, 100L)
+        boolean accelerated = warningsEnabled(normalized)
+                && safeMultiply(estimatedRemainingAtObservation, 100L)
                 <= safeMultiply(actualRemainingAtObservation, policy.maximumCoveragePercent);
         long estimatedRemainingNow = Math.max(0L, estimatedExhaustionAtMillis - nowMillis);
         long actualRemainingNow = Math.max(0L, resetAtMillis - nowMillis);
@@ -60,7 +63,7 @@ public final class UsagePace {
 
     public static int mostAcceleratedWindow(UsageSnapshot snapshot, long nowMillis,
             String sensitivity) {
-        if (snapshot == null) return WINDOW_NONE;
+        if (snapshot == null || !warningsEnabled(sensitivity)) return WINDOW_NONE;
         Assessment fiveHour = assess(snapshot.fiveHour, snapshot.fetchedAtMillis, nowMillis,
                 sensitivity);
         Assessment weekly = assess(snapshot.weekly, snapshot.fetchedAtMillis, nowMillis,
@@ -73,10 +76,16 @@ public final class UsagePace {
     }
 
     public static String normalizeSensitivity(String sensitivity) {
-        if (SENSITIVE.equals(sensitivity) || RELAXED.equals(sensitivity)) {
+        if (OFF.equals(sensitivity) || SENSITIVE.equals(sensitivity)
+                || RELAXED.equals(sensitivity)) {
             return sensitivity;
         }
         return BALANCED;
+    }
+
+    /** Whether accelerated-usage warnings (and their Now Bar triggers) may fire. */
+    public static boolean warningsEnabled(String sensitivity) {
+        return !OFF.equals(normalizeSensitivity(sensitivity));
     }
 
     private static Policy policy(String sensitivity, long windowMillis) {
@@ -87,6 +96,8 @@ public final class UsagePace {
             case RELAXED:
                 return new Policy(10, Math.max(TimeUnit.MINUTES.toMillis(10),
                         windowMillis / 100L), 50);
+            case OFF:
+                // Keep balanced sample gates so estimates still appear without warnings.
             default:
                 return new Policy(5, Math.max(TimeUnit.MINUTES.toMillis(5),
                         windowMillis / 200L), 75);

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -98,6 +98,12 @@ public final class ParserSelfTest {
                 "balanced policy warns at 75 percent projected coverage");
         check(!UsagePace.assess(borderline, now, now, UsagePace.RELAXED).accelerated,
                 "relaxed policy requires a more severe shortfall");
+        UsagePace.Assessment offWarning = UsagePace.assess(
+                fastWeekly, now, now, UsagePace.OFF);
+        check(offWarning.available && !offWarning.accelerated,
+                "off sensitivity keeps estimates without accelerated warnings");
+        check(!UsagePace.warningsEnabled(UsagePace.OFF),
+                "off sensitivity disables warning triggers");
 
         UsageWindow tinySample = new UsageWindow(4, TimeUnit.DAYS.toSeconds(7), 0L,
                 (now - hour + week) / 1000L);
@@ -111,8 +117,13 @@ public final class ParserSelfTest {
         check(UsagePace.mostAcceleratedWindow(both, now, UsagePace.BALANCED)
                         == UsagePace.WINDOW_WEEKLY,
                 "accelerated window selection identifies weekly quota");
+        check(UsagePace.mostAcceleratedWindow(both, now, UsagePace.OFF)
+                        == UsagePace.WINDOW_NONE,
+                "off sensitivity never selects an accelerated window");
         check(UsagePace.BALANCED.equals(UsagePace.normalizeSensitivity("invalid")),
                 "invalid sensitivity falls back to balanced");
+        check(UsagePace.OFF.equals(UsagePace.normalizeSensitivity(UsagePace.OFF)),
+                "off sensitivity is preserved");
         check(!UsagePace.assess(fastWeekly, now, fast.resetAtMillis, UsagePace.BALANCED).available,
                 "expired windows do not produce stale warnings");
         System.out.println("Usage-pace demo: 15% of a week in one hour projects about 6h 40m.");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds an **Off** option to Warning sensitivity under Settings → Refresh & usage so users can keep estimated usage-time projections without orange accelerated-usage warnings or matching Now Bar auto-start triggers.

## Context
- Settings redesign (#54) already landed on `main`; this change targets the paged Refresh & usage / Now Bar screens from that redesign.
- Estimated usage time remains its own toggle; Off only suppresses warnings.

## Behavior
- Warning sensitivity: Off / Sensitive / Balanced / Relaxed
- Off keeps pace estimates available, forces `accelerated=false`, and blocks accelerated Now Bar starts
- Now Bar “Start for accelerated usage” is disabled when warnings are Off
- Root Refresh & usage summary shows `Estimates on · Warnings off` when applicable

## Verification
- `./run-tests.sh` passed (usage-pace Off cases + source checks)
- `./build.sh` passed (phone + Wear release APKs)
- `./lint.sh` passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7b94-4b54-7451-b3db-8510d0b81864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7b94-4b54-7451-b3db-8510d0b81864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

