### PR TITLE
Add Codex usage tips screen

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -8,5 +8,9 @@
             android:name="dev.bennett.codexmeter.UsagePaceDemoActivity"
             android:exported="true"
             android:theme="@style/AppTheme" />
+        <activity
+            android:name="dev.bennett.codexmeter.TipsDemoActivity"
+            android:exported="true"
+            android:theme="@style/AppTheme" />
     </application>
 </manifest>

--- a/android/app/src/debug/java/dev/bennett/codexmeter/TipsDemoActivity.java
+++ b/android/app/src/debug/java/dev/bennett/codexmeter/TipsDemoActivity.java
@@ -1,0 +1,16 @@
+package dev.bennett.codexmeter;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+/** Debug-only entry point for emulator and screenshot verification of the tips screen. */
+public final class TipsDemoActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle state) {
+        super.onCreate(state);
+        startActivity(new Intent(this, TipsActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
+        finish();
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,9 @@
             android:name="dev.bennett.codexmeter.SettingsActivity"
             android:exported="false"/>
         <activity
+            android:name="dev.bennett.codexmeter.TipsActivity"
+            android:exported="false"/>
+        <activity
             android:name="dev.bennett.codexmeter.UpdateActivity"
             android:configChanges="orientation|screenSize"
             android:exported="false"/>

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -34,6 +34,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class MainActivity extends AppCompatActivity {
+    private static final int MENU_TIPS = 8100;
     private static final int MENU_SETTINGS = 8101;
     private String appliedTheme;
     private boolean appliedMaterialYou;
@@ -104,7 +105,10 @@ public final class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        menu.add(Menu.NONE, MENU_SETTINGS, 0, "Settings")
+        menu.add(Menu.NONE, MENU_TIPS, 0, getString(R.string.tips_menu))
+                .setIcon(R.drawable.ic_oui_info_outline)
+                .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        menu.add(Menu.NONE, MENU_SETTINGS, 1, "Settings")
                 .setIcon(R.drawable.ic_oui_settings_outline)
                 .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
         return true;
@@ -112,6 +116,10 @@ public final class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == MENU_TIPS) {
+            Ui.startSecondaryActivity(this, TipsActivity.class);
+            return true;
+        }
         if (item.getItemId() == MENU_SETTINGS) {
             Ui.startSecondaryActivity(this, SettingsActivity.class);
             return true;

--- a/android/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java
@@ -1,0 +1,192 @@
+package dev.bennett.codexmeter;
+
+import android.content.Intent;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.GradientDrawable;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import androidx.appcompat.app.AppCompatActivity;
+import dev.oneuiproject.oneui.widget.CardItemView;
+import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
+
+/** Practical, source-backed guidance for making included Codex usage last longer. */
+public final class TipsActivity extends AppCompatActivity {
+    private static final String OPENAI_PRICING_URL = "https://developers.openai.com/codex/pricing";
+    private static final String OPENAI_SPEED_URL = "https://developers.openai.com/codex/speed";
+    private static final String OPENAI_COMMANDS_URL =
+            "https://developers.openai.com/codex/cli/slash-commands";
+
+    private boolean dark;
+
+    @Override
+    protected void onCreate(Bundle bundle) {
+        Ui.applySelectedTheme(this);
+        super.onCreate(bundle);
+        dark = Ui.isDark(this);
+        LinearLayout content = Ui.installPage(this, getString(R.string.tips_title), true).content;
+        build(content);
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+
+    private void build(LinearLayout content) {
+        content.addView(buildHero());
+        content.addView(Ui.sectionTitle(this, "Make your allowance last", dark));
+
+        addTip(content, 1, "Use Standard speed",
+                "Fast mode is about 1.5× faster, but GPT-5.6 and GPT-5.5 use credits "
+                        + "at 2.5× the Standard rate; GPT-5.4 uses 2×. Keep it off unless "
+                        + "latency matters more than allowance.",
+                "/fast off", false);
+        addTip(content, 2, "Match power to the job",
+                "Use a smaller model for routine edits and reserve Sol, GPT-5.5, high, "
+                        + "xhigh, or Ultra-style workflows for work that truly needs deep "
+                        + "reasoning. Medium is a strong starting point for ordinary coding.",
+                "/model", false);
+        addTip(content, 3, "Keep context lean",
+                "Point Codex at only the relevant files, remove repeated instructions, and "
+                        + "disable MCP servers you do not need. Precise scope saves context and "
+                        + "usually reduces expensive rework.",
+                null, false);
+        addTip(content, 4, "Plan complex work first",
+                "For migrations and multi-step changes, define a testable finish line before "
+                        + "implementation. Plan mode can expose missing requirements early, when "
+                        + "they are cheaper to fix.",
+                "/plan", false);
+        addTip(content, 5, "Spend the last few percent on one goal",
+                "If Goal mode is available, start one useful, bounded task with clear checks. "
+                        + "OpenAI says an active turn may continue after you reach a limit, "
+                        + "subject to fair use. This helps finish work already underway; it does "
+                        + "not guarantee unlimited work or unlock another turn.",
+                "/goal", true);
+        addTip(content, 6, "Watch the trend, not one prompt",
+                "Model, reasoning, context, tools, retrieval, and caching all affect usage. "
+                        + "Check your five-hour and weekly pace, then adjust before a large task "
+                        + "instead of waiting until the allowance is gone.",
+                "/usage", false);
+
+        content.addView(Ui.sectionTitle(this, "Learn more", dark));
+        RoundedLinearLayout sources = Ui.cardGroup(this, dark);
+        sources.addView(sourceRow("OpenAI usage and pricing",
+                "Official limits, credit behavior, and efficiency guidance.",
+                R.drawable.ic_oui_battery, OPENAI_PRICING_URL, false));
+        sources.addView(sourceRow("Fast mode",
+                "Current speed and credit multipliers by model.",
+                R.drawable.ic_oui_time, OPENAI_SPEED_URL, true));
+        sources.addView(sourceRow("Codex commands",
+                "Official reference for /model, /fast, /plan, and /usage.",
+                R.drawable.ic_oui_info_outline, OPENAI_COMMANDS_URL, true));
+        content.addView(sources);
+
+        TextView note = Ui.text(this,
+                "Features, models, and limits can change. Check the linked OpenAI guidance "
+                        + "before relying on a specific multiplier or command.",
+                12, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(-1, -2);
+        noteParams.setMargins(Ui.dp(this, 12), Ui.dp(this, 14),
+                Ui.dp(this, 12), Ui.dp(this, 8));
+        content.addView(note, noteParams);
+    }
+
+    private LinearLayout buildHero() {
+        RoundedLinearLayout hero = new RoundedLinearLayout(this);
+        hero.setOrientation(LinearLayout.VERTICAL);
+        hero.setPadding(Ui.dp(this, 22), Ui.dp(this, 22),
+                Ui.dp(this, 22), Ui.dp(this, 22));
+        hero.setClipToOutline(true);
+        int accent = Ui.accent(this, dark);
+        hero.setBackground(shape(accent, Ui.dp(this, 28)));
+
+        TextView eyebrow = Ui.text(this, "CODEX FIELD GUIDE", 12, Ui.onAccent(this, dark));
+        eyebrow.setTypeface(Ui.mediumTypeface(this));
+        eyebrow.setLetterSpacing(0.08f);
+        hero.addView(eyebrow);
+
+        TextView title = Ui.text(this, "Do more with every limit", 26,
+                Ui.onAccent(this, dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(-1, -2);
+        titleParams.setMargins(0, Ui.dp(this, 8), 0, 0);
+        hero.addView(title, titleParams);
+
+        TextView summary = Ui.text(this,
+                "Six practical ways to preserve included usage without blindly trading away "
+                        + "quality.",
+                15, withAlpha(Ui.onAccent(this, dark), 220));
+        LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
+        summaryParams.setMargins(0, Ui.dp(this, 8), 0, 0);
+        hero.addView(summary, summaryParams);
+        return hero;
+    }
+
+    private void addTip(LinearLayout content, int number, String title, String body,
+            String command, boolean caution) {
+        LinearLayout card = Ui.card(this, dark);
+
+        LinearLayout heading = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
+        TextView badge = Ui.text(this, String.valueOf(number), 14,
+                caution ? Color.WHITE : Ui.onAccent(this, dark));
+        badge.setGravity(Gravity.CENTER);
+        badge.setTypeface(Ui.mediumTypeface(this));
+        badge.setBackground(shape(caution ? Ui.warning(dark) : Ui.accent(this, dark),
+                Ui.dp(this, 999)));
+        heading.addView(badge,
+                new LinearLayout.LayoutParams(Ui.dp(this, 32), Ui.dp(this, 32)));
+
+        TextView headingText = Ui.text(this, title, 18, Ui.mainText(dark));
+        headingText.setTypeface(Ui.mediumTypeface(this));
+        LinearLayout.LayoutParams headingParams = new LinearLayout.LayoutParams(0, -2, 1);
+        headingParams.setMargins(Ui.dp(this, 12), 0, 0, 0);
+        heading.addView(headingText, headingParams);
+        card.addView(heading);
+
+        TextView detail = Ui.text(this, body, 14, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(-1, -2);
+        detailParams.setMargins(0, Ui.dp(this, 12), 0, command == null ? 0 : Ui.dp(this, 14));
+        card.addView(detail, detailParams);
+
+        if (command != null) {
+            TextView commandView = Ui.text(this, command, 14, Ui.mainText(dark));
+            commandView.setTypeface(Typeface.MONOSPACE);
+            commandView.setGravity(Gravity.CENTER_VERTICAL);
+            commandView.setPadding(Ui.dp(this, 14), Ui.dp(this, 10),
+                    Ui.dp(this, 14), Ui.dp(this, 10));
+            commandView.setBackground(shape(Ui.controlSurface(this, dark), Ui.dp(this, 12)));
+            card.addView(commandView, new LinearLayout.LayoutParams(-1, -2));
+        }
+
+        LinearLayout.LayoutParams cardParams = new LinearLayout.LayoutParams(-1, -2);
+        cardParams.setMargins(0, 0, 0, Ui.dp(this, 12));
+        content.addView(card, cardParams);
+    }
+
+    private CardItemView sourceRow(String title, String summary, int icon, String url,
+            boolean divider) {
+        CardItemView row = Ui.actionRow(this, title, summary, icon, view -> openUrl(url));
+        row.setShowTopDivider(divider);
+        return row;
+    }
+
+    private void openUrl(String url) {
+        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+    }
+
+    private static GradientDrawable shape(int color, int radius) {
+        GradientDrawable background = new GradientDrawable();
+        background.setColor(color);
+        background.setCornerRadius(radius);
+        return background;
+    }
+
+    private static int withAlpha(int color, int alpha) {
+        return Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color));
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java
@@ -89,6 +89,8 @@ public final class TipsActivity extends AppCompatActivity {
     private CardItemView tipRow(String title, String summary, boolean divider) {
         CardItemView row = Ui.actionRow(this, title, summary, 0, null);
         row.setShowTopDivider(divider);
+        row.setClickable(false);
+        row.setFocusable(false);
         return row;
     }
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java
@@ -1,12 +1,8 @@
 package dev.bennett.codexmeter;
 
 import android.content.Intent;
-import android.graphics.Color;
-import android.graphics.Typeface;
-import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.view.Gravity;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
@@ -17,8 +13,6 @@ import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 public final class TipsActivity extends AppCompatActivity {
     private static final String OPENAI_PRICING_URL = "https://developers.openai.com/codex/pricing";
     private static final String OPENAI_SPEED_URL = "https://developers.openai.com/codex/speed";
-    private static final String OPENAI_COMMANDS_URL =
-            "https://developers.openai.com/codex/cli/slash-commands";
 
     private boolean dark;
 
@@ -38,42 +32,41 @@ public final class TipsActivity extends AppCompatActivity {
     }
 
     private void build(LinearLayout content) {
-        content.addView(buildHero());
-        content.addView(Ui.sectionTitle(this, "Make your allowance last", dark));
+        content.addView(Ui.sectionTitle(this, "Reduce consumption", dark));
+        RoundedLinearLayout usage = Ui.cardGroup(this, dark);
+        usage.addView(tipRow("Use Standard speed",
+                "Fast mode lowers latency but uses included credits faster. On supported "
+                        + "models, it currently costs 2×–2.5× the Standard rate.",
+                false));
+        usage.addView(tipRow("Lower the reasoning level",
+                "Use low or medium effort for straightforward work. Increase it only when the "
+                        + "task needs deeper analysis or the lower setting is not succeeding.",
+                true));
+        usage.addView(tipRow("Turn off Ultra when you do not need it",
+                "If your Codex client offers Ultra or another high-compute workflow, reserve it "
+                        + "for genuinely difficult work instead of leaving it enabled by default.",
+                true));
+        usage.addView(tipRow("Use a smaller model for routine work",
+                "Routine edits, searches, and boilerplate usually do not need the most capable "
+                        + "model. Switching down can make included usage last much longer.",
+                true));
+        usage.addView(tipRow("Remove unused context and integrations",
+                "Include only relevant files and instructions. Disable integrations and MCP "
+                        + "servers you are not using so they do not add unnecessary context.",
+                true));
+        content.addView(usage);
 
-        addTip(content, 1, "Use Standard speed",
-                "Fast mode is about 1.5× faster, but GPT-5.6 and GPT-5.5 use credits "
-                        + "at 2.5× the Standard rate; GPT-5.4 uses 2×. Keep it off unless "
-                        + "latency matters more than allowance.",
-                "/fast off", false);
-        addTip(content, 2, "Match power to the job",
-                "Use a smaller model for routine edits and reserve Sol, GPT-5.5, high, "
-                        + "xhigh, or Ultra-style workflows for work that truly needs deep "
-                        + "reasoning. Medium is a strong starting point for ordinary coding.",
-                "/model", false);
-        addTip(content, 3, "Keep context lean",
-                "Point Codex at only the relevant files, remove repeated instructions, and "
-                        + "disable MCP servers you do not need. Precise scope saves context and "
-                        + "usually reduces expensive rework.",
-                null, false);
-        addTip(content, 4, "Plan complex work first",
-                "For migrations and multi-step changes, define a testable finish line before "
-                        + "implementation. Plan mode can expose missing requirements early, when "
-                        + "they are cheaper to fix.",
-                "/plan", false);
-        addTip(content, 5, "Spend the last few percent on one goal",
-                "If Goal mode is available, start one useful, bounded task with clear checks. "
-                        + "OpenAI says an active turn may continue after you reach a limit, "
-                        + "subject to fair use. This helps finish work already underway; it does "
-                        + "not guarantee unlimited work or unlock another turn.",
-                "/goal", true);
-        addTip(content, 6, "Watch the trend, not one prompt",
-                "Model, reasoning, context, tools, retrieval, and caching all affect usage. "
-                        + "Check your five-hour and weekly pace, then adjust before a large task "
-                        + "instead of waiting until the allowance is gone.",
-                "/usage", false);
+        content.addView(Ui.sectionTitle(this, "Near your weekly limit", dark));
+        RoundedLinearLayout nearLimit = Ui.cardGroup(this, dark);
+        nearLimit.addView(tipRow("Use Goal mode where available",
+                "With only a small amount remaining, start one complex, well-scoped task with "
+                        + "clear completion checks. OpenAI may allow that active turn to continue "
+                        + "after the limit is reached, subject to fair use. This does not unlock "
+                        + "additional turns.",
+                false));
+        content.addView(nearLimit);
 
-        content.addView(Ui.sectionTitle(this, "Learn more", dark));
+        content.addView(Ui.sectionTitle(this, "Official guidance", dark));
         RoundedLinearLayout sources = Ui.cardGroup(this, dark);
         sources.addView(sourceRow("OpenAI usage and pricing",
                 "Official limits, credit behavior, and efficiency guidance.",
@@ -81,14 +74,11 @@ public final class TipsActivity extends AppCompatActivity {
         sources.addView(sourceRow("Fast mode",
                 "Current speed and credit multipliers by model.",
                 R.drawable.ic_oui_time, OPENAI_SPEED_URL, true));
-        sources.addView(sourceRow("Codex commands",
-                "Official reference for /model, /fast, /plan, and /usage.",
-                R.drawable.ic_oui_info_outline, OPENAI_COMMANDS_URL, true));
         content.addView(sources);
 
         TextView note = Ui.text(this,
-                "Features, models, and limits can change. Check the linked OpenAI guidance "
-                        + "before relying on a specific multiplier or command.",
+                "Based on OpenAI guidance available in July 2026. Features, models, and limits "
+                        + "can vary by client and may change.",
                 12, Ui.secondaryText(dark));
         LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(-1, -2);
         noteParams.setMargins(Ui.dp(this, 12), Ui.dp(this, 14),
@@ -96,76 +86,10 @@ public final class TipsActivity extends AppCompatActivity {
         content.addView(note, noteParams);
     }
 
-    private LinearLayout buildHero() {
-        RoundedLinearLayout hero = new RoundedLinearLayout(this);
-        hero.setOrientation(LinearLayout.VERTICAL);
-        hero.setPadding(Ui.dp(this, 22), Ui.dp(this, 22),
-                Ui.dp(this, 22), Ui.dp(this, 22));
-        hero.setClipToOutline(true);
-        int accent = Ui.accent(this, dark);
-        hero.setBackground(shape(accent, Ui.dp(this, 28)));
-
-        TextView eyebrow = Ui.text(this, "CODEX FIELD GUIDE", 12, Ui.onAccent(this, dark));
-        eyebrow.setTypeface(Ui.mediumTypeface(this));
-        eyebrow.setLetterSpacing(0.08f);
-        hero.addView(eyebrow);
-
-        TextView title = Ui.text(this, "Do more with every limit", 26,
-                Ui.onAccent(this, dark));
-        title.setTypeface(Ui.mediumTypeface(this));
-        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(-1, -2);
-        titleParams.setMargins(0, Ui.dp(this, 8), 0, 0);
-        hero.addView(title, titleParams);
-
-        TextView summary = Ui.text(this,
-                "Six practical ways to preserve included usage without blindly trading away "
-                        + "quality.",
-                15, withAlpha(Ui.onAccent(this, dark), 220));
-        LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
-        summaryParams.setMargins(0, Ui.dp(this, 8), 0, 0);
-        hero.addView(summary, summaryParams);
-        return hero;
-    }
-
-    private void addTip(LinearLayout content, int number, String title, String body,
-            String command, boolean caution) {
-        LinearLayout card = Ui.card(this, dark);
-
-        LinearLayout heading = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
-        TextView badge = Ui.text(this, String.valueOf(number), 14,
-                caution ? Color.WHITE : Ui.onAccent(this, dark));
-        badge.setGravity(Gravity.CENTER);
-        badge.setTypeface(Ui.mediumTypeface(this));
-        badge.setBackground(shape(caution ? Ui.warning(dark) : Ui.accent(this, dark),
-                Ui.dp(this, 999)));
-        heading.addView(badge,
-                new LinearLayout.LayoutParams(Ui.dp(this, 32), Ui.dp(this, 32)));
-
-        TextView headingText = Ui.text(this, title, 18, Ui.mainText(dark));
-        headingText.setTypeface(Ui.mediumTypeface(this));
-        LinearLayout.LayoutParams headingParams = new LinearLayout.LayoutParams(0, -2, 1);
-        headingParams.setMargins(Ui.dp(this, 12), 0, 0, 0);
-        heading.addView(headingText, headingParams);
-        card.addView(heading);
-
-        TextView detail = Ui.text(this, body, 14, Ui.secondaryText(dark));
-        LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(-1, -2);
-        detailParams.setMargins(0, Ui.dp(this, 12), 0, command == null ? 0 : Ui.dp(this, 14));
-        card.addView(detail, detailParams);
-
-        if (command != null) {
-            TextView commandView = Ui.text(this, command, 14, Ui.mainText(dark));
-            commandView.setTypeface(Typeface.MONOSPACE);
-            commandView.setGravity(Gravity.CENTER_VERTICAL);
-            commandView.setPadding(Ui.dp(this, 14), Ui.dp(this, 10),
-                    Ui.dp(this, 14), Ui.dp(this, 10));
-            commandView.setBackground(shape(Ui.controlSurface(this, dark), Ui.dp(this, 12)));
-            card.addView(commandView, new LinearLayout.LayoutParams(-1, -2));
-        }
-
-        LinearLayout.LayoutParams cardParams = new LinearLayout.LayoutParams(-1, -2);
-        cardParams.setMargins(0, 0, 0, Ui.dp(this, 12));
-        content.addView(card, cardParams);
+    private CardItemView tipRow(String title, String summary, boolean divider) {
+        CardItemView row = Ui.actionRow(this, title, summary, 0, null);
+        row.setShowTopDivider(divider);
+        return row;
     }
 
     private CardItemView sourceRow(String title, String summary, int icon, String url,
@@ -177,16 +101,5 @@ public final class TipsActivity extends AppCompatActivity {
 
     private void openUrl(String url) {
         startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
-    }
-
-    private static GradientDrawable shape(int color, int radius) {
-        GradientDrawable background = new GradientDrawable();
-        background.setColor(color);
-        background.setCornerRadius(radius);
-        return background;
-    }
-
-    private static int withAlpha(int color, int alpha) {
-        return Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color));
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -37,8 +37,8 @@
     <string name="oauth_channel_name">ChatGPT sign-in</string>
     <string name="refresh">Refresh</string>
     <string name="refreshing">Refreshing…</string>
-    <string name="tips_menu">Tips and tricks</string>
-    <string name="tips_title">Tips &amp; tricks</string>
+    <string name="tips_menu">Tips</string>
+    <string name="tips_title">Tips</string>
     <string name="update_downloading">Downloading checksum and APK…</string>
     <string name="update_opening_installer">Verified. Opening Android’s install confirmation…</string>
     <string name="update_waiting_for_installer">Waiting for Android’s install confirmation.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="oauth_channel_name">ChatGPT sign-in</string>
     <string name="refresh">Refresh</string>
     <string name="refreshing">Refreshing…</string>
+    <string name="tips_menu">Tips and tricks</string>
+    <string name="tips_title">Tips &amp; tricks</string>
     <string name="update_downloading">Downloading checksum and APK…</string>
     <string name="update_opening_installer">Verified. Opening Android’s install confirmation…</string>
     <string name="update_waiting_for_installer">Waiting for Android’s install confirmation.</string>

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -91,7 +91,7 @@ grep -q 'UpdateInstallReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ReleaseHistoryActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'TipsActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'MENU_TIPS' "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
-grep -q 'OpenAI says an active turn may continue' \
+grep -q 'This does not unlock' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java"
 grep -q 'https://developers.openai.com/codex/pricing' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -89,6 +89,12 @@ grep -q 'ReleaseUpdateJobService' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'WidgetRepairJobService' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'UpdateInstallReceiver' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'ReleaseHistoryActivity' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'TipsActivity' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'MENU_TIPS' "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'OpenAI says an active turn may continue' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java"
+grep -q 'https://developers.openai.com/codex/pricing' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/TipsActivity.java"
 grep -q 'ReleaseNotesMarkdown.toHtml' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesUi.java"
 grep -q 'ReleaseNotesUi.create' \

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -424,6 +424,7 @@ test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsagePacePreferences.java"
 test -f "$ROOT/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java"
 grep -q 'UsagePaceDemoActivity' "$ROOT/app/src/debug/AndroidManifest.xml"
+grep -q 'TipsDemoActivity' "$ROOT/app/src/debug/AndroidManifest.xml"
 grep -q 'usage_pace_enabled_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
 grep -q 'usage_pace_sensitivity_ui' \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a Tips action immediately left of Settings on the dashboard
- replace the custom hero, numbered badges, command chips, and separate cards with compact One UI grouped rows and native dividers
- limit guidance to concrete usage controls: Standard speed, reasoning effort, Ultra/high-compute workflows, model choice, context/integrations, and Goal mode near the weekly limit
- keep instructions client-neutral and mark Goal mode and Ultra as client-dependent
- link official OpenAI usage and speed guidance
- qualify active-turn continuation as fair-use-limited rather than unlimited usage
- ensure informational tip rows are not exposed as clickable controls

## Validation
- `./run-tests.sh` passes
- `./build.sh` passes for phone and Wear release APKs
- `./lint.sh` passes against the project baseline
- `:app:assembleDebug` passes after the final accessibility adjustment
- installed on an unaccelerated AOSP Android 11 emulator using SwiftShader
- opened Tips through the real dashboard Info action and verified scrolling/layout end to end

## Emulator captures
[Dashboard Tips action](https://cursor.com/agents/bc-73865a25-c777-4e55-952f-af6d6280c6c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcodex-meter-redesign-dashboard.png)
[Redesigned Tips top](https://cursor.com/agents/bc-73865a25-c777-4e55-952f-af6d6280c6c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcodex-meter-redesign-tips-top.png)
[Redesigned Tips grouped rows](https://cursor.com/agents/bc-73865a25-c777-4e55-952f-af6d6280c6c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcodex-meter-redesign-tips-more.png)
[Goal guidance and official sources](https://cursor.com/agents/bc-73865a25-c777-4e55-952f-af6d6280c6c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcodex-meter-redesign-tips-goal.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73865a25-c777-4e55-952f-af6d6280c6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73865a25-c777-4e55-952f-af6d6280c6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

