### PR TITLE
Add adaptive usage dashboard sections

### DIFF
--- a/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
+++ b/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
@@ -24,10 +24,22 @@ public final class UsagePaceDemoActivity extends Activity {
             long weeklyReset = now - TimeUnit.HOURS.toMillis(1)
                     + TimeUnit.DAYS.toMillis(7);
             UsageSnapshot snapshot = new UsageSnapshot("pro", true, false,
-                    new UsageWindow(15, TimeUnit.HOURS.toSeconds(5), 0L,
+                    new UsageWindow(37, TimeUnit.HOURS.toSeconds(5), 0L,
                             fiveHourReset / 1000L),
-                    new UsageWindow(15, TimeUnit.DAYS.toSeconds(7), 0L,
+                    new UsageWindow(61, TimeUnit.DAYS.toSeconds(7), 0L,
                             weeklyReset / 1000L),
+                    Arrays.asList(new UsageLimit(
+                            "codex-spark",
+                            "GPT-5.3-Codex-Spark",
+                            "codex_bengalfox",
+                            true,
+                            false,
+                            new UsageWindow(24, TimeUnit.HOURS.toSeconds(5), 0L,
+                                    (now + TimeUnit.HOURS.toMillis(3)) / 1000L),
+                            new UsageWindow(42, TimeUnit.DAYS.toSeconds(7), 0L,
+                                    (now + TimeUnit.DAYS.toMillis(5)) / 1000L))),
+                    new UsageCredits(true, false, "2500"),
+                    3,
                     now);
             SecureTokenStore.save(this, new AuthTokens(
                     "debug-demo-access", "debug-demo-refresh", "", Long.MAX_VALUE,
@@ -42,6 +54,7 @@ public final class UsagePaceDemoActivity extends Activity {
                             now + TimeUnit.DAYS.toMillis(7), "Reset credit 3", "")),
                     now));
             AppPreferences.setRefreshOnLaunch(this, false);
+            AppPreferences.setDashboardVisibility(this, true, true, true, true, true);
             AppPreferences.completeOnboarding(this);
             UsagePacePreferences.setEnabled(this, true);
             UsagePacePreferences.setSensitivity(this, UsagePace.BALANCED);

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -9,6 +9,11 @@ import org.json.JSONObject;
 public final class AppPreferences {
     private static final String KEY_APP_STYLE = "app_surface_style";
     private static final String KEY_APP_THEME = "app_theme";
+    private static final String KEY_DASHBOARD_ADDITIONAL_LIMITS = "dashboard_additional_limits";
+    private static final String KEY_DASHBOARD_FIVE_HOUR = "dashboard_five_hour";
+    private static final String KEY_DASHBOARD_RESET_CREDITS = "dashboard_reset_credits";
+    private static final String KEY_DASHBOARD_USAGE_CREDITS = "dashboard_usage_credits";
+    private static final String KEY_DASHBOARD_WEEKLY = "dashboard_weekly";
     private static final String KEY_MATERIAL_YOU = "material_you";
     private static final String KEY_ERROR = "last_error";
     private static final String KEY_ERROR_AT = "last_error_at";
@@ -201,6 +206,38 @@ public final class AppPreferences {
 
     public static void setRefreshOnLaunch(Context context, boolean enabled) {
         prefs(context).edit().putBoolean(KEY_REFRESH_ON_LAUNCH, enabled).apply();
+    }
+
+    public static boolean showDashboardFiveHour(Context context) {
+        return prefs(context).getBoolean(KEY_DASHBOARD_FIVE_HOUR, true);
+    }
+
+    public static boolean showDashboardWeekly(Context context) {
+        return prefs(context).getBoolean(KEY_DASHBOARD_WEEKLY, true);
+    }
+
+    public static boolean showDashboardAdditionalLimits(Context context) {
+        return prefs(context).getBoolean(KEY_DASHBOARD_ADDITIONAL_LIMITS, true);
+    }
+
+    public static boolean showDashboardUsageCredits(Context context) {
+        return prefs(context).getBoolean(KEY_DASHBOARD_USAGE_CREDITS, true);
+    }
+
+    public static boolean showDashboardResetCredits(Context context) {
+        return prefs(context).getBoolean(KEY_DASHBOARD_RESET_CREDITS, true);
+    }
+
+    public static void setDashboardVisibility(Context context, boolean fiveHour,
+            boolean weekly, boolean additionalLimits, boolean usageCredits,
+            boolean resetCredits) {
+        prefs(context).edit()
+                .putBoolean(KEY_DASHBOARD_FIVE_HOUR, fiveHour)
+                .putBoolean(KEY_DASHBOARD_WEEKLY, weekly)
+                .putBoolean(KEY_DASHBOARD_ADDITIONAL_LIMITS, additionalLimits)
+                .putBoolean(KEY_DASHBOARD_USAGE_CREDITS, usageCredits)
+                .putBoolean(KEY_DASHBOARD_RESET_CREDITS, resetCredits)
+                .apply();
     }
 
     private static boolean validRefresh(int i) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -27,6 +27,9 @@ import android.widget.ProgressBar;
 import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import androidx.appcompat.app.AppCompatActivity;
@@ -261,16 +264,34 @@ public final class MainActivity extends AppCompatActivity {
                 this.content.addView(buildUpdateCard(update));
                 Ui.addSpacer(this.content, 20);
             }
-            this.content.addView(buildUsageDashboard());
-            Ui.addSpacer(this.content, 20);
-            if (!SecureTokenStore.isSignedIn(this)) {
+            LinearLayout dashboard = buildUsageDashboard();
+            if (dashboard.getChildCount() > 0) {
+                this.content.addView(dashboard);
+                Ui.addSpacer(this.content, 20);
+            }
+            boolean signedIn = SecureTokenStore.isSignedIn(this);
+            if (!signedIn) {
                 Button signIn = Ui.nativePrimaryButton(this,
                         AppPreferences.isOAuthPending(this) ? "Continue sign-in" : "Sign in with ChatGPT");
                 signIn.setOnClickListener(view -> startOrContinueSignIn());
                 this.content.addView(signIn, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
                 Ui.addSpacer(this.content, 20);
             }
-            this.content.addView(buildResetCreditsCard());
+            UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
+            boolean showResetCredits = AppPreferences.showDashboardResetCredits(this)
+                    && signedIn
+                    && (AppPreferences.loadResetCredits(this) != null
+                    || (snapshot != null && snapshot.resetCreditsAvailable >= 0));
+            if (showResetCredits) {
+                this.content.addView(buildResetCreditsCard());
+            } else if (signedIn && dashboard.getChildCount() == 0) {
+                TextView empty = Ui.text(this,
+                        "No dashboard items are available. Refresh usage or choose items in "
+                                + "Settings → Refresh & usage.",
+                        14.0f, Ui.secondaryText(this.dark));
+                empty.setGravity(Gravity.CENTER);
+                this.content.addView(empty, new LinearLayout.LayoutParams(-1, -2));
+            }
         }
     }
 
@@ -306,32 +327,132 @@ public final class MainActivity extends AppCompatActivity {
         boolean signedIn = SecureTokenStore.isSignedIn(this);
         LinearLayout column = new LinearLayout(this);
         column.setOrientation(LinearLayout.VERTICAL);
-        column.addView(buildMetricCard("5 hour", snapshot,
-                signedIn && snapshot != null ? snapshot.fiveHour : null, signedIn, false));
-        Ui.addSpacer(column, 20);
-        column.addView(buildMetricCard("Weekly", snapshot,
-                signedIn && snapshot != null ? snapshot.weekly : null, signedIn, true));
+        if (!signedIn || snapshot == null) {
+            return column;
+        }
+        boolean inverted = false;
+        if (AppPreferences.showDashboardFiveHour(this) && snapshot.fiveHour != null) {
+            addDashboardCard(column, buildMetricCard(
+                    "5-hour", snapshot, snapshot.fiveHour, inverted));
+            inverted = !inverted;
+        }
+        if (AppPreferences.showDashboardWeekly(this) && snapshot.weekly != null) {
+            addDashboardCard(column, buildMetricCard(
+                    "Weekly", snapshot, snapshot.weekly, inverted));
+            inverted = !inverted;
+        }
+        if (AppPreferences.showDashboardAdditionalLimits(this)) {
+            for (UsageLimit limit : snapshot.additionalLimits) {
+                if (limit.primary != null) {
+                    addDashboardCard(column, buildMetricCard(
+                            limitTitle(limit) + " · " + cadenceLabel(limit.primary),
+                            snapshot, limit.primary, inverted));
+                    inverted = !inverted;
+                }
+                if (limit.secondary != null) {
+                    addDashboardCard(column, buildMetricCard(
+                            limitTitle(limit) + " · " + cadenceLabel(limit.secondary),
+                            snapshot, limit.secondary, inverted));
+                    inverted = !inverted;
+                }
+            }
+        }
+        if (AppPreferences.showDashboardUsageCredits(this) && snapshot.usageCredits != null) {
+            addDashboardCard(column, buildUsageCreditsCard(snapshot.usageCredits));
+        }
         return column;
     }
 
+    private void addDashboardCard(LinearLayout column, View card) {
+        if (column.getChildCount() > 0) {
+            Ui.addSpacer(column, 20);
+        }
+        column.addView(card);
+    }
+
     private LinearLayout buildMetricCard(String label, UsageSnapshot snapshot, UsageWindow window,
-            boolean signedIn, boolean invertedWave) {
+            boolean invertedWave) {
         LinearLayout card = Ui.card(this, this.dark);
         card.setPadding(0, 0, 0, 0);
         card.setMinimumHeight(Ui.dp(this, 103.0f));
         long now = System.currentTimeMillis();
-        String reset = window == null
-                ? (signedIn ? "Waiting for data" : "Not connected")
-                : UsageFormat.reset(this, window, WidgetOptions.RESET_RELATIVE,
-                        snapshot == null ? now : snapshot.fetchedAtMillis, now);
+        String reset = UsageFormat.reset(this, window, WidgetOptions.RESET_RELATIVE,
+                snapshot.fetchedAtMillis, now);
         UsagePace.Assessment pace = UsagePacePreferences.assess(this, snapshot, window, now);
         UsageWaveView wave = new UsageWaveView(this);
         wave.setUsage(label, reset, UsageFormat.estimatedRemaining(pace),
-                window == null ? 0 : window.remainingPercent(),
-                "Weekly".equals(label) ? R.drawable.ic_oui_calendar_week : R.drawable.ic_oui_time,
+                window.remainingPercent(),
+                window.windowSeconds >= 86_400L
+                        ? R.drawable.ic_oui_calendar_week : R.drawable.ic_oui_time,
                 invertedWave, pace.accelerated);
         card.addView(wave, new LinearLayout.LayoutParams(-1, Ui.dp(this, 103.0f)));
         return card;
+    }
+
+    private LinearLayout buildUsageCreditsCard(UsageCredits credits) {
+        LinearLayout card = Ui.card(this, this.dark);
+        card.setGravity(Gravity.CENTER);
+        card.setPadding(Ui.dp(this, 20), Ui.dp(this, 20),
+                Ui.dp(this, 20), Ui.dp(this, 20));
+        TextView balance = Ui.text(this, usageCreditBalance(credits), 30.0f,
+                Ui.mainText(this.dark));
+        balance.setTypeface(Ui.mediumTypeface(this));
+        balance.setGravity(Gravity.CENTER);
+        card.addView(balance);
+        TextView label = Ui.text(this, "Usage-credit balance", 16.0f,
+                Ui.secondaryText(this.dark));
+        label.setGravity(Gravity.CENTER);
+        LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(-2, -2);
+        labelParams.setMargins(0, Ui.dp(this, 4), 0, 0);
+        card.addView(label, labelParams);
+        return card;
+    }
+
+    private static String usageCreditBalance(UsageCredits credits) {
+        if (credits.unlimited) {
+            return "Unlimited";
+        }
+        if (credits.balance.isEmpty()) {
+            return credits.hasCredits ? "Available" : "No purchased credits";
+        }
+        try {
+            BigDecimal amount = new BigDecimal(credits.balance.replace(",", ""));
+            NumberFormat format = NumberFormat.getNumberInstance(Locale.getDefault());
+            format.setMaximumFractionDigits(2);
+            return format.format(amount) + " credits";
+        } catch (NumberFormatException ignored) {
+            return credits.balance;
+        }
+    }
+
+    private static String cadenceLabel(UsageWindow window) {
+        long seconds = window.windowSeconds;
+        if (seconds >= 432_000L && seconds <= 777_600L) {
+            return "Weekly";
+        }
+        if (seconds >= 10_800L && seconds <= 28_800L) {
+            long hours = Math.max(1L, Math.round(seconds / 3600.0d));
+            return hours + "-hour";
+        }
+        if (seconds % 86_400L == 0L) {
+            long days = seconds / 86_400L;
+            return days + "-day";
+        }
+        if (seconds % 3_600L == 0L) {
+            long hours = seconds / 3_600L;
+            return hours + "-hour";
+        }
+        return "Usage";
+    }
+
+    private static String limitTitle(UsageLimit limit) {
+        if (limit.limitReached) {
+            return limit.displayName() + " (limit reached)";
+        }
+        if (!limit.allowed) {
+            return limit.displayName() + " (unavailable)";
+        }
+        return limit.displayName();
     }
 
     private LinearLayout buildUsageCard() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -173,6 +173,12 @@ public final class SettingsTransferStore {
         json.put("material_you", AppPreferences.isMaterialYouEnabled(context));
         json.put("refresh_minutes", AppPreferences.getRefreshMinutes(context));
         json.put("refresh_on_launch", AppPreferences.getRefreshOnLaunch(context));
+        json.put("dashboard_five_hour", AppPreferences.showDashboardFiveHour(context));
+        json.put("dashboard_weekly", AppPreferences.showDashboardWeekly(context));
+        json.put("dashboard_additional_limits",
+                AppPreferences.showDashboardAdditionalLimits(context));
+        json.put("dashboard_usage_credits", AppPreferences.showDashboardUsageCredits(context));
+        json.put("dashboard_reset_credits", AppPreferences.showDashboardResetCredits(context));
         json.put("usage_pace_enabled", UsagePacePreferences.isEnabled(context));
         json.put("usage_pace_sensitivity", UsagePacePreferences.getSensitivity(context));
         json.put("automatic_update_checks", UpdatePreferences.automaticChecks(context));
@@ -220,6 +226,18 @@ public final class SettingsTransferStore {
                 AppPreferences.getRefreshMinutes(context)));
         AppPreferences.setRefreshOnLaunch(context, json.optBoolean("refresh_on_launch",
                 AppPreferences.getRefreshOnLaunch(context)));
+        AppPreferences.setDashboardVisibility(
+                context,
+                json.optBoolean("dashboard_five_hour",
+                        AppPreferences.showDashboardFiveHour(context)),
+                json.optBoolean("dashboard_weekly",
+                        AppPreferences.showDashboardWeekly(context)),
+                json.optBoolean("dashboard_additional_limits",
+                        AppPreferences.showDashboardAdditionalLimits(context)),
+                json.optBoolean("dashboard_usage_credits",
+                        AppPreferences.showDashboardUsageCredits(context)),
+                json.optBoolean("dashboard_reset_credits",
+                        AppPreferences.showDashboardResetCredits(context)));
         UsagePacePreferences.setEnabled(context, json.optBoolean("usage_pace_enabled",
                 UsagePacePreferences.isEnabled(context)));
         UsagePacePreferences.setSensitivity(context, json.optString("usage_pace_sensitivity",

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
@@ -43,8 +43,8 @@ public final class UsageApi {
                 throw new Exception(OAuthClient.readError(responseRequestUsage.body, str));
             }
             usageSnapshot = UsageParser.parse(responseRequestUsage.body, System.currentTimeMillis());
-            if (usageSnapshot.fiveHour == null && usageSnapshot.weekly == null) {
-                throw new Exception("OpenAI returned no recognizable Codex usage windows.");
+            if (!usageSnapshot.hasDisplayableData()) {
+                throw new Exception("OpenAI returned no recognizable Codex usage data.");
             }
             UsageSnapshot previousSnapshot = AppPreferences.loadSnapshot(context);
             if (!AppPreferences.saveSnapshot(context, usageSnapshot)) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageParser.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageParser.java
@@ -1,7 +1,6 @@
 package dev.bennett.codexmeter;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -23,7 +22,7 @@ public final class UsageParser {
         String strOptString = jSONObject.optString("plan_type", "");
         JSONObject jSONObjectNullableObject = nullableObject(jSONObject, "rate_limit");
         ArrayList arrayList = new ArrayList();
-        ArrayList arrayList2 = new ArrayList();
+        ArrayList<UsageLimit> additionalLimits = new ArrayList<>();
         UsageWindow usageWindowFromJson = null;
         if (jSONObjectNullableObject == null) {
             z = true;
@@ -55,39 +54,48 @@ public final class UsageParser {
                     }
                     UsageWindow usageWindowFromJson3 = UsageWindow.fromJson(nullableObject(jSONObjectNullableObject2, "primary_window"));
                     UsageWindow usageWindowFromJson4 = UsageWindow.fromJson(nullableObject(jSONObjectNullableObject2, "secondary_window"));
-                    if (usageWindowFromJson3 != null) {
-                        arrayList2.add(usageWindowFromJson3);
-                    }
-                    if (usageWindowFromJson4 != null) {
-                        arrayList2.add(usageWindowFromJson4);
+                    if (usageWindowFromJson3 != null || usageWindowFromJson4 != null) {
+                        String name = jSONObjectOptJSONObject.optString("limit_name", "");
+                        String feature = jSONObjectOptJSONObject.optString("metered_feature", "");
+                        String id = firstNonEmpty(
+                                jSONObjectOptJSONObject.optString("limit_id", ""),
+                                name, feature, "additional");
+                        additionalLimits.add(new UsageLimit(
+                                id + "-" + i,
+                                name,
+                                feature,
+                                jSONObjectNullableObject2.optBoolean("allowed", true),
+                                jSONObjectNullableObject2.optBoolean("limit_reached", false),
+                                usageWindowFromJson3,
+                                usageWindowFromJson4));
                     }
                 }
             }
         }
         UsageWindow usageWindowNearest = nearest(arrayList, FIVE_HOURS, 10800L, 28800L);
         UsageWindow usageWindowNearestExcluding = nearestExcluding(arrayList, WEEK, 432000L, 777600L, usageWindowNearest);
-        if (usageWindowNearest == null) {
-            if (usageWindow != null && usageWindow != usageWindowNearestExcluding) {
-                usageWindowNearest = usageWindow;
-            } else if (usageWindowFromJson != null && usageWindowFromJson != usageWindowNearestExcluding) {
-                usageWindowNearest = usageWindowFromJson;
+        JSONObject jSONObjectNullableObject3 = nullableObject(jSONObject, "rate_limit_reset_credits");
+        UsageCredits usageCredits = UsageCredits.fromJson(nullableObject(jSONObject, "credits"));
+        return new UsageSnapshot(
+                strOptString,
+                z,
+                z2,
+                usageWindowNearest,
+                usageWindowNearestExcluding,
+                additionalLimits,
+                usageCredits,
+                jSONObjectNullableObject3 == null
+                        ? -1 : jSONObjectNullableObject3.optInt("available_count", -1),
+                j);
+    }
+
+    private static String firstNonEmpty(String... values) {
+        for (String value : values) {
+            if (value != null && !value.trim().isEmpty()) {
+                return value.trim();
             }
         }
-        if (usageWindowNearestExcluding != null) {
-            usageWindowFromJson = usageWindowNearestExcluding;
-        } else if (usageWindowFromJson == null || usageWindowFromJson == usageWindowNearest) {
-            usageWindowFromJson = farthestDifferent(arrayList, usageWindowNearest);
-        }
-        if (usageWindowNearest == null) {
-            usageWindowNearest = nearest(arrayList2, FIVE_HOURS, 10800L, 28800L);
-        }
-        UsageWindow usageWindowNearestExcluding2 = usageWindowFromJson == null ? nearestExcluding(arrayList2, WEEK, 432000L, 777600L, usageWindowNearest) : usageWindowFromJson;
-        UsageWindow usageWindow2 = (usageWindowNearest != null || arrayList2.isEmpty()) ? usageWindowNearest : (UsageWindow) arrayList2.get(0);
-        if (usageWindowNearestExcluding2 == null) {
-            usageWindowNearestExcluding2 = farthestDifferent(arrayList2, usageWindow2);
-        }
-        JSONObject jSONObjectNullableObject3 = nullableObject(jSONObject, "rate_limit_reset_credits");
-        return new UsageSnapshot(strOptString, z, z2, usageWindow2, usageWindowNearestExcluding2, jSONObjectNullableObject3 == null ? -1 : jSONObjectNullableObject3.optInt("available_count", -1), j);
+        return "";
     }
 
     private static JSONObject nullableObject(JSONObject jSONObject, String str) {
@@ -151,27 +159,4 @@ public final class UsageParser {
         return usageWindow3;
     }
 
-    private static UsageWindow farthestDifferent(List<UsageWindow> list, UsageWindow usageWindow) {
-        UsageWindow usageWindow2;
-        UsageWindow usageWindow3 = null;
-        long j = -1;
-        Iterator<UsageWindow> it = list.iterator();
-        while (true) {
-            UsageWindow usageWindow4 = usageWindow3;
-            long j2 = j;
-            if (it.hasNext()) {
-                UsageWindow next = it.next();
-                if (next == usageWindow || next.windowSeconds <= j2) {
-                    usageWindow2 = usageWindow4;
-                } else {
-                    j2 = next.windowSeconds;
-                    usageWindow2 = next;
-                }
-                j = j2;
-                usageWindow3 = usageWindow2;
-            } else {
-                return usageWindow4;
-            }
-        }
-    }
 }

--- a/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
+++ b/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
@@ -14,6 +14,34 @@
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="Dashboard">
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="dashboard_five_hour"
+            android:summary="Shown only when OpenAI returns this window"
+            android:title="5-hour limit" />
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="dashboard_weekly"
+            android:summary="Shown only when OpenAI returns this window"
+            android:title="Weekly limit" />
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="dashboard_additional_limits"
+            android:summary="Model-specific limits such as GPT-5.3-Codex-Spark"
+            android:title="Additional limits" />
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="dashboard_usage_credits"
+            android:summary="Purchased credits returned by OpenAI"
+            android:title="Usage-credit balance" />
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="dashboard_reset_credits"
+            android:summary="Earned credits that can reset usage windows"
+            android:title="Reset credits" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="Usage estimates">
         <SwitchPreferenceCompat
             android:key="usage_pace_enabled_ui"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -27,6 +27,8 @@ rm -rf "$OUT" && mkdir -p "$OUT"
 
 javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageLimit.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java" \

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
@@ -1,0 +1,41 @@
+package dev.bennett.codexmeter;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** Purchased usage-credit state returned by the main Codex usage endpoint. */
+public final class UsageCredits {
+    public final boolean hasCredits;
+    public final boolean unlimited;
+    public final String balance;
+
+    public UsageCredits(boolean hasCredits, boolean unlimited, String balance) {
+        this.hasCredits = hasCredits;
+        this.unlimited = unlimited;
+        this.balance = balance == null ? "" : balance.trim();
+    }
+
+    public JSONObject toJson() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("has_credits", hasCredits);
+        object.put("unlimited", unlimited);
+        if (!balance.isEmpty()) {
+            object.put("balance", balance);
+        }
+        return object;
+    }
+
+    public static UsageCredits fromJson(JSONObject object) {
+        if (object == null || (!object.has("has_credits")
+                && !object.has("unlimited") && !object.has("balance"))) {
+            return null;
+        }
+        Object rawBalance = object.opt("balance");
+        String balance = rawBalance == null || JSONObject.NULL.equals(rawBalance)
+                ? "" : String.valueOf(rawBalance);
+        return new UsageCredits(
+                object.optBoolean("has_credits", false),
+                object.optBoolean("unlimited", false),
+                balance);
+    }
+}

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
@@ -12,7 +12,8 @@ public final class UsageCredits {
     public UsageCredits(boolean hasCredits, boolean unlimited, String balance) {
         this.hasCredits = hasCredits;
         this.unlimited = unlimited;
-        this.balance = balance == null ? "" : balance.trim();
+        String cleanBalance = balance == null ? "" : balance.trim();
+        this.balance = hasCredits || unlimited ? cleanBalance : "";
     }
 
     public JSONObject toJson() throws JSONException {

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageLimit.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageLimit.java
@@ -1,0 +1,95 @@
+package dev.bennett.codexmeter;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** A named, independently metered limit returned in additional_rate_limits. */
+public final class UsageLimit {
+    public final String id;
+    public final String name;
+    public final String meteredFeature;
+    public final boolean allowed;
+    public final boolean limitReached;
+    public final UsageWindow primary;
+    public final UsageWindow secondary;
+
+    public UsageLimit(String id, String name, String meteredFeature, boolean allowed,
+            boolean limitReached, UsageWindow primary, UsageWindow secondary) {
+        this.id = clean(id);
+        this.name = clean(name);
+        this.meteredFeature = clean(meteredFeature);
+        this.allowed = allowed;
+        this.limitReached = limitReached;
+        this.primary = primary;
+        this.secondary = secondary;
+    }
+
+    public String displayName() {
+        if (!name.isEmpty()) {
+            return name;
+        }
+        if (!meteredFeature.isEmpty()) {
+            return titleCase(meteredFeature);
+        }
+        return "Additional usage";
+    }
+
+    public JSONObject toJson() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("id", id);
+        object.put("name", name);
+        object.put("metered_feature", meteredFeature);
+        object.put("allowed", allowed);
+        object.put("limit_reached", limitReached);
+        if (primary != null) {
+            object.put("primary", primary.toJson());
+        }
+        if (secondary != null) {
+            object.put("secondary", secondary.toJson());
+        }
+        return object;
+    }
+
+    public static UsageLimit fromJson(JSONObject object) {
+        if (object == null) {
+            return null;
+        }
+        UsageWindow primary = UsageWindow.fromJson(object.optJSONObject("primary"));
+        UsageWindow secondary = UsageWindow.fromJson(object.optJSONObject("secondary"));
+        if (primary == null && secondary == null) {
+            return null;
+        }
+        return new UsageLimit(
+                object.optString("id", ""),
+                object.optString("name", ""),
+                object.optString("metered_feature", ""),
+                object.optBoolean("allowed", true),
+                object.optBoolean("limit_reached", false),
+                primary,
+                secondary);
+    }
+
+    private static String clean(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static String titleCase(String value) {
+        String normalized = value.replace('_', ' ').replace('-', ' ').trim();
+        if (normalized.isEmpty()) {
+            return "";
+        }
+        StringBuilder result = new StringBuilder(normalized.length());
+        boolean capitalize = true;
+        for (int i = 0; i < normalized.length(); i++) {
+            char current = normalized.charAt(i);
+            if (Character.isWhitespace(current)) {
+                result.append(current);
+                capitalize = true;
+            } else {
+                result.append(capitalize ? Character.toUpperCase(current) : current);
+                capitalize = false;
+            }
+        }
+        return result.toString();
+    }
+}

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java
@@ -121,7 +121,9 @@ public final class UsageSnapshot {
 
     public boolean hasDisplayableData() {
         return fiveHour != null || weekly != null || !additionalLimits.isEmpty()
-                || usageCredits != null || resetCreditsAvailable >= 0;
+                || (usageCredits != null && (usageCredits.hasCredits
+                || usageCredits.unlimited || !usageCredits.balance.isEmpty()))
+                || resetCreditsAvailable >= 0;
     }
 
     private long earlierFutureReset(long current, UsageWindow window, long now) {

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java
@@ -1,16 +1,22 @@
 package dev.bennett.codexmeter;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class UsageSnapshot {
     public final boolean allowed;
+    public final List<UsageLimit> additionalLimits;
     public final long fetchedAtMillis;
     public final UsageWindow fiveHour;
     public final boolean limitReached;
     public final String planType;
     public final int resetCreditsAvailable;
+    public final UsageCredits usageCredits;
     public final UsageWindow weekly;
 
     public UsageSnapshot(String str, boolean z, boolean z2, UsageWindow usageWindow, UsageWindow usageWindow2, long j) {
@@ -18,11 +24,21 @@ public final class UsageSnapshot {
     }
 
     public UsageSnapshot(String str, boolean z, boolean z2, UsageWindow usageWindow, UsageWindow usageWindow2, int i, long j) {
+        this(str, z, z2, usageWindow, usageWindow2, Collections.emptyList(), null, i, j);
+    }
+
+    public UsageSnapshot(String str, boolean z, boolean z2, UsageWindow usageWindow,
+            UsageWindow usageWindow2, List<UsageLimit> additionalLimits,
+            UsageCredits usageCredits, int i, long j) {
         this.planType = str == null ? "" : str;
         this.allowed = z;
         this.limitReached = z2;
         this.fiveHour = usageWindow;
         this.weekly = usageWindow2;
+        this.additionalLimits = additionalLimits == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(additionalLimits));
+        this.usageCredits = usageCredits;
         this.resetCreditsAvailable = i < 0 ? -1 : i;
         this.fetchedAtMillis = j;
     }
@@ -38,6 +54,18 @@ public final class UsageSnapshot {
         if (this.weekly != null) {
             jSONObject.put("weekly", this.weekly.toJson());
         }
+        if (!this.additionalLimits.isEmpty()) {
+            JSONArray limits = new JSONArray();
+            for (UsageLimit limit : this.additionalLimits) {
+                if (limit != null) {
+                    limits.put(limit.toJson());
+                }
+            }
+            jSONObject.put("additional_limits", limits);
+        }
+        if (this.usageCredits != null) {
+            jSONObject.put("usage_credits", this.usageCredits.toJson());
+        }
         if (this.resetCreditsAvailable >= 0) {
             jSONObject.put("reset_credits_available", this.resetCreditsAvailable);
         }
@@ -49,7 +77,27 @@ public final class UsageSnapshot {
         if (jSONObject == null) {
             return null;
         }
-        return new UsageSnapshot(jSONObject.optString("plan_type", ""), jSONObject.optBoolean("allowed", true), jSONObject.optBoolean("limit_reached", false), UsageWindow.fromJson(jSONObject.optJSONObject("five_hour")), UsageWindow.fromJson(jSONObject.optJSONObject("weekly")), jSONObject.has("reset_credits_available") ? jSONObject.optInt("reset_credits_available", -1) : -1, jSONObject.optLong("fetched_at", 0L));
+        ArrayList<UsageLimit> additionalLimits = new ArrayList<>();
+        JSONArray limits = jSONObject.optJSONArray("additional_limits");
+        if (limits != null) {
+            for (int i = 0; i < limits.length(); i++) {
+                UsageLimit limit = UsageLimit.fromJson(limits.optJSONObject(i));
+                if (limit != null) {
+                    additionalLimits.add(limit);
+                }
+            }
+        }
+        return new UsageSnapshot(
+                jSONObject.optString("plan_type", ""),
+                jSONObject.optBoolean("allowed", true),
+                jSONObject.optBoolean("limit_reached", false),
+                UsageWindow.fromJson(jSONObject.optJSONObject("five_hour")),
+                UsageWindow.fromJson(jSONObject.optJSONObject("weekly")),
+                additionalLimits,
+                UsageCredits.fromJson(jSONObject.optJSONObject("usage_credits")),
+                jSONObject.has("reset_credits_available")
+                        ? jSONObject.optInt("reset_credits_available", -1) : -1,
+                jSONObject.optLong("fetched_at", 0L));
     }
 
     public long nextResetMillis(long j) {
@@ -61,10 +109,27 @@ public final class UsageSnapshot {
         if (weeklyReset > j) {
             jMin = Math.min(jMin, weeklyReset);
         }
+        for (UsageLimit limit : additionalLimits) {
+            jMin = earlierFutureReset(jMin, limit.primary, j);
+            jMin = earlierFutureReset(jMin, limit.secondary, j);
+        }
         if (jMin == Long.MAX_VALUE) {
             return 0L;
         }
         return jMin;
+    }
+
+    public boolean hasDisplayableData() {
+        return fiveHour != null || weekly != null || !additionalLimits.isEmpty()
+                || usageCredits != null || resetCreditsAvailable >= 0;
+    }
+
+    private long earlierFutureReset(long current, UsageWindow window, long now) {
+        if (window == null) {
+            return current;
+        }
+        long reset = window.effectiveResetAtMillis(fetchedAtMillis);
+        return reset > now ? Math.min(current, reset) : current;
     }
 
     static UsageWindow currentWindow(UsageWindow window, long now) {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -568,6 +568,11 @@ public final class ParserSelfTest {
         UsageSnapshot empty = UsageParser.parse("{\"credits\":{}}", 4L);
         check(empty.usageCredits == null && !empty.hasDisplayableData(),
                 "empty credits object does not become dashboard data");
+        UsageSnapshot none = UsageParser.parse(
+                "{\"credits\":{\"has_credits\":false,\"balance\":\"0\"}}", 5L);
+        check(none.usageCredits != null && none.usageCredits.balance.isEmpty()
+                        && !none.hasDisplayableData(),
+                "zero balance for an account without purchased credits is not standalone data");
     }
 
     private static void testMalformedWindowIgnored() throws Exception {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -17,6 +17,8 @@ public final class ParserSelfTest {
         testWindowIdentification();
         testAdditionalLimits();
         testPrimaryLimitWinsOverAdditional();
+        testOptionalUsageSections();
+        testUsageCredits();
         testMalformedWindowIgnored();
         testZeroDurationWindowIgnored();
         testNextResetSelection();
@@ -503,8 +505,11 @@ public final class ParserSelfTest {
                 "\"rate_limit\":{\"primary_window\":{\"used_percent\":150,\"limit_window_seconds\":18000,\"reset_after_seconds\":1,\"reset_at\":2}," +
                 "\"secondary_window\":{\"used_percent\":-5,\"limit_window_seconds\":604800,\"reset_after_seconds\":1,\"reset_at\":3}}}]}";
         UsageSnapshot snapshot = UsageParser.parse(json, 1L);
-        check(snapshot.fiveHour.remainingPercent() == 0, "upper clamp");
-        check(snapshot.weekly.remainingPercent() == 100, "lower clamp");
+        check(snapshot.fiveHour == null && snapshot.weekly == null,
+                "additional limits do not masquerade as standard limits");
+        check(snapshot.additionalLimits.size() == 1, "additional limit preserved");
+        check(snapshot.additionalLimits.get(0).primary.remainingPercent() == 0, "upper clamp");
+        check(snapshot.additionalLimits.get(0).secondary.remainingPercent() == 100, "lower clamp");
     }
 
 
@@ -520,6 +525,49 @@ public final class ParserSelfTest {
                 "main Codex limit takes precedence over additional feature limits");
         check(snapshot.weekly != null && snapshot.weekly.usedPercent == 20,
                 "main weekly limit takes precedence");
+        check(snapshot.additionalLimits.size() == 1
+                        && snapshot.additionalLimits.get(0).primary.usedPercent == 90,
+                "additional feature limit remains independently available");
+    }
+
+    private static void testOptionalUsageSections() throws Exception {
+        String weeklyOnly = "{\"plan_type\":\"pro\",\"rate_limit\":{"
+                + "\"secondary_window\":{\"used_percent\":25,"
+                + "\"limit_window_seconds\":604800,\"reset_at\":2000}}}";
+        UsageSnapshot snapshot = UsageParser.parse(weeklyOnly, 1L);
+        check(snapshot.fiveHour == null, "missing five-hour limit stays absent");
+        check(snapshot.weekly != null && snapshot.weekly.usedPercent == 25,
+                "weekly limit remains available without five-hour data");
+
+        String namedAdditional = "{\"additional_rate_limits\":[{"
+                + "\"limit_name\":\"GPT-5.3-Codex-Spark\","
+                + "\"metered_feature\":\"codex_bengalfox\","
+                + "\"rate_limit\":{\"allowed\":false,\"limit_reached\":true,"
+                + "\"primary_window\":{\"used_percent\":40,\"limit_window_seconds\":18000}}}]}";
+        UsageSnapshot additional = UsageParser.parse(namedAdditional, 2L);
+        UsageLimit limit = additional.additionalLimits.get(0);
+        check("GPT-5.3-Codex-Spark".equals(limit.displayName()),
+                "API-provided additional limit label preserved");
+        check(!limit.allowed && limit.limitReached, "additional limit status preserved");
+        check(additional.hasDisplayableData(), "additional-only response is displayable");
+    }
+
+    private static void testUsageCredits() throws Exception {
+        UsageSnapshot snapshot = UsageParser.parse(
+                "{\"credits\":{\"has_credits\":true,\"unlimited\":false,"
+                        + "\"balance\":\"2500.5\"}}",
+                3L);
+        check(snapshot.usageCredits != null && snapshot.usageCredits.hasCredits,
+                "purchased usage credits parsed");
+        check("2500.5".equals(snapshot.usageCredits.balance), "usage-credit balance preserved");
+        check(snapshot.hasDisplayableData(), "credit-only response is displayable");
+        UsageSnapshot restored = UsageSnapshot.fromJson(snapshot.toJson());
+        check(restored != null && restored.usageCredits != null
+                        && "2500.5".equals(restored.usageCredits.balance),
+                "usage credits survive cache round trip");
+        UsageSnapshot empty = UsageParser.parse("{\"credits\":{}}", 4L);
+        check(empty.usageCredits == null && !empty.hasDisplayableData(),
+                "empty credits object does not become dashboard data");
     }
 
     private static void testMalformedWindowIgnored() throws Exception {

--- a/ios/CodexMeter/AppModel.swift
+++ b/ios/CodexMeter/AppModel.swift
@@ -133,6 +133,28 @@ final class AppModel {
                     resetAt: now.addingTimeInterval(280_000)
                 ),
                 resetCreditsAvailable: 2,
+                additionalLimits: [
+                    UsageLimit(
+                        id: "codex-spark",
+                        name: "GPT-5.3-Codex-Spark",
+                        meteredFeature: "codex_bengalfox",
+                        primary: UsageWindow(
+                            usedPercent: 24,
+                            windowSeconds: 18_000,
+                            resetAt: now.addingTimeInterval(10_800)
+                        ),
+                        secondary: UsageWindow(
+                            usedPercent: 42,
+                            windowSeconds: 604_800,
+                            resetAt: now.addingTimeInterval(432_000)
+                        )
+                    )
+                ],
+                usageCredits: UsageCredits(
+                    hasCredits: true,
+                    unlimited: false,
+                    balance: "2500"
+                ),
                 fetchedAt: now
             )
             credits = ResetCreditsSnapshot(

--- a/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
+++ b/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
@@ -43,6 +43,11 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
     public var appearance: AppAppearance
     public var refreshOnLaunch: Bool
     public var refreshMinutes: Int
+    public var showFiveHour: Bool
+    public var showWeekly: Bool
+    public var showAdditionalLimits: Bool
+    public var showUsageCredits: Bool
+    public var showResetCredits: Bool
     public var notificationsEnabled: Bool
     public var alertMetric: AlertMetric
     /// Remaining allowance percentage. `100` corresponds to the “Always” UI option.
@@ -57,6 +62,11 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         appearance: AppAppearance = .system,
         refreshOnLaunch: Bool = true,
         refreshMinutes: Int = 30,
+        showFiveHour: Bool = true,
+        showWeekly: Bool = true,
+        showAdditionalLimits: Bool = true,
+        showUsageCredits: Bool = true,
+        showResetCredits: Bool = true,
         notificationsEnabled: Bool = false,
         alertMetric: AlertMetric = .both,
         alertThreshold: Int = 25,
@@ -68,6 +78,11 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         self.appearance = appearance
         self.refreshOnLaunch = refreshOnLaunch
         self.refreshMinutes = Self.allowedRefreshMinutes.contains(refreshMinutes) ? refreshMinutes : 30
+        self.showFiveHour = showFiveHour
+        self.showWeekly = showWeekly
+        self.showAdditionalLimits = showAdditionalLimits
+        self.showUsageCredits = showUsageCredits
+        self.showResetCredits = showResetCredits
         self.notificationsEnabled = notificationsEnabled
         self.alertMetric = alertMetric
         self.alertThreshold = Self.allowedAlertThresholds.contains(alertThreshold) ? alertThreshold : 25
@@ -101,6 +116,11 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         case appearance
         case refreshOnLaunch
         case refreshMinutes
+        case showFiveHour
+        case showWeekly
+        case showAdditionalLimits
+        case showUsageCredits
+        case showResetCredits
         case notificationsEnabled
         case alertMetric
         case alertThreshold
@@ -116,6 +136,11 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
             appearance: try container.decodeIfPresent(AppAppearance.self, forKey: .appearance) ?? .system,
             refreshOnLaunch: try container.decodeIfPresent(Bool.self, forKey: .refreshOnLaunch) ?? true,
             refreshMinutes: try container.decodeIfPresent(Int.self, forKey: .refreshMinutes) ?? 30,
+            showFiveHour: try container.decodeIfPresent(Bool.self, forKey: .showFiveHour) ?? true,
+            showWeekly: try container.decodeIfPresent(Bool.self, forKey: .showWeekly) ?? true,
+            showAdditionalLimits: try container.decodeIfPresent(Bool.self, forKey: .showAdditionalLimits) ?? true,
+            showUsageCredits: try container.decodeIfPresent(Bool.self, forKey: .showUsageCredits) ?? true,
+            showResetCredits: try container.decodeIfPresent(Bool.self, forKey: .showResetCredits) ?? true,
             notificationsEnabled: try container.decodeIfPresent(Bool.self, forKey: .notificationsEnabled) ?? false,
             alertMetric: try container.decodeIfPresent(AlertMetric.self, forKey: .alertMetric) ?? .both,
             alertThreshold: try container.decodeIfPresent(Int.self, forKey: .alertThreshold) ?? 25,

--- a/ios/CodexMeter/Services/DemoCodexService.swift
+++ b/ios/CodexMeter/Services/DemoCodexService.swift
@@ -92,6 +92,28 @@ public actor DemoCodexService: CodexService {
                 resetAt: referenceDate.addingTimeInterval(3 * 24 * 60 * 60 + 8 * 60 * 60)
             ),
             resetCreditsAvailable: availableCredits,
+            additionalLimits: [
+                UsageLimit(
+                    id: "codex-spark",
+                    name: "GPT-5.3-Codex-Spark",
+                    meteredFeature: "codex_bengalfox",
+                    primary: UsageWindow(
+                        usedPercent: 24,
+                        windowSeconds: 18_000,
+                        resetAt: referenceDate.addingTimeInterval(3 * 60 * 60)
+                    ),
+                    secondary: UsageWindow(
+                        usedPercent: 42,
+                        windowSeconds: 604_800,
+                        resetAt: referenceDate.addingTimeInterval(5 * 24 * 60 * 60)
+                    )
+                )
+            ],
+            usageCredits: UsageCredits(
+                hasCredits: true,
+                unlimited: false,
+                balance: "2500"
+            ),
             fetchedAt: fetchedAt
         )
         try await appCache.save(

--- a/ios/CodexMeter/Services/LiveCodexService.swift
+++ b/ios/CodexMeter/Services/LiveCodexService.swift
@@ -281,9 +281,21 @@ public actor LiveCodexService: CodexService {
             fiveHour: resolvingResetDate(in: parsed.fiveHour, relativeTo: fetchedAt),
             weekly: resolvingResetDate(in: parsed.weekly, relativeTo: fetchedAt),
             resetCreditsAvailable: parsed.resetCreditsAvailable,
+            additionalLimits: parsed.additionalLimits.map {
+                UsageLimit(
+                    id: $0.id,
+                    name: $0.name,
+                    meteredFeature: $0.meteredFeature,
+                    allowed: $0.allowed,
+                    limitReached: $0.limitReached,
+                    primary: resolvingResetDate(in: $0.primary, relativeTo: fetchedAt),
+                    secondary: resolvingResetDate(in: $0.secondary, relativeTo: fetchedAt)
+                )
+            },
+            usageCredits: parsed.usageCredits,
             fetchedAt: fetchedAt
         )
-        guard usage.fiveHour != nil || usage.weekly != nil else {
+        guard usage.hasDisplayableData else {
             throw CodexServiceError.invalidResponse
         }
         return usage
@@ -310,6 +322,8 @@ public actor LiveCodexService: CodexService {
             fiveHour: usage.fiveHour,
             weekly: usage.weekly,
             resetCreditsAvailable: count,
+            additionalLimits: usage.additionalLimits,
+            usageCredits: usage.usageCredits,
             fetchedAt: usage.fetchedAt
         )
     }

--- a/ios/CodexMeter/Views/DashboardView.swift
+++ b/ios/CodexMeter/Views/DashboardView.swift
@@ -99,7 +99,7 @@ struct DashboardView: View {
                             }
                             ForEach(additionalWindows) { item in
                                 UsageMeterCard(
-                                    title: item.title,
+                                    title: LocalizedStringKey(item.title),
                                     systemImage: item.window.windowSeconds >= 86_400
                                         ? "calendar.badge.clock" : "clock.badge",
                                     window: item.window,

--- a/ios/CodexMeter/Views/DashboardView.swift
+++ b/ios/CodexMeter/Views/DashboardView.swift
@@ -11,6 +11,40 @@ struct DashboardView: View {
             : [GridItem(.flexible())]
     }
 
+    private var additionalWindows: [AdditionalWindowPresentation] {
+        guard model.settings.showAdditionalLimits else { return [] }
+        return (model.usage?.additionalLimits ?? []).flatMap { limit in
+            var windows: [AdditionalWindowPresentation] = []
+            if let primary = limit.primary {
+                windows.append(
+                    AdditionalWindowPresentation(
+                        id: "\(limit.id)-primary",
+                        title: "\(Self.limitTitle(limit)) · \(Self.cadenceLabel(primary))",
+                        window: primary,
+                        accent: .teal
+                    )
+                )
+            }
+            if let secondary = limit.secondary {
+                windows.append(
+                    AdditionalWindowPresentation(
+                        id: "\(limit.id)-secondary",
+                        title: "\(Self.limitTitle(limit)) · \(Self.cadenceLabel(secondary))",
+                        window: secondary,
+                        accent: .purple
+                    )
+                )
+            }
+            return windows
+        }
+    }
+
+    private var hasVisibleUsageWindows: Bool {
+        (model.settings.showFiveHour && model.usage?.fiveHour != nil)
+            || (model.settings.showWeekly && model.usage?.weekly != nil)
+            || !additionalWindows.isEmpty
+    }
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: AppChrome.sectionSpacing) {
@@ -41,24 +75,49 @@ struct DashboardView: View {
                         )
                     }
 
-                    LazyVGrid(columns: columns, spacing: AppChrome.sectionSpacing) {
-                        UsageMeterCard(
-                            title: "5-hour",
-                            systemImage: "clock",
-                            window: model.usage?.fiveHour,
-                            accent: .mint,
-                            fetchedAt: model.usage?.fetchedAt ?? .now
-                        )
-                        UsageMeterCard(
-                            title: "Weekly",
-                            systemImage: "calendar",
-                            window: model.usage?.weekly,
-                            accent: .indigo,
-                            fetchedAt: model.usage?.fetchedAt ?? .now
-                        )
+                    if hasVisibleUsageWindows {
+                        LazyVGrid(columns: columns, spacing: AppChrome.sectionSpacing) {
+                            if model.settings.showFiveHour,
+                               let window = model.usage?.fiveHour {
+                                UsageMeterCard(
+                                    title: "5-hour",
+                                    systemImage: "clock",
+                                    window: window,
+                                    accent: .mint,
+                                    fetchedAt: model.usage?.fetchedAt ?? .now
+                                )
+                            }
+                            if model.settings.showWeekly,
+                               let window = model.usage?.weekly {
+                                UsageMeterCard(
+                                    title: "Weekly",
+                                    systemImage: "calendar",
+                                    window: window,
+                                    accent: .indigo,
+                                    fetchedAt: model.usage?.fetchedAt ?? .now
+                                )
+                            }
+                            ForEach(additionalWindows) { item in
+                                UsageMeterCard(
+                                    title: item.title,
+                                    systemImage: item.window.windowSeconds >= 86_400
+                                        ? "calendar.badge.clock" : "clock.badge",
+                                    window: item.window,
+                                    accent: item.accent,
+                                    fetchedAt: model.usage?.fetchedAt ?? .now
+                                )
+                            }
+                        }
                     }
 
-                    ResetCreditsCard()
+                    if model.settings.showUsageCredits,
+                       let usageCredits = model.usage?.usageCredits {
+                        UsageCreditsCard(credits: usageCredits)
+                    }
+                    if model.settings.showResetCredits,
+                       model.credits != nil || model.usage?.resetCreditsAvailable != nil {
+                        ResetCreditsCard()
+                    }
                     PrivacyFootnote()
                 }
             }
@@ -99,6 +158,40 @@ struct DashboardView: View {
             await model.startIfNeeded()
         }
     }
+
+    private static func cadenceLabel(_ window: UsageWindow) -> String {
+        let seconds = window.windowSeconds
+        if (432_000 ... 777_600).contains(seconds) {
+            return "Weekly"
+        }
+        if (10_800 ... 28_800).contains(seconds) {
+            return "\(max(1, Int((Double(seconds) / 3_600).rounded())))-hour"
+        }
+        if seconds.isMultiple(of: 86_400) {
+            return "\(seconds / 86_400)-day"
+        }
+        if seconds.isMultiple(of: 3_600) {
+            return "\(seconds / 3_600)-hour"
+        }
+        return "Usage"
+    }
+
+    private static func limitTitle(_ limit: UsageLimit) -> String {
+        if limit.limitReached {
+            return "\(limit.displayName) (limit reached)"
+        }
+        if !limit.allowed {
+            return "\(limit.displayName) (unavailable)"
+        }
+        return limit.displayName
+    }
+}
+
+private struct AdditionalWindowPresentation: Identifiable {
+    let id: String
+    let title: String
+    let window: UsageWindow
+    let accent: Color
 }
 
 private struct DashboardStatusStrip: View {
@@ -160,7 +253,7 @@ private struct SignedOutView: View {
                 Text("Your Codex allowance at a glance")
                     .font(.title2.bold())
                     .multilineTextAlignment(.center)
-                Text("Connect your ChatGPT account to see the current five-hour and weekly windows, reset times, and earned reset credits.")
+                Text("Connect your ChatGPT account to see current usage limits, purchased usage credits, reset times, and earned reset credits.")
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
@@ -190,6 +283,48 @@ private struct SignedOutView: View {
         .frame(maxWidth: .infinity)
         .padding(28)
         .cardSurface()
+    }
+}
+
+private struct UsageCreditsCard: View {
+    let credits: UsageCredits
+
+    private var balance: String {
+        if credits.unlimited {
+            return "Unlimited"
+        }
+        guard let raw = credits.balance else {
+            return credits.hasCredits ? "Available" : "No purchased credits"
+        }
+        if let number = Double(raw.replacingOccurrences(of: ",", with: "")),
+           number.isFinite {
+            return number.formatted(
+                .number.precision(.fractionLength(0 ... 2))
+            ) + " credits"
+        }
+        return raw
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "creditcard.fill")
+                .font(.system(size: 34))
+                .foregroundStyle(.tint)
+                .symbolRenderingMode(.hierarchical)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(balance)
+                    .font(.title2.bold())
+                    .contentTransition(.numericText())
+                Text("Usage-credit balance")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(AppChrome.cardPadding)
+        .cardSurface()
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/ios/CodexMeter/Views/SettingsView.swift
+++ b/ios/CodexMeter/Views/SettingsView.swift
@@ -45,6 +45,18 @@ struct SettingsView: View {
             }
 
             Section {
+                Toggle("5-hour limit", isOn: $model.settings.showFiveHour)
+                Toggle("Weekly limit", isOn: $model.settings.showWeekly)
+                Toggle("Additional limits", isOn: $model.settings.showAdditionalLimits)
+                Toggle("Usage-credit balance", isOn: $model.settings.showUsageCredits)
+                Toggle("Reset credits", isOn: $model.settings.showResetCredits)
+            } header: {
+                Text("Dashboard")
+            } footer: {
+                Text("Enabled items still appear only when OpenAI returns data for them. Additional limits include temporary model-specific allowances.")
+            }
+
+            Section {
                 Toggle("Refresh on launch", isOn: $model.settings.refreshOnLaunch)
                 Picker("Preferred interval", selection: $model.settings.refreshMinutes) {
                     ForEach([5, 10, 15, 30, 60, 120], id: \.self) { minutes in

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
@@ -96,6 +96,29 @@ public struct UsageLimit: Codable, Sendable, Equatable, Identifiable {
         }
         return "Additional usage"
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case meteredFeature
+        case allowed
+        case limitReached
+        case primary
+        case secondary
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try container.decodeIfPresent(String.self, forKey: .id) ?? "",
+            name: try container.decodeIfPresent(String.self, forKey: .name) ?? "",
+            meteredFeature: try container.decodeIfPresent(String.self, forKey: .meteredFeature) ?? "",
+            allowed: try container.decodeIfPresent(Bool.self, forKey: .allowed) ?? true,
+            limitReached: try container.decodeIfPresent(Bool.self, forKey: .limitReached) ?? false,
+            primary: try container.decodeIfPresent(UsageWindow.self, forKey: .primary),
+            secondary: try container.decodeIfPresent(UsageWindow.self, forKey: .secondary)
+        )
+    }
 }
 
 public struct UsageCredits: Codable, Sendable, Equatable {
@@ -107,7 +130,23 @@ public struct UsageCredits: Codable, Sendable, Equatable {
         self.hasCredits = hasCredits
         self.unlimited = unlimited
         let cleanBalance = balance?.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.balance = cleanBalance?.isEmpty == false ? cleanBalance : nil
+        self.balance = (hasCredits || unlimited) && cleanBalance?.isEmpty == false
+            ? cleanBalance : nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case hasCredits
+        case unlimited
+        case balance
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            hasCredits: try container.decodeIfPresent(Bool.self, forKey: .hasCredits) ?? false,
+            unlimited: try container.decodeIfPresent(Bool.self, forKey: .unlimited) ?? false,
+            balance: try container.decodeIfPresent(String.self, forKey: .balance)
+        )
     }
 }
 
@@ -155,7 +194,8 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
 
     public var hasDisplayableData: Bool {
         fiveHour != nil || weekly != nil || !additionalLimits.isEmpty
-            || usageCredits != nil || resetCreditsAvailable != nil
+            || usageCredits?.hasCredits == true || usageCredits?.unlimited == true
+            || usageCredits?.balance != nil || resetCreditsAvailable != nil
     }
 
     public func isStale(at date: Date = Date(), maxAge: TimeInterval) -> Bool {

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
@@ -57,6 +57,60 @@ public struct UsageWindow: Codable, Sendable, Equatable {
     }
 }
 
+public struct UsageLimit: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let name: String
+    public let meteredFeature: String
+    public let allowed: Bool
+    public let limitReached: Bool
+    public let primary: UsageWindow?
+    public let secondary: UsageWindow?
+
+    public init(
+        id: String,
+        name: String = "",
+        meteredFeature: String = "",
+        allowed: Bool = true,
+        limitReached: Bool = false,
+        primary: UsageWindow?,
+        secondary: UsageWindow?
+    ) {
+        self.id = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.meteredFeature = meteredFeature.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.allowed = allowed
+        self.limitReached = limitReached
+        self.primary = primary
+        self.secondary = secondary
+    }
+
+    public var displayName: String {
+        if !name.isEmpty {
+            return name
+        }
+        if !meteredFeature.isEmpty {
+            return meteredFeature
+                .replacingOccurrences(of: "_", with: " ")
+                .replacingOccurrences(of: "-", with: " ")
+                .capitalized
+        }
+        return "Additional usage"
+    }
+}
+
+public struct UsageCredits: Codable, Sendable, Equatable {
+    public let hasCredits: Bool
+    public let unlimited: Bool
+    public let balance: String?
+
+    public init(hasCredits: Bool, unlimited: Bool, balance: String?) {
+        self.hasCredits = hasCredits
+        self.unlimited = unlimited
+        let cleanBalance = balance?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.balance = cleanBalance?.isEmpty == false ? cleanBalance : nil
+    }
+}
+
 public struct UsageSnapshot: Codable, Sendable, Equatable {
     public let planType: String
     public let allowed: Bool
@@ -64,6 +118,8 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
     public let fiveHour: UsageWindow?
     public let weekly: UsageWindow?
     public let resetCreditsAvailable: Int?
+    public let additionalLimits: [UsageLimit]
+    public let usageCredits: UsageCredits?
     public let fetchedAt: Date
 
     public init(
@@ -73,6 +129,8 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
         fiveHour: UsageWindow?,
         weekly: UsageWindow?,
         resetCreditsAvailable: Int? = nil,
+        additionalLimits: [UsageLimit] = [],
+        usageCredits: UsageCredits? = nil,
         fetchedAt: Date
     ) {
         self.planType = planType
@@ -81,14 +139,23 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
         self.fiveHour = fiveHour
         self.weekly = weekly
         self.resetCreditsAvailable = resetCreditsAvailable.map { max(0, $0) }
+        self.additionalLimits = additionalLimits.filter {
+            $0.primary != nil || $0.secondary != nil
+        }
+        self.usageCredits = usageCredits
         self.fetchedAt = fetchedAt
     }
 
     public func nextReset(after date: Date) -> Date? {
-        [fiveHour, weekly]
+        ([fiveHour, weekly] + additionalLimits.flatMap { [$0.primary, $0.secondary] })
             .compactMap { $0?.effectiveResetDate(relativeTo: fetchedAt) }
             .filter { $0 > date }
             .min()
+    }
+
+    public var hasDisplayableData: Bool {
+        fiveHour != nil || weekly != nil || !additionalLimits.isEmpty
+            || usageCredits != nil || resetCreditsAvailable != nil
     }
 
     public func isStale(at date: Date = Date(), maxAge: TimeInterval) -> Bool {
@@ -102,6 +169,8 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
         case fiveHour
         case weekly
         case resetCreditsAvailable
+        case additionalLimits
+        case usageCredits
         case fetchedAt
     }
 
@@ -114,6 +183,8 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
             fiveHour: try container.decodeIfPresent(UsageWindow.self, forKey: .fiveHour),
             weekly: try container.decodeIfPresent(UsageWindow.self, forKey: .weekly),
             resetCreditsAvailable: try container.decodeIfPresent(Int.self, forKey: .resetCreditsAvailable),
+            additionalLimits: try container.decodeIfPresent([UsageLimit].self, forKey: .additionalLimits) ?? [],
+            usageCredits: try container.decodeIfPresent(UsageCredits.self, forKey: .usageCredits),
             fetchedAt: try container.decodeIfPresent(Date.self, forKey: .fetchedAt)
                 ?? Date(timeIntervalSince1970: 0)
         )

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsageParser.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsageParser.swift
@@ -42,80 +42,74 @@ public enum UsageParser {
             secondary = nil
         }
 
-        var additionalCandidates: [Candidate] = []
-        if let additionalLimits = JSONSupport.array(root["additional_rate_limits"]) {
-            for item in additionalLimits {
+        var additionalLimits: [UsageLimit] = []
+        if let rawAdditionalLimits = JSONSupport.array(root["additional_rate_limits"]) {
+            for (index, item) in rawAdditionalLimits.enumerated() {
                 guard let item = JSONSupport.object(item) else {
                     continue
                 }
                 let nested = JSONSupport.object(item["rate_limit"]) ?? item
-                if let window = candidate(from: JSONSupport.object(nested["primary_window"])) {
-                    additionalCandidates.append(window)
-                }
-                if let window = candidate(from: JSONSupport.object(nested["secondary_window"])) {
-                    additionalCandidates.append(window)
+                let additionalPrimary = parseWindow(JSONSupport.object(nested["primary_window"]))
+                let additionalSecondary = parseWindow(JSONSupport.object(nested["secondary_window"]))
+                if additionalPrimary != nil || additionalSecondary != nil {
+                    let name = JSONSupport.string(item["limit_name"])
+                    let feature = JSONSupport.string(item["metered_feature"])
+                    let id = [
+                        JSONSupport.string(item["limit_id"]),
+                        name,
+                        feature,
+                        "additional-\(index)"
+                    ].first { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }!
+                    additionalLimits.append(
+                        UsageLimit(
+                            id: "\(id)-\(index)",
+                            name: name,
+                            meteredFeature: feature,
+                            allowed: JSONSupport.bool(nested["allowed"], default: true),
+                            limitReached: JSONSupport.bool(nested["limit_reached"], default: false),
+                            primary: additionalPrimary,
+                            secondary: additionalSecondary
+                        )
+                    )
                 }
             }
         }
 
-        var fiveHour = nearest(
+        let fiveHour = nearest(
             in: primaryCandidates,
             target: fiveHours,
             range: 10_800 ... 28_800,
             excluding: nil
         )
-        var weekly = nearest(
+        let weekly = nearest(
             in: primaryCandidates,
             target: week,
             range: 432_000 ... 777_600,
             excluding: fiveHour?.id
         )
 
-        if fiveHour == nil {
-            if let primary, primary.id != weekly?.id {
-                fiveHour = primary
-            } else if let secondary, secondary.id != weekly?.id {
-                fiveHour = secondary
-            }
-        }
-
-        if let durationMatchedWeekly = weekly {
-            weekly = durationMatchedWeekly
-        } else if secondary == nil || secondary?.id == fiveHour?.id {
-            weekly = farthestDifferent(in: primaryCandidates, excluding: fiveHour?.id)
-        } else {
-            weekly = secondary
-        }
-
-        if fiveHour == nil {
-            fiveHour = nearest(
-                in: additionalCandidates,
-                target: fiveHours,
-                range: 10_800 ... 28_800,
-                excluding: nil
-            )
-        }
-
-        if weekly == nil {
-            weekly = nearest(
-                in: additionalCandidates,
-                target: week,
-                range: 432_000 ... 777_600,
-                excluding: fiveHour?.id
-            )
-        }
-
-        if fiveHour == nil, let firstAdditional = additionalCandidates.first {
-            fiveHour = firstAdditional
-        }
-        if weekly == nil {
-            weekly = farthestDifferent(in: additionalCandidates, excluding: fiveHour?.id)
-        }
-
         let resetCredits = JSONSupport.object(root["rate_limit_reset_credits"])
         let rawAvailableCount = resetCredits.map {
             JSONSupport.int($0["available_count"], default: -1)
         } ?? -1
+        let usageCredits = JSONSupport.object(root["credits"]).flatMap { credits in
+            guard credits.keys.contains("has_credits")
+                    || credits.keys.contains("unlimited")
+                    || credits.keys.contains("balance") else {
+                return nil
+            }
+            return UsageCredits(
+                hasCredits: JSONSupport.bool(credits["has_credits"], default: false),
+                unlimited: JSONSupport.bool(credits["unlimited"], default: false),
+                balance: {
+                    guard credits.keys.contains("balance"),
+                          !(credits["balance"] is NSNull) else {
+                        return nil
+                    }
+                    return JSONSupport.string(credits["balance"])
+                }()
+            )
+        }
 
         return UsageSnapshot(
             planType: planType,
@@ -124,6 +118,8 @@ public enum UsageParser {
             fiveHour: fiveHour?.window,
             weekly: weekly?.window,
             resetCreditsAvailable: rawAvailableCount >= 0 ? rawAvailableCount : nil,
+            additionalLimits: additionalLimits,
+            usageCredits: usageCredits,
             fetchedAt: fetchedAt
         )
     }
@@ -188,20 +184,6 @@ public enum UsageParser {
                 best = candidate
                 bestDistance = distance
             }
-        }
-        return best
-    }
-
-    private static func farthestDifferent(
-        in candidates: [Candidate],
-        excluding excludedID: Int?
-    ) -> Candidate? {
-        var best: Candidate?
-        var longestDuration: Int64 = -1
-        for candidate in candidates
-        where candidate.id != excludedID && candidate.window.windowSeconds > longestDuration {
-            best = candidate
-            longestDuration = candidate.window.windowSeconds
         }
         return best
     }

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/Fixtures/usage-additional.json
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/Fixtures/usage-additional.json
@@ -2,7 +2,11 @@
   "plan_type": "team",
   "additional_rate_limits": [
     {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_bengalfox",
       "rate_limit": {
+        "allowed": false,
+        "limit_reached": true,
         "primary_window": {
           "used_percent": 150,
           "limit_window_seconds": 18000,
@@ -17,5 +21,10 @@
         }
       }
     }
-  ]
+  ],
+  "credits": {
+    "has_credits": true,
+    "unlimited": false,
+    "balance": "2500.5"
+  }
 }

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageParserTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageParserTests.swift
@@ -121,6 +121,18 @@ final class UsageParserTests: XCTestCase {
         XCTAssertTrue(snapshot.hasDisplayableData)
     }
 
+    func testNoCreditsBalanceIsNotStandaloneUsageData() throws {
+        let snapshot = try UsageParser.parse(
+            """
+            {"credits":{"has_credits":false,"unlimited":false,"balance":"0"}}
+            """,
+            fetchedAt: fetchedAt
+        )
+        XCTAssertNotNil(snapshot.usageCredits)
+        XCTAssertNil(snapshot.usageCredits?.balance)
+        XCTAssertFalse(snapshot.hasDisplayableData)
+    }
+
     func testFiveHourTieChoosesFirstAndDoesNotInventWeeklyWindow() throws {
         let json = """
         {

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageParserTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageParserTests.swift
@@ -36,11 +36,19 @@ final class UsageParserTests: XCTestCase {
             FixtureLoader.data(named: "usage-additional"),
             fetchedAt: fetchedAt
         )
-        XCTAssertEqual(snapshot.fiveHour?.usedPercent, 100)
-        XCTAssertEqual(snapshot.fiveHour?.remainingPercent, 0)
-        XCTAssertEqual(snapshot.fiveHour?.resetAfterSeconds, 0)
-        XCTAssertEqual(snapshot.weekly?.usedPercent, 0)
-        XCTAssertEqual(snapshot.weekly?.remainingPercent, 100)
+        XCTAssertNil(snapshot.fiveHour)
+        XCTAssertNil(snapshot.weekly)
+        let limit = try XCTUnwrap(snapshot.additionalLimits.first)
+        XCTAssertEqual(limit.displayName, "GPT-5.3-Codex-Spark")
+        XCTAssertEqual(limit.meteredFeature, "codex_bengalfox")
+        XCTAssertFalse(limit.allowed)
+        XCTAssertTrue(limit.limitReached)
+        XCTAssertEqual(limit.primary?.usedPercent, 100)
+        XCTAssertEqual(limit.primary?.remainingPercent, 0)
+        XCTAssertEqual(limit.primary?.resetAfterSeconds, 0)
+        XCTAssertEqual(limit.secondary?.usedPercent, 0)
+        XCTAssertEqual(limit.secondary?.remainingPercent, 100)
+        XCTAssertEqual(snapshot.usageCredits?.balance, "2500.5")
     }
 
     func testMainRateLimitTakesPrecedenceOverCloserAdditionalWindow() throws {
@@ -60,20 +68,23 @@ final class UsageParserTests: XCTestCase {
         )
         XCTAssertFalse(snapshot.allowed)
         XCTAssertTrue(snapshot.limitReached)
-        XCTAssertEqual(snapshot.fiveHour?.usedPercent, 45)
-        XCTAssertEqual(snapshot.fiveHour?.resetAfterSeconds, 0)
-        XCTAssertNil(snapshot.fiveHour?.resetAt)
+        XCTAssertNil(snapshot.fiveHour)
         XCTAssertNil(snapshot.weekly)
+        XCTAssertEqual(snapshot.additionalLimits.first?.primary?.usedPercent, 45)
+        XCTAssertEqual(snapshot.additionalLimits.first?.primary?.resetAfterSeconds, 0)
+        XCTAssertNil(snapshot.additionalLimits.first?.primary?.resetAt)
         XCTAssertNil(snapshot.resetCreditsAvailable)
     }
 
-    func testAdditionalLimitsOnlyFillMissingPrimarySlots() throws {
+    func testAdditionalLimitsRemainIndependentFromMissingPrimarySlots() throws {
         let snapshot = try UsageParser.parse(
             FixtureLoader.data(named: "usage-fill-missing"),
             fetchedAt: fetchedAt
         )
-        XCTAssertEqual(snapshot.fiveHour?.usedPercent, 30)
+        XCTAssertNil(snapshot.fiveHour)
         XCTAssertEqual(snapshot.weekly?.usedPercent, 70)
+        XCTAssertEqual(snapshot.additionalLimits.first?.primary?.usedPercent, 30)
+        XCTAssertEqual(snapshot.additionalLimits.first?.secondary?.usedPercent, 99)
     }
 
     func testDefaultsWhenRateLimitIsMissing() throws {
@@ -82,9 +93,35 @@ final class UsageParserTests: XCTestCase {
         XCTAssertFalse(snapshot.limitReached)
         XCTAssertNil(snapshot.fiveHour)
         XCTAssertNil(snapshot.weekly)
+        XCTAssertFalse(snapshot.hasDisplayableData)
     }
 
-    func testTieChoosesFirstWindow() throws {
+    func testWeeklyAndCreditsCanExistWithoutFiveHourWindow() throws {
+        let snapshot = try UsageParser.parse(
+            """
+            {
+              "rate_limit": {
+                "secondary_window": {
+                  "used_percent": 25,
+                  "limit_window_seconds": 604800
+                }
+              },
+              "credits": {
+                "has_credits": true,
+                "unlimited": false,
+                "balance": 2500
+              }
+            }
+            """,
+            fetchedAt: fetchedAt
+        )
+        XCTAssertNil(snapshot.fiveHour)
+        XCTAssertEqual(snapshot.weekly?.usedPercent, 25)
+        XCTAssertEqual(snapshot.usageCredits?.balance, "2500")
+        XCTAssertTrue(snapshot.hasDisplayableData)
+    }
+
+    func testFiveHourTieChoosesFirstAndDoesNotInventWeeklyWindow() throws {
         let json = """
         {
           "rate_limit": {
@@ -95,7 +132,7 @@ final class UsageParserTests: XCTestCase {
         """
         let snapshot = try UsageParser.parse(json, fetchedAt: fetchedAt)
         XCTAssertEqual(snapshot.fiveHour?.usedPercent, 11)
-        XCTAssertEqual(snapshot.weekly?.usedPercent, 22)
+        XCTAssertNil(snapshot.weekly)
     }
 
     func testInvalidRootThrows() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve and render named `additional_rate_limits` such as GPT-5.3-Codex-Spark
- hide missing standard windows instead of showing empty cards
- parse and display purchased usage-credit balances separately from reset credits
- add Android and iOS dashboard visibility controls with safe migration defaults
- extend parser coverage for partial, additional-only, and credit-only responses
- expand the existing Android debug dashboard fixture with Spark and purchased-credit data

## Testing
- `./run-tests.sh`
- `./build.sh` (phone and Wear release APKs; v2 signatures verified)
- `./lint.sh`
- `./gradlew :app:assembleDebug`
- Android 16 Google APIs emulator launched through direct x86_64 QEMU TCG
- manually verified full dashboard rendering and persisted visibility settings
- Swift source compile review completed; Swift is not installed on this Linux image, so `swift test --package-path ios/CodexMeterCore` could not run

## Walkthrough
[Standard and Spark usage cards](https://cursor.com/agents/bc-13c7901f-457f-4465-a02f-f0ccfdf51f15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_standard_and_spark.webp)

[Purchased usage credits and reset credits](https://cursor.com/agents/bc-13c7901f-457f-4465-a02f-f0ccfdf51f15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_usage_and_reset_credits.webp)

[android_dynamic_usage_dashboard_demo.mp4](https://cursor.com/agents/bc-13c7901f-457f-4465-a02f-f0ccfdf51f15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fandroid_dynamic_usage_dashboard_demo.mp4)

[android_dashboard_customization_demo.mp4](https://cursor.com/agents/bc-13c7901f-457f-4465-a02f-f0ccfdf51f15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fandroid_dashboard_customization_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13c7901f-457f-4465-a02f-f0ccfdf51f15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13c7901f-457f-4465-a02f-f0ccfdf51f15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

