### PR TITLE
Add adaptive automatic refresh scheduling

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -17,6 +17,8 @@ public final class AppPreferences {
     private static final String KEY_OAUTH_URL = "oauth_url";
     private static final String KEY_ONBOARDING_COMPLETE = "onboarding_complete";
     private static final String KEY_ONBOARDING_STEP = "onboarding_step";
+    private static final String KEY_AUTOMATIC_REFRESH = "automatic_refresh";
+    private static final String KEY_REFRESH_FAILURES = "refresh_failures";
     private static final String KEY_REFRESH_MINUTES = "refresh_minutes";
     private static final String KEY_REFRESH_ON_LAUNCH = "refresh_on_launch";
     private static final String KEY_RESET_CREDITS = "reset_credits_snapshot";
@@ -59,7 +61,9 @@ public final class AppPreferences {
     }
 
     public static void clearSnapshot(Context context) {
-        prefs(context).edit().remove(KEY_SNAPSHOT).remove(KEY_ERROR).remove(KEY_ERROR_AT).remove(KEY_RESET_CREDITS).remove(KEY_RESET_ERROR).remove(KEY_RESET_ERROR_AT).apply();
+        prefs(context).edit().remove(KEY_SNAPSHOT).remove(KEY_ERROR).remove(KEY_ERROR_AT)
+                .remove(KEY_RESET_CREDITS).remove(KEY_RESET_ERROR).remove(KEY_RESET_ERROR_AT)
+                .remove(KEY_REFRESH_FAILURES).apply();
         NowBarManager.stop(context);
         NowBarPreferences.clearSuppression(context);
         ResetNotificationManager.clearState(context);
@@ -193,6 +197,27 @@ public final class AppPreferences {
             i = 30;
         }
         editorEdit.putInt(KEY_REFRESH_MINUTES, i).apply();
+    }
+
+    public static boolean getAutomaticRefresh(Context context) {
+        return prefs(context).getBoolean(KEY_AUTOMATIC_REFRESH, true);
+    }
+
+    public static void setAutomaticRefresh(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_AUTOMATIC_REFRESH, enabled).apply();
+    }
+
+    public static int getRefreshFailures(Context context) {
+        return Math.max(0, Math.min(3, prefs(context).getInt(KEY_REFRESH_FAILURES, 0)));
+    }
+
+    public static void recordRefreshSuccess(Context context) {
+        prefs(context).edit().remove(KEY_REFRESH_FAILURES).apply();
+    }
+
+    public static void recordRefreshFailure(Context context) {
+        int failures = Math.min(3, getRefreshFailures(context) + 1);
+        prefs(context).edit().putInt(KEY_REFRESH_FAILURES, failures).apply();
     }
 
     public static boolean getRefreshOnLaunch(Context context) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -152,6 +152,7 @@ public final class MainActivity extends AppCompatActivity {
     @SuppressLint({"UnspecifiedRegisterReceiverFlag"})
     protected void onStart() {
         super.onStart();
+        RefreshEngagement.onForeground(this);
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(AppConstants.ACTION_OAUTH_READY);
         intentFilter.addAction(AppConstants.ACTION_OAUTH_RESULT);
@@ -186,6 +187,10 @@ public final class MainActivity extends AppCompatActivity {
 
     @Override // android.app.Activity
     protected void onStop() {
+        RefreshEngagement.onBackground(this);
+        if (AppPreferences.getAutomaticRefresh(this)) {
+            RefreshScheduler.schedulePeriodic(this);
+        }
         if (this.receiverRegistered) {
             try {
                 unregisterReceiver(this.authReceiver);

--- a/android/app/src/main/java/dev/bennett/codexmeter/RefreshEngagement.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/RefreshEngagement.java
@@ -1,0 +1,84 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Stores a decaying attention score instead of an activity history. Recent opens and foreground
+ * time influence automatic refresh without retaining analytics events.
+ */
+public final class RefreshEngagement {
+    private static final long HALF_LIFE_MS = TimeUnit.HOURS.toMillis(6);
+    private static final long OPEN_DEBOUNCE_MS = TimeUnit.MINUTES.toMillis(10);
+    private static final long FOREGROUND_UNIT_MS = TimeUnit.MINUTES.toMillis(10);
+    private static final String KEY_FOREGROUND_AT = "foreground_at";
+    private static final String KEY_LAST_OPEN_AT = "last_open_at";
+    private static final String KEY_SCORE = "score";
+    private static final String KEY_SCORE_AT = "score_at";
+    private static final String PREFS = "codex_meter_refresh_engagement_v1";
+
+    private RefreshEngagement() {
+    }
+
+    public static synchronized void onForeground(Context context) {
+        onForeground(context, System.currentTimeMillis());
+    }
+
+    static synchronized void onForeground(Context context, long nowMillis) {
+        SharedPreferences prefs = prefs(context);
+        double score = decayedScore(prefs, nowMillis);
+        long lastOpen = prefs.getLong(KEY_LAST_OPEN_AT, 0L);
+        SharedPreferences.Editor edit = prefs.edit();
+        if (lastOpen <= 0L || nowMillis - lastOpen >= OPEN_DEBOUNCE_MS) {
+            score += 1.0d;
+            edit.putLong(KEY_LAST_OPEN_AT, nowMillis);
+        }
+        edit.putLong(KEY_FOREGROUND_AT, nowMillis)
+                .putLong(KEY_SCORE_AT, nowMillis)
+                .putLong(KEY_SCORE, Double.doubleToRawLongBits(score))
+                .apply();
+    }
+
+    public static synchronized void onBackground(Context context) {
+        onBackground(context, System.currentTimeMillis());
+    }
+
+    static synchronized void onBackground(Context context, long nowMillis) {
+        SharedPreferences prefs = prefs(context);
+        long foregroundAt = prefs.getLong(KEY_FOREGROUND_AT, 0L);
+        double score = decayedScore(prefs, nowMillis);
+        if (foregroundAt > 0L && nowMillis > foregroundAt) {
+            score += Math.min(6.0d, (double) (nowMillis - foregroundAt) / FOREGROUND_UNIT_MS);
+        }
+        prefs.edit()
+                .remove(KEY_FOREGROUND_AT)
+                .putLong(KEY_SCORE_AT, nowMillis)
+                .putLong(KEY_SCORE, Double.doubleToRawLongBits(score))
+                .apply();
+    }
+
+    public static synchronized double score(Context context, long nowMillis) {
+        SharedPreferences prefs = prefs(context);
+        double score = decayedScore(prefs, nowMillis);
+        long foregroundAt = prefs.getLong(KEY_FOREGROUND_AT, 0L);
+        if (foregroundAt > 0L && nowMillis > foregroundAt) {
+            score += Math.min(6.0d, (double) (nowMillis - foregroundAt) / FOREGROUND_UNIT_MS);
+        }
+        return Math.max(0.0d, score);
+    }
+
+    private static double decayedScore(SharedPreferences prefs, long nowMillis) {
+        double stored = Double.longBitsToDouble(prefs.getLong(
+                KEY_SCORE, Double.doubleToRawLongBits(0.0d)));
+        long scoreAt = prefs.getLong(KEY_SCORE_AT, nowMillis);
+        long elapsed = Math.max(0L, nowMillis - scoreAt);
+        if (!Double.isFinite(stored) || stored <= 0.0d) return 0.0d;
+        return stored * Math.pow(0.5d, (double) elapsed / HALF_LIFE_MS);
+    }
+
+    private static SharedPreferences prefs(Context context) {
+        Context app = context.getApplicationContext();
+        return (app == null ? context : app).getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/RefreshScheduler.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/RefreshScheduler.java
@@ -5,11 +5,13 @@ import android.app.job.JobScheduler;
 import android.content.ComponentName;
 import android.content.Context;
 import android.os.PersistableBundle;
+import java.util.Calendar;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class RefreshScheduler {
     private static final int IMMEDIATE_JOB_ID = 73101;
     private static final int PERIODIC_JOB_ID = 73100;
+    static final String REASON_ADAPTIVE = "adaptive";
     static final String REASON_SHORT_PERIODIC = "short_periodic";
     private static final int RESET_JOB_ID = 73102;
     private static final int SHORT_JOB_ID_A = 73103;
@@ -33,14 +35,24 @@ public final class RefreshScheduler {
             if (jobSchedulerScheduler == null) {
                 AppPreferences.setSchedulerError(contextAppContext, "Android's background scheduler is unavailable.");
             } else {
-                int refreshMinutes = AppPreferences.getRefreshMinutes(contextAppContext);
                 jobSchedulerScheduler.cancel(PERIODIC_JOB_ID);
                 jobSchedulerScheduler.cancel(SHORT_JOB_ID_A);
                 jobSchedulerScheduler.cancel(SHORT_JOB_ID_B);
-                if (refreshMinutes < 15) {
-                    zSubmit = scheduleNextShort(contextAppContext, SHORT_JOB_ID_B);
+                if (AppPreferences.getAutomaticRefresh(contextAppContext)) {
+                    zSubmit = scheduleNextChained(contextAppContext, SHORT_JOB_ID_B,
+                            REASON_ADAPTIVE);
                 } else {
-                    zSubmit = submit(contextAppContext, base(contextAppContext, PERIODIC_JOB_ID, "periodic").setPeriodic(((long) refreshMinutes) * 60 * 1000).setPersisted(true).build());
+                    int refreshMinutes = AppPreferences.getRefreshMinutes(contextAppContext);
+                    if (refreshMinutes < 15) {
+                        zSubmit = scheduleNextChained(contextAppContext, SHORT_JOB_ID_B,
+                                REASON_SHORT_PERIODIC);
+                    } else {
+                        zSubmit = submit(contextAppContext,
+                                base(contextAppContext, PERIODIC_JOB_ID, "periodic")
+                                        .setPeriodic(((long) refreshMinutes) * 60 * 1000)
+                                        .setPersisted(true)
+                                        .build());
+                    }
                 }
             }
             return zSubmit;
@@ -50,7 +62,6 @@ public final class RefreshScheduler {
     }
 
     static boolean scheduleNextShort(Context context, int i) {
-        boolean zSubmit = false;
         Context contextAppContext = appContext(context);
         if (contextAppContext == null) {
             return false;
@@ -58,24 +69,53 @@ public final class RefreshScheduler {
         if (!SecureTokenStore.isSignedIn(contextAppContext)) {
             return true;
         }
-        int refreshMinutes = AppPreferences.getRefreshMinutes(contextAppContext);
-        if (refreshMinutes >= 15) {
+        if (!AppPreferences.getAutomaticRefresh(contextAppContext)
+                && AppPreferences.getRefreshMinutes(contextAppContext) >= 15) {
             return schedulePeriodic(contextAppContext);
         }
+        return scheduleNextChained(contextAppContext, i,
+                AppPreferences.getAutomaticRefresh(contextAppContext)
+                        ? REASON_ADAPTIVE : REASON_SHORT_PERIODIC);
+    }
+
+    private static boolean scheduleNextChained(Context context, int previousJobId,
+            String reason) {
+        boolean zSubmit = false;
+        int refreshMinutes = effectiveRefreshMinutes(context);
         try {
-            JobScheduler jobSchedulerScheduler = scheduler(contextAppContext);
+            JobScheduler jobSchedulerScheduler = scheduler(context);
             if (jobSchedulerScheduler == null) {
-                AppPreferences.setSchedulerError(contextAppContext, "Android's background scheduler is unavailable.");
+                AppPreferences.setSchedulerError(context,
+                        "Android's background scheduler is unavailable.");
             } else {
-                int i2 = i == SHORT_JOB_ID_A ? SHORT_JOB_ID_B : SHORT_JOB_ID_A;
+                int i2 = previousJobId == SHORT_JOB_ID_A ? SHORT_JOB_ID_B : SHORT_JOB_ID_A;
                 jobSchedulerScheduler.cancel(i2);
                 long j = ((long) refreshMinutes) * 60 * 1000;
-                zSubmit = submit(contextAppContext, base(contextAppContext, i2, REASON_SHORT_PERIODIC).setMinimumLatency(j).setOverrideDeadline(j + 300000).build());
+                zSubmit = submit(context,
+                        base(context, i2, reason)
+                                .setMinimumLatency(j)
+                                .setOverrideDeadline(j + 300000)
+                                .build());
             }
             return zSubmit;
         } catch (RuntimeException e) {
-            return failed(contextAppContext, e);
+            return failed(context, e);
         }
+    }
+
+    public static int effectiveRefreshMinutes(Context context) {
+        Context app = appContext(context);
+        if (app == null || !AppPreferences.getAutomaticRefresh(app)) {
+            return app == null ? 30 : AppPreferences.getRefreshMinutes(app);
+        }
+        long now = System.currentTimeMillis();
+        int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
+        return AdaptiveRefreshPolicy.chooseMinutes(
+                AppPreferences.loadSnapshot(app),
+                RefreshEngagement.score(app, now),
+                hour,
+                AppPreferences.getRefreshFailures(app),
+                now);
     }
 
     public static boolean scheduleImmediate(Context context) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -259,10 +259,15 @@ public final class SettingsActivity extends AppCompatActivity {
             findPreference("settings_appearance").setSummary(themeLabel + " · Material You "
                     + (AppPreferences.isMaterialYouEnabled(requireContext()) ? "on" : "off"));
 
-            int refreshMinutes = AppPreferences.getRefreshMinutes(requireContext());
+            int refreshMinutes = AppPreferences.getAutomaticRefresh(requireContext())
+                    ? RefreshScheduler.effectiveRefreshMinutes(requireContext())
+                    : AppPreferences.getRefreshMinutes(requireContext());
             String refreshLabel = refreshMinutes < 60
                     ? refreshMinutes + " minutes"
                     : refreshMinutes == 60 ? "Hourly" : "Every " + (refreshMinutes / 60) + " hours";
+            if (AppPreferences.getAutomaticRefresh(requireContext())) {
+                refreshLabel = "Automatic · currently " + refreshLabel;
+            }
             String estimatesSummary;
             if (!UsagePacePreferences.isEnabled(requireContext())) {
                 estimatesSummary = "Estimates off";
@@ -430,9 +435,24 @@ public final class SettingsActivity extends AppCompatActivity {
             });
 
             ListPreference interval = findPreference("refresh_interval_ui");
+            interval.setPersistent(false);
             interval.setValue(String.valueOf(AppPreferences.getRefreshMinutes(requireContext())));
+            interval.setEnabled(!AppPreferences.getAutomaticRefresh(requireContext()));
             interval.setOnPreferenceChangeListener((preference, value) -> {
                 AppPreferences.setRefreshMinutes(requireContext(), Integer.parseInt(String.valueOf(value)));
+                RefreshScheduler.schedulePeriodic(requireContext());
+                PhoneWearSync.pushSettings(requireContext());
+                return true;
+            });
+
+            ListPreference mode = findPreference("refresh_mode_ui");
+            mode.setPersistent(false);
+            mode.setValue(AppPreferences.getAutomaticRefresh(requireContext())
+                    ? "automatic" : "manual");
+            mode.setOnPreferenceChangeListener((preference, value) -> {
+                boolean automatic = "automatic".equals(String.valueOf(value));
+                AppPreferences.setAutomaticRefresh(requireContext(), automatic);
+                interval.setEnabled(!automatic);
                 RefreshScheduler.schedulePeriodic(requireContext());
                 PhoneWearSync.pushSettings(requireContext());
                 return true;

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -171,6 +171,7 @@ public final class SettingsTransferStore {
         JSONObject json = new JSONObject();
         json.put("app_theme", AppPreferences.getAppTheme(context));
         json.put("material_you", AppPreferences.isMaterialYouEnabled(context));
+        json.put("automatic_refresh", AppPreferences.getAutomaticRefresh(context));
         json.put("refresh_minutes", AppPreferences.getRefreshMinutes(context));
         json.put("refresh_on_launch", AppPreferences.getRefreshOnLaunch(context));
         json.put("usage_pace_enabled", UsagePacePreferences.isEnabled(context));
@@ -216,6 +217,8 @@ public final class SettingsTransferStore {
         AppPreferences.setAppTheme(context, theme);
         AppPreferences.setMaterialYouEnabled(context,
                 json.optBoolean("material_you", previousMaterialYou));
+        AppPreferences.setAutomaticRefresh(context, json.optBoolean("automatic_refresh",
+                AppPreferences.getAutomaticRefresh(context)));
         AppPreferences.setRefreshMinutes(context, json.optInt("refresh_minutes",
                 AppPreferences.getRefreshMinutes(context)));
         AppPreferences.setRefreshOnLaunch(context, json.optBoolean("refresh_on_launch",

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageRefreshJobService.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageRefreshJobService.java
@@ -61,13 +61,16 @@ public final class UsageRefreshJobService extends JobService {
 
     private final class JobRun implements Runnable {
         private final JobParameters params;
-        private final boolean shortCycle;
+        private final boolean chainedCycle;
         private volatile boolean stopped;
         private FutureTask<Void> task;
 
         JobRun(JobParameters jobParameters) {
             this.params = jobParameters;
-            this.shortCycle = "short_periodic".equals(jobParameters.getExtras() == null ? "" : jobParameters.getExtras().getString("reason", ""));
+            String reason = jobParameters.getExtras() == null
+                    ? "" : jobParameters.getExtras().getString("reason", "");
+            this.chainedCycle = RefreshScheduler.REASON_SHORT_PERIODIC.equals(reason)
+                    || RefreshScheduler.REASON_ADAPTIVE.equals(reason);
         }
 
         @Override // java.lang.Runnable
@@ -75,25 +78,27 @@ public final class UsageRefreshJobService extends JobService {
             try {
                 try {
                     RefreshScheduler.scheduleAtNextReset(UsageRefreshJobService.this.getApplicationContext(), UsageApi.refreshAndCache(UsageRefreshJobService.this.getApplicationContext()));
+                    AppPreferences.recordRefreshSuccess(
+                            UsageRefreshJobService.this.getApplicationContext());
                     WidgetRenderer.updateAll(UsageRefreshJobService.this.getApplicationContext());
                     UsageRefreshJobService.this.active.remove(Integer.valueOf(this.params.getJobId()), this);
                     if (!this.stopped) {
                         UsageRefreshJobService usageRefreshJobService = UsageRefreshJobService.this;
                         JobParameters jobParameters = this.params;
-                        if (this.shortCycle) {
-                        }
                         usageRefreshJobService.jobFinished(jobParameters, false);
-                        if (this.shortCycle && SecureTokenStore.isSignedIn(UsageRefreshJobService.this.getApplicationContext())) {
+                        if (this.chainedCycle && SecureTokenStore.isSignedIn(UsageRefreshJobService.this.getApplicationContext())) {
                             RefreshScheduler.scheduleNextShort(UsageRefreshJobService.this.getApplicationContext(), this.params.getJobId());
                         }
                     }
                 } catch (Exception e) {
                     AppPreferences.setLastError(UsageRefreshJobService.this.getApplicationContext(), UsageRefreshJobService.safeMessage(e));
+                    AppPreferences.recordRefreshFailure(
+                            UsageRefreshJobService.this.getApplicationContext());
                     WidgetRenderer.updateAll(UsageRefreshJobService.this.getApplicationContext());
                     UsageRefreshJobService.this.active.remove(Integer.valueOf(this.params.getJobId()), this);
                     if (!this.stopped) {
-                        UsageRefreshJobService.this.jobFinished(this.params, !this.shortCycle);
-                        if (this.shortCycle && SecureTokenStore.isSignedIn(UsageRefreshJobService.this.getApplicationContext())) {
+                        UsageRefreshJobService.this.jobFinished(this.params, !this.chainedCycle);
+                        if (this.chainedCycle && SecureTokenStore.isSignedIn(UsageRefreshJobService.this.getApplicationContext())) {
                             RefreshScheduler.scheduleNextShort(UsageRefreshJobService.this.getApplicationContext(), this.params.getJobId());
                         }
                     }
@@ -104,10 +109,8 @@ public final class UsageRefreshJobService extends JobService {
                 if (!this.stopped) {
                     UsageRefreshJobService usageRefreshJobService2 = UsageRefreshJobService.this;
                     JobParameters jobParameters2 = this.params;
-                    if (this.shortCycle) {
-                    }
                     usageRefreshJobService2.jobFinished(jobParameters2, false);
-                    if (this.shortCycle && SecureTokenStore.isSignedIn(UsageRefreshJobService.this.getApplicationContext())) {
+                    if (this.chainedCycle && SecureTokenStore.isSignedIn(UsageRefreshJobService.this.getApplicationContext())) {
                         RefreshScheduler.scheduleNextShort(UsageRefreshJobService.this.getApplicationContext(), this.params.getJobId());
                     }
                 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/wear/PhoneWearSync.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/wear/PhoneWearSync.java
@@ -10,6 +10,7 @@ import com.google.android.gms.wearable.Wearable;
 import dev.bennett.codexmeter.AppPreferences;
 import dev.bennett.codexmeter.NowBarManager;
 import dev.bennett.codexmeter.NowBarPreferences;
+import dev.bennett.codexmeter.RefreshScheduler;
 import dev.bennett.codexmeter.SecureTokenStore;
 import dev.bennett.codexmeter.UsageSnapshot;
 import dev.bennett.codexmeter.UsagePacePreferences;
@@ -152,7 +153,7 @@ public final class PhoneWearSync {
                 NowBarPreferences.getMetric(context),
                 NowBarPreferences.getThreshold(context),
                 NowBarManager.isActive(context),
-                AppPreferences.getRefreshMinutes(context),
+                RefreshScheduler.effectiveRefreshMinutes(context),
                 updatedAtMillis,
                 WearSettingsState.SOURCE_PHONE,
                 context.getPackageName(),

--- a/android/app/src/main/res/values/settings_arrays.xml
+++ b/android/app/src/main/res/values/settings_arrays.xml
@@ -17,6 +17,12 @@
         <item>5 minutes</item><item>10 minutes</item><item>15 minutes</item>
         <item>30 minutes</item><item>60 minutes</item><item>2 hours</item>
     </string-array>
+    <string-array name="settings_refresh_mode_entries">
+        <item>Automatic</item><item>Manual</item>
+    </string-array>
+    <string-array name="settings_refresh_mode_values">
+        <item>automatic</item><item>manual</item>
+    </string-array>
     <string-array name="settings_refresh_values">
         <item>5</item><item>10</item><item>15</item><item>30</item><item>60</item><item>120</item>
     </string-array>

--- a/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
+++ b/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
@@ -7,10 +7,16 @@
             android:key="refresh_on_launch"
             android:title="Refresh on launch" />
         <ListPreference
+            android:entries="@array/settings_refresh_mode_entries"
+            android:entryValues="@array/settings_refresh_mode_values"
+            android:key="refresh_mode_ui"
+            android:summary="Adapts to remaining usage, app attention, reset timing, and recent failures"
+            android:title="Refresh mode" />
+        <ListPreference
             android:entries="@array/settings_refresh_entries"
             android:entryValues="@array/settings_refresh_values"
             android:key="refresh_interval_ui"
-            android:title="Refresh interval"
+            android:title="Manual interval"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -29,6 +29,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/AdaptiveRefreshPolicy.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarPercentMode.java" \

--- a/android/shared/src/main/java/dev/bennett/codexmeter/AdaptiveRefreshPolicy.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/AdaptiveRefreshPolicy.java
@@ -1,0 +1,105 @@
+package dev.bennett.codexmeter;
+
+import java.util.concurrent.TimeUnit;
+
+/** Pure, low-cost policy for selecting the next automatic usage refresh. */
+public final class AdaptiveRefreshPolicy {
+    private static final int[] INTERVALS = {5, 10, 15, 30, 60, 120};
+
+    private AdaptiveRefreshPolicy() {
+    }
+
+    public static int chooseMinutes(UsageSnapshot snapshot, double attentionScore,
+            int localHour, int consecutiveFailures, long nowMillis) {
+        UsageWindow fiveHour = snapshot == null ? null
+                : UsageSnapshot.currentWindow(snapshot.fiveHour, snapshot.fetchedAtMillis,
+                        nowMillis);
+        UsageWindow weekly = snapshot == null ? null
+                : UsageSnapshot.currentWindow(snapshot.weekly, snapshot.fetchedAtMillis,
+                        nowMillis);
+        int remaining = minimumRemaining(fiveHour, weekly);
+        boolean limited = snapshot != null && (!snapshot.allowed || snapshot.limitReached);
+
+        int minutes;
+        if (limited || remaining <= 10) {
+            minutes = 5;
+        } else if (remaining <= 25) {
+            minutes = 10;
+        } else if (remaining <= 50) {
+            minutes = 15;
+        } else if (remaining <= 75) {
+            minutes = 30;
+        } else if (remaining <= 100) {
+            minutes = 60;
+        } else {
+            minutes = 30;
+        }
+
+        long nextUsedReset = nextUsedReset(fiveHour, weekly,
+                snapshot == null ? 0L : snapshot.fetchedAtMillis, nowMillis);
+        long untilReset = nextUsedReset <= nowMillis ? Long.MAX_VALUE : nextUsedReset - nowMillis;
+        if (untilReset <= TimeUnit.MINUTES.toMillis(15)) {
+            minutes = Math.min(minutes, 5);
+        } else if (untilReset <= TimeUnit.HOURS.toMillis(1)) {
+            minutes = Math.min(minutes, 10);
+        }
+
+        if (snapshot != null
+                && UsagePace.mostAcceleratedWindow(snapshot, nowMillis, UsagePace.BALANCED)
+                != UsagePace.WINDOW_NONE) {
+            minutes = Math.min(minutes, 10);
+        }
+
+        double attention = Math.max(0.0d, attentionScore);
+        if (attention >= 6.0d) {
+            minutes = Math.min(minutes, 5);
+        } else if (attention >= 3.0d) {
+            minutes = Math.min(minutes, 10);
+        } else if (attention >= 1.5d) {
+            minutes = Math.min(minutes, 15);
+        } else if (attention >= 0.5d) {
+            minutes = Math.min(minutes, 30);
+        }
+
+        boolean urgent = limited || remaining <= 25
+                || untilReset <= TimeUnit.HOURS.toMillis(1);
+        int hour = Math.max(0, Math.min(23, localHour));
+        if (!urgent && attention < 0.5d && hour >= 1 && hour < 6) {
+            minutes = Math.max(minutes, 120);
+        }
+
+        int failures = Math.max(0, Math.min(3, consecutiveFailures));
+        for (int i = 0; i < failures; i++) {
+            minutes = nextSlower(minutes);
+        }
+        return urgent ? Math.min(minutes, 30) : Math.min(minutes, 120);
+    }
+
+    private static int minimumRemaining(UsageWindow first, UsageWindow second) {
+        int remaining = 101;
+        if (first != null) remaining = Math.min(remaining, first.remainingPercent());
+        if (second != null) remaining = Math.min(remaining, second.remainingPercent());
+        return remaining;
+    }
+
+    private static long nextUsedReset(UsageWindow first, UsageWindow second,
+            long observedAtMillis, long nowMillis) {
+        long next = Long.MAX_VALUE;
+        if (first != null && first.usedPercent > 0) {
+            long reset = first.effectiveResetAtMillis(observedAtMillis);
+            if (reset > nowMillis) next = Math.min(next, reset);
+        }
+        if (second != null && second.usedPercent > 0) {
+            long reset = second.effectiveResetAtMillis(observedAtMillis);
+            if (reset > nowMillis) next = Math.min(next, reset);
+        }
+        return next == Long.MAX_VALUE ? 0L : next;
+    }
+
+    private static int nextSlower(int minutes) {
+        for (int interval : INTERVALS) {
+            if (interval > minutes) return interval;
+        }
+        return INTERVALS[INTERVALS.length - 1];
+    }
+}

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -25,6 +25,7 @@ public final class ParserSelfTest {
         testResetCreditExpiryOrdering();
         testFullWindowHidesResetCountdown();
         testUsagePace();
+        testAdaptiveRefreshPolicy();
         testNowBarAutoStart();
         testNowBarDisplayModes();
         testWearSurfaceModes();
@@ -131,6 +132,54 @@ public final class ParserSelfTest {
         check(!UsagePace.assess(fastWeekly, now, fast.resetAtMillis, UsagePace.BALANCED).available,
                 "expired windows do not produce stale warnings");
         System.out.println("Usage-pace demo: 15% of a week in one hour projects about 6h 40m.");
+    }
+
+    private static void testAdaptiveRefreshPolicy() {
+        long now = 2_000_000_000_000L;
+        UsageWindow healthy = new UsageWindow(5, TimeUnit.HOURS.toSeconds(5), 0L,
+                (now + TimeUnit.HOURS.toMillis(4)) / 1000L);
+        UsageWindow mid = new UsageWindow(60, TimeUnit.HOURS.toSeconds(5), 0L,
+                (now + TimeUnit.HOURS.toMillis(3)) / 1000L);
+        UsageWindow low = new UsageWindow(92, TimeUnit.HOURS.toSeconds(5), 0L,
+                (now + TimeUnit.HOURS.toMillis(2)) / 1000L);
+        UsageWindow nearReset = new UsageWindow(20, TimeUnit.HOURS.toSeconds(5), 0L,
+                (now + TimeUnit.MINUTES.toMillis(10)) / 1000L);
+
+        check(AdaptiveRefreshPolicy.chooseMinutes(null, 0.0d, 12, 0, now) == 30,
+                "automatic refresh uses a balanced interval before data exists");
+        check(AdaptiveRefreshPolicy.chooseMinutes(
+                        new UsageSnapshot("plus", true, false, healthy, null, now),
+                        0.0d, 12, 0, now) == 60,
+                "healthy quota refreshes less often");
+        check(AdaptiveRefreshPolicy.chooseMinutes(
+                        new UsageSnapshot("plus", true, false, mid, null, now),
+                        0.0d, 12, 0, now) == 15,
+                "lower quota increases refresh frequency");
+        check(AdaptiveRefreshPolicy.chooseMinutes(
+                        new UsageSnapshot("plus", true, false, low, null, now),
+                        0.0d, 12, 0, now) == 5,
+                "critical quota uses the fastest interval");
+        check(AdaptiveRefreshPolicy.chooseMinutes(
+                        new UsageSnapshot("plus", true, false, healthy, null, now),
+                        3.0d, 12, 0, now) == 10,
+                "frequent attention increases refresh frequency");
+        check(AdaptiveRefreshPolicy.chooseMinutes(
+                        new UsageSnapshot("plus", true, false, healthy, null, now),
+                        0.0d, 3, 0, now) == 120,
+                "quiet hours reduce healthy unattended polling");
+        check(AdaptiveRefreshPolicy.chooseMinutes(
+                        new UsageSnapshot("plus", true, false, nearReset, null, now),
+                        0.0d, 12, 0, now) == 5,
+                "an approaching used-window reset refreshes precisely");
+        check(AdaptiveRefreshPolicy.chooseMinutes(
+                        new UsageSnapshot("plus", true, false, low, null, now),
+                        0.0d, 12, 2, now) == 15,
+                "consecutive failures back off even when quota is low");
+        check(AdaptiveRefreshPolicy.chooseMinutes(
+                        new UsageSnapshot("plus", false, true, low, null, now),
+                        0.0d, 12, 3, now) == 30,
+                "failure backoff remains bounded for a limited account");
+        System.out.println("Automatic refresh demo: quota, attention, resets, quiet hours, and failures adapt the cadence.");
     }
 
     private static void testNowBarAutoStart() {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -139,7 +139,7 @@ public final class ParserSelfTest {
         UsageWindow healthy = new UsageWindow(5, TimeUnit.HOURS.toSeconds(5), 0L,
                 (now + TimeUnit.HOURS.toMillis(4)) / 1000L);
         UsageWindow mid = new UsageWindow(60, TimeUnit.HOURS.toSeconds(5), 0L,
-                (now + TimeUnit.HOURS.toMillis(3)) / 1000L);
+                (now + TimeUnit.HOURS.toMillis(2)) / 1000L);
         UsageWindow low = new UsageWindow(92, TimeUnit.HOURS.toSeconds(5), 0L,
                 (now + TimeUnit.HOURS.toMillis(2)) / 1000L);
         UsageWindow nearReset = new UsageWindow(20, TimeUnit.HOURS.toSeconds(5), 0L,

--- a/ios/CodexMeter/AppModel.swift
+++ b/ios/CodexMeter/AppModel.swift
@@ -79,6 +79,7 @@ final class AppModel {
     private let cache: AppCacheStore
     private let settingsStore: AppSettingsStore
     private let notificationCoordinator: NotificationCoordinator
+    private let refreshEngagementStore: RefreshEngagementStore
     private let defaults: UserDefaults
     private var hasStarted = false
     private var hasFinishedStartup = false
@@ -104,6 +105,7 @@ final class AppModel {
         settingsStore: AppSettingsStore = AppSettingsStore(),
         notificationCoordinator: NotificationCoordinator = NotificationCoordinator(),
         defaults: UserDefaults = .standard,
+        refreshEngagementStore: RefreshEngagementStore? = nil,
         preview: Bool = false
     ) {
         self.liveService = liveService
@@ -112,6 +114,8 @@ final class AppModel {
         self.settingsStore = settingsStore
         self.notificationCoordinator = notificationCoordinator
         self.defaults = defaults
+        self.refreshEngagementStore = refreshEngagementStore
+            ?? RefreshEngagementStore(defaults: defaults)
         self.settings = settingsStore.settings
         self.isPreview = preview
 
@@ -232,14 +236,17 @@ final class AppModel {
 
         do {
             let snapshot = try await activeService.refresh()
+            refreshEngagementStore.recordRefreshSuccess()
             await apply(refresh: snapshot)
         } catch is CancellationError {
             return
         } catch {
+            refreshEngagementStore.recordRefreshFailure()
             visibleError = error.localizedDescription
             if let cached = try? await cache.load() {
                 apply(cache: cached, preservingVisibleError: true)
             }
+            scheduleBackgroundRefresh()
         }
     }
 
@@ -479,6 +486,7 @@ final class AppModel {
     }
 
     func sceneBecameActive() async {
+        refreshEngagementStore.recordForeground()
         await refreshNotificationPermissionState()
         guard hasStarted else {
             await startIfNeeded()
@@ -488,6 +496,11 @@ final class AppModel {
         if usage == nil || usage?.isStale(at: .now, maxAge: 5 * 60) == true {
             await refresh()
         }
+    }
+
+    func sceneBecameInactive() {
+        refreshEngagementStore.recordBackground()
+        scheduleBackgroundRefresh()
     }
 
     private var activeService: any CodexService {
@@ -564,9 +577,23 @@ final class AppModel {
             if mode != .live { backgroundRefreshCoordinator.cancel() }
             return
         }
+        let now = Date()
         try? backgroundRefreshCoordinator.schedule(
-            preferredMinutes: settings.refreshMinutes,
+            preferredMinutes: effectiveRefreshMinutes(at: now),
             nextReset: usage?.nextReset(after: .now)
+        )
+    }
+
+    private func effectiveRefreshMinutes(at date: Date) -> Int {
+        guard settings.refreshMode == .automatic else {
+            return settings.refreshMinutes
+        }
+        return AdaptiveRefreshPolicy.chooseMinutes(
+            snapshot: usage,
+            attentionScore: refreshEngagementStore.attentionScore(at: date),
+            localHour: Calendar.current.component(.hour, from: date),
+            consecutiveFailures: refreshEngagementStore.consecutiveFailures,
+            now: date
         )
     }
 
@@ -596,11 +623,23 @@ final class AppModel {
             defaults.set(AppMode.live.rawValue, forKey: Self.modeDefaultsKey)
             apply(tokens: tokens)
         }
-        let refreshed = try await liveService.refresh()
-        await apply(refresh: refreshed)
-        return BackgroundRefreshOutcome(
-            preferredMinutes: settings.refreshMinutes,
-            nextReset: refreshed.usage.nextReset(after: .now)
-        )
+        do {
+            let refreshed = try await liveService.refresh()
+            refreshEngagementStore.recordRefreshSuccess()
+            await apply(refresh: refreshed)
+            let now = Date()
+            return BackgroundRefreshOutcome(
+                preferredMinutes: effectiveRefreshMinutes(at: now),
+                nextReset: refreshed.usage.nextReset(after: now)
+            )
+        } catch {
+            refreshEngagementStore.recordRefreshFailure()
+            let now = Date()
+            return BackgroundRefreshOutcome(
+                preferredMinutes: effectiveRefreshMinutes(at: now),
+                nextReset: usage?.nextReset(after: now),
+                succeeded: false
+            )
+        }
     }
 }

--- a/ios/CodexMeter/CodexMeterApp.swift
+++ b/ios/CodexMeter/CodexMeterApp.swift
@@ -67,8 +67,11 @@ struct CodexMeterApp: App {
                 }
         }
         .onChange(of: scenePhase) { _, phase in
-            guard phase == .active else { return }
-            Task { await model.sceneBecameActive() }
+            if phase == .active {
+                Task { await model.sceneBecameActive() }
+            } else {
+                model.sceneBecameInactive()
+            }
         }
     }
 }

--- a/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
+++ b/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
@@ -32,6 +32,13 @@ nonisolated public enum AlertMetric: String, Codable, Sendable, CaseIterable, Id
     }
 }
 
+nonisolated public enum RefreshMode: String, Codable, Sendable, CaseIterable, Identifiable {
+    case automatic
+    case manual
+
+    public var id: String { rawValue }
+}
+
 nonisolated public struct AppSettings: Codable, Sendable, Equatable {
     public static let allowedRefreshMinutes = [5, 10, 15, 30, 60, 120]
     public static let allowedAlertThresholds = [100, 10, 25, 50, 75]
@@ -42,6 +49,7 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
 
     public var appearance: AppAppearance
     public var refreshOnLaunch: Bool
+    public var refreshMode: RefreshMode
     public var refreshMinutes: Int
     public var notificationsEnabled: Bool
     public var alertMetric: AlertMetric
@@ -56,6 +64,7 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
     public init(
         appearance: AppAppearance = .system,
         refreshOnLaunch: Bool = true,
+        refreshMode: RefreshMode = .automatic,
         refreshMinutes: Int = 30,
         notificationsEnabled: Bool = false,
         alertMetric: AlertMetric = .both,
@@ -67,6 +76,7 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
     ) {
         self.appearance = appearance
         self.refreshOnLaunch = refreshOnLaunch
+        self.refreshMode = refreshMode
         self.refreshMinutes = Self.allowedRefreshMinutes.contains(refreshMinutes) ? refreshMinutes : 30
         self.notificationsEnabled = notificationsEnabled
         self.alertMetric = alertMetric
@@ -100,6 +110,7 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case appearance
         case refreshOnLaunch
+        case refreshMode
         case refreshMinutes
         case notificationsEnabled
         case alertMetric
@@ -115,6 +126,7 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         self.init(
             appearance: try container.decodeIfPresent(AppAppearance.self, forKey: .appearance) ?? .system,
             refreshOnLaunch: try container.decodeIfPresent(Bool.self, forKey: .refreshOnLaunch) ?? true,
+            refreshMode: try container.decodeIfPresent(RefreshMode.self, forKey: .refreshMode) ?? .automatic,
             refreshMinutes: try container.decodeIfPresent(Int.self, forKey: .refreshMinutes) ?? 30,
             notificationsEnabled: try container.decodeIfPresent(Bool.self, forKey: .notificationsEnabled) ?? false,
             alertMetric: try container.decodeIfPresent(AlertMetric.self, forKey: .alertMetric) ?? .both,
@@ -158,6 +170,11 @@ public final class AppSettingsStore: ObservableObject {
         set { settings.refreshOnLaunch = newValue }
     }
 
+    public var refreshMode: RefreshMode {
+        get { settings.refreshMode }
+        set { settings.refreshMode = newValue }
+    }
+
     public var refreshMinutes: Int {
         get { settings.refreshMinutes }
         set {
@@ -191,5 +208,78 @@ public final class AppSettingsStore: ObservableObject {
     private func persist() {
         guard let data = try? JSONEncoder().encode(settings) else { return }
         defaults.set(data, forKey: Self.storageKey)
+    }
+}
+
+@MainActor
+final class RefreshEngagementStore {
+    private static let foregroundKey = "codex-meter.refresh-foreground-at-v1"
+    private static let lastOpenKey = "codex-meter.refresh-last-open-at-v1"
+    private static let scoreKey = "codex-meter.refresh-attention-score-v1"
+    private static let scoreDateKey = "codex-meter.refresh-attention-score-date-v1"
+    private static let failuresKey = "codex-meter.refresh-failures-v1"
+    private static let halfLife: TimeInterval = 6 * 60 * 60
+    private static let openDebounce: TimeInterval = 10 * 60
+    private static let foregroundUnit: TimeInterval = 10 * 60
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func recordForeground(at date: Date = Date()) {
+        var score = decayedScore(at: date)
+        let lastOpen = defaults.double(forKey: Self.lastOpenKey)
+        if lastOpen <= 0 || date.timeIntervalSince1970 - lastOpen >= Self.openDebounce {
+            score += 1
+            defaults.set(date.timeIntervalSince1970, forKey: Self.lastOpenKey)
+        }
+        save(score: score, at: date)
+        defaults.set(date.timeIntervalSince1970, forKey: Self.foregroundKey)
+    }
+
+    func recordBackground(at date: Date = Date()) {
+        var score = decayedScore(at: date)
+        let foregroundAt = defaults.double(forKey: Self.foregroundKey)
+        if foregroundAt > 0, date.timeIntervalSince1970 > foregroundAt {
+            score += min(6, (date.timeIntervalSince1970 - foregroundAt) / Self.foregroundUnit)
+        }
+        save(score: score, at: date)
+        defaults.removeObject(forKey: Self.foregroundKey)
+    }
+
+    func attentionScore(at date: Date = Date()) -> Double {
+        var score = decayedScore(at: date)
+        let foregroundAt = defaults.double(forKey: Self.foregroundKey)
+        if foregroundAt > 0, date.timeIntervalSince1970 > foregroundAt {
+            score += min(6, (date.timeIntervalSince1970 - foregroundAt) / Self.foregroundUnit)
+        }
+        return max(0, score)
+    }
+
+    var consecutiveFailures: Int {
+        min(3, max(0, defaults.integer(forKey: Self.failuresKey)))
+    }
+
+    func recordRefreshSuccess() {
+        defaults.removeObject(forKey: Self.failuresKey)
+    }
+
+    func recordRefreshFailure() {
+        defaults.set(min(3, consecutiveFailures + 1), forKey: Self.failuresKey)
+    }
+
+    private func decayedScore(at date: Date) -> Double {
+        let score = defaults.double(forKey: Self.scoreKey)
+        let scoreDate = defaults.double(forKey: Self.scoreDateKey)
+        guard score.isFinite, score > 0, scoreDate > 0 else { return 0 }
+        let elapsed = max(0, date.timeIntervalSince1970 - scoreDate)
+        return score * pow(0.5, elapsed / Self.halfLife)
+    }
+
+    private func save(score: Double, at date: Date) {
+        defaults.set(max(0, score), forKey: Self.scoreKey)
+        defaults.set(date.timeIntervalSince1970, forKey: Self.scoreDateKey)
     }
 }

--- a/ios/CodexMeter/Infrastructure/BackgroundRefreshCoordinator.swift
+++ b/ios/CodexMeter/Infrastructure/BackgroundRefreshCoordinator.swift
@@ -4,12 +4,14 @@ import Foundation
 nonisolated public struct BackgroundRefreshOutcome: Sendable, Equatable {
     public let preferredMinutes: Int
     public let nextReset: Date?
+    public let succeeded: Bool
 
-    public init(preferredMinutes: Int, nextReset: Date?) {
+    public init(preferredMinutes: Int, nextReset: Date?, succeeded: Bool = true) {
         self.preferredMinutes = AppSettings.allowedRefreshMinutes.contains(preferredMinutes)
             ? preferredMinutes
             : 30
         self.nextReset = nextReset
+        self.succeeded = succeeded
     }
 }
 
@@ -129,7 +131,9 @@ public final class BackgroundRefreshCoordinator {
                     }
                 }
                 let isCurrent = self?.runGate.isCurrent(generation) == true
-                task.setTaskCompleted(success: !Task.isCancelled && isCurrent)
+                task.setTaskCompleted(
+                    success: outcome.succeeded && !Task.isCancelled && isCurrent
+                )
             } catch {
                 if let self, self.runGate.isCurrent(generation) {
                     try? self.schedule(

--- a/ios/CodexMeter/Views/SettingsView.swift
+++ b/ios/CodexMeter/Views/SettingsView.swift
@@ -46,15 +46,23 @@ struct SettingsView: View {
 
             Section {
                 Toggle("Refresh on launch", isOn: $model.settings.refreshOnLaunch)
-                Picker("Preferred interval", selection: $model.settings.refreshMinutes) {
-                    ForEach([5, 10, 15, 30, 60, 120], id: \.self) { minutes in
-                        Text(minutes == 120 ? "2 hours" : "\(minutes) minutes").tag(minutes)
+                Picker("Mode", selection: $model.settings.refreshMode) {
+                    Text("Automatic").tag(RefreshMode.automatic)
+                    Text("Manual").tag(RefreshMode.manual)
+                }
+                if model.settings.refreshMode == .manual {
+                    Picker("Preferred interval", selection: $model.settings.refreshMinutes) {
+                        ForEach(AppSettings.allowedRefreshMinutes, id: \.self) { minutes in
+                            Text(minutes == 120 ? "2 hours" : "\(minutes) minutes").tag(minutes)
+                        }
                     }
                 }
             } header: {
                 Text("Refresh")
             } footer: {
-                Text("iOS decides when background work runs. This interval is an earliest preference, not a guaranteed schedule.")
+                Text(model.settings.refreshMode == .automatic
+                    ? "Automatic adapts on device to remaining usage, app attention, reset timing, quiet hours, and recent failures. iOS still decides when background work runs."
+                    : "iOS decides when background work runs. This interval is an earliest preference, not a guaranteed schedule.")
             }
 
             Section {

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/AdaptiveRefreshPolicy.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/AdaptiveRefreshPolicy.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+public enum AdaptiveRefreshPolicy {
+    private static let intervals = [5, 10, 15, 30, 60, 120]
+
+    public static func chooseMinutes(
+        snapshot: UsageSnapshot?,
+        attentionScore: Double,
+        localHour: Int,
+        consecutiveFailures: Int,
+        now: Date = Date()
+    ) -> Int {
+        let windows = [snapshot?.fiveHour, snapshot?.weekly]
+            .compactMap { $0 }
+            .filter {
+                guard let reset = $0.effectiveResetDate(relativeTo: snapshot?.fetchedAt ?? now) else {
+                    return true
+                }
+                return reset > now
+            }
+        let remaining = windows.map(\.remainingPercent).min()
+        let limited = snapshot.map { !$0.allowed || $0.limitReached } ?? false
+
+        var minutes = 30
+        if let remaining {
+            switch remaining {
+            case ...10:
+                minutes = 5
+            case ...25:
+                minutes = 10
+            case ...50:
+                minutes = 15
+            case ...75:
+                minutes = 30
+            default:
+                minutes = 60
+            }
+        }
+        if limited {
+            minutes = 5
+        }
+
+        let nextUsedReset = windows
+            .filter { $0.usedPercent > 0 }
+            .compactMap { $0.effectiveResetDate(relativeTo: snapshot?.fetchedAt ?? now) }
+            .filter { $0 > now }
+            .min()
+        let untilReset = nextUsedReset?.timeIntervalSince(now) ?? .infinity
+        if untilReset <= 15 * 60 {
+            minutes = min(minutes, 5)
+        } else if untilReset <= 60 * 60 {
+            minutes = min(minutes, 10)
+        }
+
+        let attention = max(0, attentionScore.isFinite ? attentionScore : 0)
+        switch attention {
+        case 6...:
+            minutes = min(minutes, 5)
+        case 3...:
+            minutes = min(minutes, 10)
+        case 1.5...:
+            minutes = min(minutes, 15)
+        case 0.5...:
+            minutes = min(minutes, 30)
+        default:
+            break
+        }
+
+        let urgent = limited || (remaining ?? 101) <= 25 || untilReset <= 60 * 60
+        let hour = min(23, max(0, localHour))
+        if !urgent, attention < 0.5, (1..<6).contains(hour) {
+            minutes = max(minutes, 120)
+        }
+
+        for _ in 0..<min(3, max(0, consecutiveFailures)) {
+            minutes = nextSlower(than: minutes)
+        }
+        return urgent ? min(minutes, 30) : min(minutes, 120)
+    }
+
+    private static func nextSlower(than minutes: Int) -> Int {
+        intervals.first(where: { $0 > minutes }) ?? intervals[intervals.count - 1]
+    }
+}

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/AdaptiveRefreshPolicyTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/AdaptiveRefreshPolicyTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+@testable import CodexMeterCore
+
+final class AdaptiveRefreshPolicyTests: XCTestCase {
+    func testQuotaAttentionResetQuietHoursAndFailureBackoff() {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let healthy = UsageWindow(
+            usedPercent: 5,
+            windowSeconds: 18_000,
+            resetAt: now.addingTimeInterval(4 * 60 * 60)
+        )
+        let medium = UsageWindow(
+            usedPercent: 60,
+            windowSeconds: 18_000,
+            resetAt: now.addingTimeInterval(3 * 60 * 60)
+        )
+        let low = UsageWindow(
+            usedPercent: 92,
+            windowSeconds: 18_000,
+            resetAt: now.addingTimeInterval(2 * 60 * 60)
+        )
+        let nearReset = UsageWindow(
+            usedPercent: 20,
+            windowSeconds: 18_000,
+            resetAt: now.addingTimeInterval(10 * 60)
+        )
+
+        XCTAssertEqual(choose(nil), 30)
+        XCTAssertEqual(choose(snapshot(healthy), hour: 12), 60)
+        XCTAssertEqual(choose(snapshot(medium), hour: 12), 15)
+        XCTAssertEqual(choose(snapshot(low), hour: 12), 5)
+        XCTAssertEqual(choose(snapshot(healthy), attention: 3, hour: 12), 10)
+        XCTAssertEqual(choose(snapshot(healthy), hour: 3), 120)
+        XCTAssertEqual(choose(snapshot(nearReset), hour: 12), 5)
+        XCTAssertEqual(choose(snapshot(low), hour: 12, failures: 2), 15)
+        XCTAssertEqual(
+            choose(snapshot(low, allowed: false, limited: true), hour: 12, failures: 3),
+            30
+        )
+
+        func choose(
+            _ usage: UsageSnapshot?,
+            attention: Double = 0,
+            hour: Int = 12,
+            failures: Int = 0
+        ) -> Int {
+            AdaptiveRefreshPolicy.chooseMinutes(
+                snapshot: usage,
+                attentionScore: attention,
+                localHour: hour,
+                consecutiveFailures: failures,
+                now: now
+            )
+        }
+
+        func snapshot(
+            _ window: UsageWindow,
+            allowed: Bool = true,
+            limited: Bool = false
+        ) -> UsageSnapshot {
+            UsageSnapshot(
+                planType: "plus",
+                allowed: allowed,
+                limitReached: limited,
+                fiveHour: window,
+                weekly: nil,
+                fetchedAt: now
+            )
+        }
+    }
+}

--- a/ios/CodexMeterTests/NotificationPlanningTests.swift
+++ b/ios/CodexMeterTests/NotificationPlanningTests.swift
@@ -189,6 +189,7 @@ final class NotificationPlanningTests: XCTestCase {
         """.data(using: .utf8)!
 
         let settings = try JSONDecoder().decode(AppSettings.self, from: legacy)
+        XCTAssertEqual(settings.refreshMode, .automatic)
         XCTAssertTrue(settings.creditIncreaseAlertsEnabled)
         XCTAssertTrue(settings.unexpectedRefillAlertsEnabled)
         XCTAssertTrue(settings.creditExpiryRemindersEnabled)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make Automatic the default refresh mode on Android and iOS while preserving manual intervals
- adapt refresh cadence from remaining quota, reset proximity, recent opens, foreground time, quiet hours, accelerated usage, and failure backoff
- keep engagement signals private and compact as a decaying on-device score
- synchronize Android Wear freshness with the effective adaptive cadence
- add deterministic policy and backward-compatible settings-migration coverage

## Validation
- `./run-tests.sh` passes, including adaptive policy scenarios
- `./build.sh` passes for signed phone and Wear release APKs
- `./lint.sh` passes for phone and Wear release variants
- Swift adaptive policy module compiles, runs expected `[60, 5, 10, 120]` scenarios, and its XCTest file typechecks
- changed iOS app sources pass Swift parser validation
- full Linux Swift package build remains blocked by pre-existing missing `CoreFoundation` import in `JSONSupport.swift`
- pull-request CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ea15877-6546-41ba-bca6-b5cd340a31d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ea15877-6546-41ba-bca6-b5cd340a31d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

