### PR TITLE
Prepare Codex Meter 2.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.4.2 — 2026-07-19
+
+### Added
+
+- Off option for accelerated-usage warning sensitivity so pace estimates can stay on without orange warnings or matching Now Bar auto-start triggers (#57).
+- Reset-credit expiration details on the dashboard and inventory, with soonest-expiring credit selection when redeeming (#56).
+
+### Changed
+
+- Android Settings now uses a compact hub with focused destinations for appearance, refresh and usage, notifications, Now Bar, updates, transfer, and privacy, revealing nested options only when their parent feature is enabled (#54).
+
+### Fixed
+
+- Onboarding card spacing and Settings bottom padding no longer collapse against adjacent cards or the screen edge (#52).
+
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.4.1...v2.4.2 <!-- pragma: allowlist secret -->
+
 ## 2.4.1 — 2026-07-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
 
-## Android — Version 2.4.1
+## Android — Version 2.4.2
 
-Version 2.4.1 restores reliable Live Update rendering across Android 16 variants and rebuilds an active monitor immediately after promoted-notification access changes, instead of leaving it on a previous fallback or unpromoted contract.
+Version 2.4.2 redesigns Android Settings into a compact hub with focused destinations, surfaces reset-credit expiration details, adds an Off warning-sensitivity option for pace estimates, and restores onboarding/settings spacing.
 
 ### Live countdowns
 
@@ -93,7 +93,7 @@ xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.4.1`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
+Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.4.2`) runs the full CI pipeline and publishes the signed APK plus its SHA-256 checksum to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
 
 ## Platform stability
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 18
-        versionName = "2.4.1"
+        versionCode = 19
+        versionName = "2.4.2"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 18;
-    public static final String VERSION_NAME = "2.4.1";
+    public static final int VERSION_CODE = 19;
+    public static final String VERSION_NAME = "2.4.2";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.4.1 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.4.2 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.4.1"
+VERSION_NAME="2.4.2"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -62,14 +62,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.4.1"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 18' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.4.1"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 18' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.4.1"' "$ROOT/wear/build.gradle.kts"
-grep -q 'versionCode = 18' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.4.1' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.4.1"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.4.2"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 19' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.4.2"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 19' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.4.2"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionCode = 19' "$ROOT/wear/build.gradle.kts"
+grep -q 'codex-meter-android/2.4.2' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.4.2"' "$ROOT/build.sh"
 grep -q 'BenItBuhner/Codex-Meter/releases?per_page=30' "$ROOT/app/build.gradle.kts" # pragma: allowlist secret
 ! grep -R -q 'thatjoshguy67/Codex-Meter' \
   "$ROOT/app/src" "$ROOT/app/build.gradle.kts"

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 18
-        versionName = "2.4.1"
+        versionCode = 19
+        versionName = "2.4.2"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump Android phone + Wear to version code **19** / **2.4.2** across Gradle, `AppConstants`, `build.sh`, and release self-checks.
- Document post-`v2.4.1` changes from merged PRs **#52**, **#54**, **#56**, and **#57** in `CHANGELOG.md` and refresh the README version blurb.

### Included since v2.4.1
- **#57** — Off warning sensitivity for accelerated usage
- **#56** — Reset credit expiration details
- **#54** — Redesigned Android settings navigation
- **#52** — Onboarding card gaps and settings bottom padding

After merge, create/push the `v2.4.2` tag so CI publishes the signed release artifacts.

## Test plan
- [x] Confirm version touchpoints are consistent (`AppConstants`, app/wear Gradle, `build.sh`, `run-tests.sh`)
- [x] `./run-tests.sh`
- [ ] Tag `v2.4.2` after merge (agent will push/create release once this lands)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7b9e-c4cc-73c2-b3a3-7a6cb9836ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7b9e-c4cc-73c2-b3a3-7a6cb9836ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

