### PR TITLE
Prepare Codex Meter 2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2.6.0 — 2026-07-26
+
+### Added
+
+- Adaptive Automatic refresh mode (now the default) on Android and iOS that adjusts cadence from remaining quota, reset proximity, recent engagement, quiet hours, accelerated usage, and failure backoff (#71).
+- Adaptive usage dashboard sections that preserve and render named additional rate limits such as GPT-5.3-Codex-Spark, hide missing standard windows instead of empty cards, and show purchased usage-credit balances separately from reset credits (#70).
+- Dashboard visibility controls on Android and iOS so users choose which usage sections appear, with safe migration defaults (#70).
+
+### Changed
+
+- Bumped the phone app One UI design library to `0.9.14+oneui8` and refreshed `android/vendor/m2` so offline and release builds resolve the new AAR without GitHub Packages auth (#69).
+- Wear freshness now follows the phone's effective adaptive refresh cadence (#71).
+
+### Fixed
+
+- One UI `CardItemView` / `SwitchItemView` RTL summary `ViewStub` inflation via the design-library update (#69).
+
+### Development
+
+- Expanded regression coverage for adaptive refresh policy and settings migration, plus adaptive usage parsing for partial, additional-only, and credit-only responses (#70, #71).
+
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.5.0...v2.6.0 <!-- pragma: allowlist secret -->
+
 ## 2.5.0 — 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
 
-## Android — Version 2.5.0
+## Android — Version 2.6.0
 
-Version 2.5.0 makes the Wear OS companion a first-class release: synchronized usage and monitor state, One UI Watch styling, five Tiles, four Complications, promoted ongoing monitoring, the canonical app icon, and a separately installable signed Wear APK on every tagged GitHub Release.
+Version 2.6.0 adds adaptive Automatic refresh scheduling and an adaptive usage dashboard: named additional rate limits, purchased usage credits, hide-missing windows, and per-section visibility controls on Android and iOS, plus the One UI design library bump to `0.9.14+oneui8`.
 
 ### Live countdowns
 
@@ -94,7 +94,7 @@ xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.5.0`) runs the full CI pipeline and publishes the signed phone APK, signed Wear OS APK, and their SHA-256 checksums to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
+Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.6.0`) runs the full CI pipeline and publishes the signed phone APK, signed Wear OS APK, and their SHA-256 checksums to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
 
 ## Platform stability
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 21
-        versionName = "2.5.0"
+        versionCode = 22
+        versionName = "2.6.0"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 21;
-    public static final String VERSION_NAME = "2.5.0";
+    public static final int VERSION_CODE = 22;
+    public static final String VERSION_NAME = "2.6.0";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.5.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.6.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.5.0"
+VERSION_NAME="2.6.0"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -67,14 +67,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.5.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 21' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.5.0"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 21' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.5.0"' "$ROOT/wear/build.gradle.kts"
-grep -q 'versionCode = 21' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.5.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.5.0"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.6.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 22' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.6.0"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 22' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.6.0"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionCode = 22' "$ROOT/wear/build.gradle.kts"
+grep -q 'codex-meter-android/2.6.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.6.0"' "$ROOT/build.sh"
 WORKFLOW="$ROOT/../.github/workflows/build-apk.yml"
 grep -Fq 'release-dist/CodexMeter-Wear-$VERSION_NAME.apk' "$WORKFLOW"
 grep -Fq '"platforms;android-37.0"' "$WORKFLOW"

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -332,7 +332,7 @@ public final class ParserSelfTest {
         check(!clearRoundTrip.signedIn,
                 "Wear usage clear payload preserves signed-out state");
         WearSyncStatus status = new WearSyncStatus(true, true, 3000L,
-                "Network unavailable", "2.5.0", 4000L);
+                "Network unavailable", "2.6.0", 4000L);
         WearSyncStatus statusRoundTrip = WearSyncStatus.fromJson(status.toJson());
         check(statusRoundTrip != null && statusRoundTrip.signedIn,
                 "Wear status preserves phone sign-in state");

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 21
-        versionName = "2.5.0"
+        versionCode = 22
+        versionName = "2.6.0"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump Android phone + Wear to version code **22** / **2.6.0** across Gradle, `AppConstants`, `build.sh`, and release self-checks.
- Document post-`v2.5.0` changes from merged PRs **#69**, **#70**, and **#71** in `CHANGELOG.md` and refresh the README version blurb.

### Included since v2.5.0

- **#71** — Adaptive Automatic refresh scheduling (Android + iOS)
- **#70** — Adaptive usage dashboard sections, purchased usage credits, and visibility controls (Android + iOS)
- **#69** — Bump `oneui-design` to `0.9.14+oneui8` (RTL summary ViewStub fix + vendor cache)

This PR only prepares version metadata and release notes — it does **not** create the `v2.6.0` tag or GitHub Release. After merge, tagging `v2.6.0` on the merge commit will trigger CI to publish the signed phone + Wear APKs.

## Testing

- `./run-tests.sh` passed (parser/updater/OAuth/onboarding/widget/Wear checks + version guards for 2.6.0 / code 22)
- `./build.sh` produced `android/dist/CodexMeter-2.6.0.apk` and `CodexMeter-Wear-2.6.0.apk` (APK Signature Scheme v2)
- `./lint.sh` passed (`:app:lintRelease` + `:wear:lintRelease`)
- [ ] Tag `v2.6.0` after merge (will push/create release once instructed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7a7ed7f-758f-44fb-9d9a-3338bde74681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7a7ed7f-758f-44fb-9d9a-3338bde74681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

