### PR TITLE
Show Now Bar reset countdown at 0% remaining

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -433,8 +433,13 @@ public final class NowBarManager {
         int remaining = progressWindow == null ? 0 : progressWindow.remainingPercent();
         int used = progressWindow == null ? 0 : progressWindow.usedPercent;
         boolean weeklyFocus = NowBarPercentMode.isWeeklyFocus(focus);
-        String fiveHourText = limitText("5-hour", fiveHour);
-        String weeklyText = limitText("Weekly", weekly);
+        // Preview snapshots invent their own windows without a remote observation time;
+        // live monitors must use fetchedAt so reset_after_seconds stays anchored.
+        long observedAt = preview || snapshot == null ? now : snapshot.fetchedAtMillis;
+        String fiveHourText = NowBarCopy.limitText("5-hour", fiveHour, observedAt, now);
+        String weeklyText = NowBarCopy.limitText("Weekly", weekly, observedAt, now);
+        String focusCritical = NowBarCopy.focusCriticalText(
+                weeklyFocus, progressWindow, observedAt, now);
         String title = "Codex usage";
         String estimate = UsageFormat.estimatedRemaining(pace);
         String text = fiveHourText + " · " + weeklyText
@@ -473,16 +478,15 @@ public final class NowBarManager {
                     refreshActionIcon, "Refresh", refreshIntent).build());
         }
         if (NowBarDisplayMode.SAMSUNG_COMPATIBILITY.equals(displayMode)) {
-            applySamsungCompatibility(context, builder, fiveHour, weekly, used, remaining,
-                    weeklyFocus, until, now, preview, accelerated, estimate);
+            applySamsungCompatibility(context, builder, fiveHour, weekly, used,
+                    progressWindow, weeklyFocus, until, now, observedAt, preview,
+                    accelerated, estimate);
         } else {
             Bundle promotionExtras = new Bundle();
             promotionExtras.putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true);
             builder.addExtras(promotionExtras);
             if (Build.VERSION.SDK_INT >= 36) {
-                String criticalPrefix = weeklyFocus ? "W " : "";
-                Api36.applyLiveUpdateStyle(context, builder, used,
-                        criticalPrefix + remaining + "%", accelerated);
+                Api36.applyLiveUpdateStyle(context, builder, used, focusCritical, accelerated);
             }
         }
         Notification builtNotification;
@@ -512,7 +516,8 @@ public final class NowBarManager {
         Log.i(TAG, "Posting live monitor: mode=" + displayMode + " promotable=" + promotable
                 + " allowed=" + canPostPromotedNotifications(context)
                 + " legacyColorizedFallback=" + legacyColorizedFallback
-                + " preview=" + preview + " remaining=" + remaining);
+                + " preview=" + preview + " remaining=" + remaining
+                + " focusCritical=" + focusCritical);
         try {
             manager.notify(NOTIFICATION_ID, notification);
             state(context).edit()
@@ -543,12 +548,11 @@ public final class NowBarManager {
     }
 
     private static void applySamsungCompatibility(Context context, Notification.Builder builder,
-            UsageWindow fiveHour, UsageWindow weekly, int used, int focusRemaining,
-            boolean weeklyFocus, long until, long now, boolean preview, boolean accelerated,
-            String estimate) {
-        String fiveHourText = limitText("5-hour", fiveHour);
-        String weeklyText = limitText("Weekly", weekly);
-        String focusLabel = weeklyFocus ? "Weekly " : "5-hour ";
+            UsageWindow fiveHour, UsageWindow weekly, int used, UsageWindow progressWindow,
+            boolean weeklyFocus, long until, long now, long observedAt, boolean preview,
+            boolean accelerated, String estimate) {
+        String fiveHourText = NowBarCopy.limitText("5-hour", fiveHour, observedAt, now);
+        String weeklyText = NowBarCopy.limitText("Weekly", weekly, observedAt, now);
         String availableWindows = fiveHour != null && weekly != null
                 ? "Both usage windows"
                 : fiveHour != null ? "5-hour window"
@@ -565,7 +569,7 @@ public final class NowBarManager {
         extras.putInt(SAMSUNG_ONGOING_PREFIX + "chipBgColor",
                 accelerated ? Ui.warning(false) : Color.rgb(3, 129, 254));
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "chipExpandedText",
-                "Codex · " + focusLabel + focusRemaining + "%");
+                NowBarCopy.chipExpandedText(weeklyFocus, progressWindow, observedAt, now));
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "primaryInfo",
                 fiveHourText + " · " + weeklyText);
         extras.putCharSequence(SAMSUNG_ONGOING_PREFIX + "secondaryInfo",
@@ -587,11 +591,6 @@ public final class NowBarManager {
                 .setUsesChronometer(true)
                 .setChronometerCountDown(true)
                 .setTimeoutAfter(Math.max(1L, until - now));
-    }
-
-    private static String limitText(String label, UsageWindow window) {
-        return label + ": " + (window == null ? "unavailable"
-                : window.remainingPercent() + "% left");
     }
 
     /**

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -32,6 +32,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarCopy.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/wear/WearSyncPaths.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/wear/WearSettingsState.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/wear/WearUsageState.java" \
@@ -216,6 +217,20 @@ test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarPreferences.java"
 test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java"
 test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java"
 test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java"
+test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarCopy.java"
+grep -q 'NowBarCopy.focusCriticalText' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'NowBarCopy.limitText' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'NowBarCopy.chipExpandedText' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
+grep -q 'NowBarCopy.focusCriticalText' \
+  "$ROOT/wear/src/main/java/dev/bennett/codexmeter/WearOngoingMonitor.java"
+grep -q 'NowBarCopy.wearLimitText' \
+  "$ROOT/wear/src/main/java/dev/bennett/codexmeter/WearOngoingMonitor.java"
+grep -q 'testNowBarCopy' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'exhausted five-hour focus shows hours until natural reset' \
+  "$ROOT/tests/ParserSelfTest.java"
 grep -q 'Build.VERSION.SDK_INT >= 36' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java"
 grep -q 'codex_live_monitor_v2' \

--- a/android/shared/src/main/java/dev/bennett/codexmeter/NowBarCopy.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/NowBarCopy.java
@@ -1,0 +1,118 @@
+package dev.bennett.codexmeter;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Glanceable Now Bar / Live Update copy. When a usage window is fully exhausted
+ * (0% remaining), percentage text is replaced with how long until that window's
+ * natural reset, using days and/or hours (and minutes under an hour).
+ */
+public final class NowBarCopy {
+    private NowBarCopy() {
+    }
+
+    /**
+     * Compact critical / chip percentage for the focused window. Exhausted windows
+     * show a compact reset countdown instead of {@code 0%}.
+     */
+    public static String focusCriticalText(boolean weeklyFocus, UsageWindow window,
+            long observedAtMillis, long nowMillis) {
+        String prefix = weeklyFocus ? "W " : "";
+        if (window == null) {
+            return prefix + "—";
+        }
+        int remaining = window.remainingPercent();
+        if (remaining > 0) {
+            return prefix + remaining + "%";
+        }
+        String duration = resetDurationText(window, observedAtMillis, nowMillis);
+        return duration == null ? prefix + "0%" : prefix + duration;
+    }
+
+    /**
+     * Samsung expanded-chip label: {@code Codex · 5-hour 12%} or, when exhausted,
+     * {@code Codex · Weekly 2d 4h}.
+     */
+    public static String chipExpandedText(boolean weeklyFocus, UsageWindow window,
+            long observedAtMillis, long nowMillis) {
+        String focusLabel = weeklyFocus ? "Weekly " : "5-hour ";
+        if (window == null) {
+            return "Codex · " + focusLabel + "unavailable";
+        }
+        int remaining = window.remainingPercent();
+        if (remaining > 0) {
+            return "Codex · " + focusLabel + remaining + "%";
+        }
+        String duration = resetDurationText(window, observedAtMillis, nowMillis);
+        return duration == null
+                ? "Codex · " + focusLabel + "0%"
+                : "Codex · " + focusLabel + duration;
+    }
+
+    /**
+     * Notification body line for one window: {@code 5-hour: 12% left} or, when
+     * exhausted, {@code Weekly: resets in 2d 4h}.
+     */
+    public static String limitText(String label, UsageWindow window, long observedAtMillis,
+            long nowMillis) {
+        if (window == null) {
+            return label + ": unavailable";
+        }
+        int remaining = window.remainingPercent();
+        if (remaining > 0) {
+            return label + ": " + remaining + "% left";
+        }
+        String duration = resetDurationText(window, observedAtMillis, nowMillis);
+        return duration == null
+                ? label + ": 0% left"
+                : label + ": resets in " + duration;
+    }
+
+    /**
+     * Compact Wear body fragment: {@code 5h 12%} or {@code Week resets 2d 4h}.
+     */
+    public static String wearLimitText(String label, UsageWindow window, long observedAtMillis,
+            long nowMillis) {
+        if (window == null) {
+            return label + " --";
+        }
+        int remaining = window.remainingPercent();
+        if (remaining > 0) {
+            return label + " " + remaining + "%";
+        }
+        String duration = resetDurationText(window, observedAtMillis, nowMillis);
+        return duration == null
+                ? label + " 0%"
+                : label + " resets " + duration;
+    }
+
+    /**
+     * Days and/or hours until {@code window}'s natural reset. Returns null when the
+     * reset time is unknown or not in the future.
+     */
+    public static String resetDurationText(UsageWindow window, long observedAtMillis,
+            long nowMillis) {
+        if (window == null) return null;
+        long resetAt = window.effectiveResetAtMillis(observedAtMillis);
+        if (resetAt <= nowMillis) return null;
+        return compactDuration(resetAt - nowMillis);
+    }
+
+    /**
+     * Compact remaining duration: {@code 2d 4h}, {@code 2d}, {@code 4h 20m}, {@code 4h},
+     * or {@code 12m}. Prefer days and/or hours when those units are needed.
+     */
+    public static String compactDuration(long durationMillis) {
+        long minutes = Math.max(1L, TimeUnit.MILLISECONDS.toMinutes(Math.max(0L, durationMillis)));
+        long days = minutes / TimeUnit.DAYS.toMinutes(1);
+        long hours = (minutes % TimeUnit.DAYS.toMinutes(1)) / TimeUnit.HOURS.toMinutes(1);
+        long remainingMinutes = minutes % TimeUnit.HOURS.toMinutes(1);
+        if (days > 0L) {
+            return hours > 0L ? days + "d " + hours + "h" : days + "d";
+        }
+        if (hours > 0L) {
+            return remainingMinutes > 0L ? hours + "h " + remainingMinutes + "m" : hours + "h";
+        }
+        return minutes + "m";
+    }
+}

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -29,6 +29,7 @@ public final class ParserSelfTest {
         testWearSettingsState();
         testWearGlanceFormat();
         testNowBarPercentModes();
+        testNowBarCopy();
         testJwtMerge();
         testPkce();
         testWidgetOptions();
@@ -368,6 +369,68 @@ public final class ParserSelfTest {
                         NowBarPercentMode.focusForSettingsChange("auto", mid, low, null)),
                 "settings change to AUTO without trigger picks lower remaining");
         System.out.println("Now Bar percent mode selects auto-trigger, weekly, or five-hour focus.");
+    }
+
+    private static void testNowBarCopy() {
+        long now = 1_700_000_000_000L;
+        long observed = now - TimeUnit.MINUTES.toMillis(5);
+        UsageWindow remaining = new UsageWindow(40, 18_000L, 3_600L,
+                (now + TimeUnit.HOURS.toMillis(1)) / 1000L);
+        UsageWindow exhaustedHours = new UsageWindow(100, 18_000L, 0L,
+                (now + TimeUnit.HOURS.toMillis(3) + TimeUnit.MINUTES.toMillis(20)) / 1000L);
+        UsageWindow exhaustedDays = new UsageWindow(100, 604_800L, 0L,
+                (now + TimeUnit.DAYS.toMillis(2) + TimeUnit.HOURS.toMillis(4)) / 1000L);
+        UsageWindow exhaustedNoReset = new UsageWindow(100, 18_000L, 0L, 0L);
+
+        check("60%".equals(NowBarCopy.focusCriticalText(false, remaining, observed, now)),
+                "focus critical keeps percentage while allowance remains");
+        check("W 60%".equals(NowBarCopy.focusCriticalText(true, remaining, observed, now)),
+                "weekly focus critical keeps W prefix while allowance remains");
+        check("3h 20m".equals(NowBarCopy.focusCriticalText(false, exhaustedHours, observed, now)),
+                "exhausted five-hour focus shows hours until natural reset");
+        check("W 2d 4h".equals(NowBarCopy.focusCriticalText(true, exhaustedDays, observed, now)),
+                "exhausted weekly focus shows days and hours until natural reset");
+        check("0%".equals(NowBarCopy.focusCriticalText(false, exhaustedNoReset, observed, now)),
+                "exhausted window without reset time falls back to 0%");
+
+        check("Codex · 5-hour 60%".equals(
+                        NowBarCopy.chipExpandedText(false, remaining, observed, now)),
+                "chip keeps percentage while allowance remains");
+        check("Codex · Weekly 2d 4h".equals(
+                        NowBarCopy.chipExpandedText(true, exhaustedDays, observed, now)),
+                "exhausted chip shows that window's reset duration");
+
+        check("5-hour: 60% left".equals(
+                        NowBarCopy.limitText("5-hour", remaining, observed, now)),
+                "limit text keeps remaining percentage");
+        check("Weekly: resets in 2d 4h".equals(
+                        NowBarCopy.limitText("Weekly", exhaustedDays, observed, now)),
+                "exhausted weekly limit text announces resets in days/hours");
+        check("5-hour: resets in 3h 20m".equals(
+                        NowBarCopy.limitText("5-hour", exhaustedHours, observed, now)),
+                "exhausted five-hour limit text announces resets in hours/minutes");
+        check("5-hour: unavailable".equals(
+                        NowBarCopy.limitText("5-hour", null, observed, now)),
+                "missing window stays unavailable");
+
+        check("5h 60%".equals(NowBarCopy.wearLimitText("5h", remaining, observed, now)),
+                "Wear limit text keeps remaining percentage");
+        check("Week resets 2d 4h".equals(
+                        NowBarCopy.wearLimitText("Week", exhaustedDays, observed, now)),
+                "Wear exhausted weekly text uses compact reset duration");
+        check("2d 4h".equals(NowBarCopy.compactDuration(
+                        TimeUnit.DAYS.toMillis(2) + TimeUnit.HOURS.toMillis(4))),
+                "compact duration prefers days and hours");
+        check("2d".equals(NowBarCopy.compactDuration(TimeUnit.DAYS.toMillis(2))),
+                "compact duration omits zero hours for whole days");
+        check("4h".equals(NowBarCopy.compactDuration(TimeUnit.HOURS.toMillis(4))),
+                "compact duration omits zero minutes for whole hours");
+        check("3h 20m".equals(NowBarCopy.compactDuration(
+                        TimeUnit.HOURS.toMillis(3) + TimeUnit.MINUTES.toMillis(20))),
+                "compact duration keeps leftover minutes under a day");
+        check("12m".equals(NowBarCopy.compactDuration(TimeUnit.MINUTES.toMillis(12))),
+                "compact duration uses minutes under one hour");
+        System.out.println("Now Bar exhausted windows swap percentage copy for reset duration.");
     }
 
     private static void testStandardUsage() throws Exception {

--- a/android/wear/src/main/java/dev/bennett/codexmeter/WearOngoingMonitor.java
+++ b/android/wear/src/main/java/dev/bennett/codexmeter/WearOngoingMonitor.java
@@ -147,10 +147,12 @@ public final class WearOngoingMonitor {
                 null);
         UsageWindow progressWindow = NowBarPercentMode.selectWindow(focus, fiveHour, weekly);
         int used = progressWindow == null ? 0 : progressWindow.usedPercent;
-        int remaining = progressWindow == null ? 0 : progressWindow.remainingPercent();
         boolean weeklyFocus = NowBarPercentMode.isWeeklyFocus(focus);
-        String criticalText = (weeklyFocus ? "W " : "") + remaining + "%";
-        String contentText = limitText("5h", fiveHour) + " · " + limitText("Week", weekly);
+        long observedAt = snapshot.fetchedAtMillis;
+        String criticalText = NowBarCopy.focusCriticalText(
+                weeklyFocus, progressWindow, observedAt, now);
+        String contentText = NowBarCopy.wearLimitText("5h", fiveHour, observedAt, now)
+                + " · " + NowBarCopy.wearLimitText("Week", weekly, observedAt, now);
         PendingIntent contentIntent = PendingIntent.getActivity(context, REQUEST_CONTENT,
                 new Intent(context, WearMainActivity.class)
                         .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP),
@@ -221,10 +223,6 @@ public final class WearOngoingMonitor {
 
     private static long elapsedTimeZero(long untilWallMillis, long nowWallMillis) {
         return SystemClock.elapsedRealtime() + Math.max(1L, untilWallMillis - nowWallMillis);
-    }
-
-    private static String limitText(String label, UsageWindow window) {
-        return label + " " + (window == null ? "--" : window.remainingPercent() + "%");
     }
 
     private static void createChannel(NotificationManager manager) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
When a Now Bar / Live Update focused usage window hits **0% remaining**, the monitor now shows how long until that specific window resets naturally (days and/or hours), instead of a useless `0%` label.

## Changes
- Added shared `NowBarCopy` helpers for focus critical text, Samsung chip text, notification limit lines, and Wear compact lines.
- Wired phone `NowBarManager` (Android Live Update + Samsung compatibility) and Wear `WearOngoingMonitor` through those helpers.
- Uses each exhausted window’s own reset timestamp (not the earliest of both windows).
- Regression coverage in `ParserSelfTest` + `run-tests.sh` source checks.

## Examples
- Five-hour exhausted, 3h 20m left → critical `3h 20m`, body `5-hour: resets in 3h 20m`
- Weekly exhausted, 2d 4h left → critical `W 2d 4h`, chip `Codex · Weekly 2d 4h`
- Remaining &gt; 0% unchanged (`12%`, `12% left`, etc.)

## Testing
- `./run-tests.sh` (passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c03a547c-93c4-4771-83c5-afe094c05461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c03a547c-93c4-4771-83c5-afe094c05461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

