### PR TITLE
Hide zero usage credits and add One UI dashboard reorder

### DIFF
--- a/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
+++ b/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
@@ -23,6 +23,11 @@ public final class UsagePaceDemoActivity extends Activity {
                     + TimeUnit.HOURS.toMillis(5);
             long weeklyReset = now - TimeUnit.HOURS.toMillis(1)
                     + TimeUnit.DAYS.toMillis(7);
+            boolean zeroCredits = getIntent().getBooleanExtra("zero_usage_credits", false);
+            boolean openReorder = getIntent().getBooleanExtra("open_reorder", false);
+            UsageCredits credits = zeroCredits
+                    ? new UsageCredits(true, false, "0")
+                    : new UsageCredits(true, false, "2500");
             UsageSnapshot snapshot = new UsageSnapshot("pro", true, false,
                     new UsageWindow(37, TimeUnit.HOURS.toSeconds(5), 0L,
                             fiveHourReset / 1000L),
@@ -38,7 +43,7 @@ public final class UsagePaceDemoActivity extends Activity {
                                     (now + TimeUnit.HOURS.toMillis(3)) / 1000L),
                             new UsageWindow(42, TimeUnit.DAYS.toSeconds(7), 0L,
                                     (now + TimeUnit.DAYS.toMillis(5)) / 1000L))),
-                    new UsageCredits(true, false, "2500"),
+                    credits,
                     3,
                     now);
             SecureTokenStore.save(this, new AuthTokens(
@@ -55,6 +60,10 @@ public final class UsagePaceDemoActivity extends Activity {
                     now));
             AppPreferences.setRefreshOnLaunch(this, false);
             AppPreferences.setDashboardVisibility(this, true, true, true, true, true);
+            if (getIntent().hasExtra("dashboard_order")) {
+                AppPreferences.setDashboardItemOrder(this,
+                        DashboardOrder.parse(getIntent().getStringExtra("dashboard_order")));
+            }
             AppPreferences.completeOnboarding(this);
             UsagePacePreferences.setEnabled(this, true);
             UsagePacePreferences.setSensitivity(this, UsagePace.BALANCED);
@@ -62,8 +71,10 @@ public final class UsagePaceDemoActivity extends Activity {
             if (livePreview && !NowBarManager.startPreview(this)) {
                 throw new IllegalStateException("Could not start live notification preview");
             }
-            startActivity(new Intent(this,
-                    livePreview ? SettingsActivity.class : MainActivity.class)
+            Class<?> target = livePreview
+                    ? SettingsActivity.class
+                    : (openReorder ? DashboardReorderActivity.class : MainActivity.class);
+            startActivity(new Intent(this, target)
                     .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
         } catch (Exception exception) {
             throw new IllegalStateException("Could not seed usage pace demo", exception);

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,9 @@
             android:name="dev.bennett.codexmeter.SettingsActivity"
             android:exported="false"/>
         <activity
+            android:name="dev.bennett.codexmeter.DashboardReorderActivity"
+            android:exported="false"/>
+        <activity
             android:name="dev.bennett.codexmeter.UpdateActivity"
             android:configChanges="orientation|screenSize"
             android:exported="false"/>

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -3,6 +3,7 @@ package dev.bennett.codexmeter;
 import android.content.Context;
 import android.content.SharedPreferences;
 import dev.bennett.codexmeter.wear.PhoneWearSync;
+import java.util.List;
 import org.json.JSONObject;
 
 /* JADX INFO: loaded from: classes.dex */
@@ -11,6 +12,7 @@ public final class AppPreferences {
     private static final String KEY_APP_THEME = "app_theme";
     private static final String KEY_DASHBOARD_ADDITIONAL_LIMITS = "dashboard_additional_limits";
     private static final String KEY_DASHBOARD_FIVE_HOUR = "dashboard_five_hour";
+    private static final String KEY_DASHBOARD_ITEM_ORDER = "dashboard_item_order";
     private static final String KEY_DASHBOARD_RESET_CREDITS = "dashboard_reset_credits";
     private static final String KEY_DASHBOARD_USAGE_CREDITS = "dashboard_usage_credits";
     private static final String KEY_DASHBOARD_WEEKLY = "dashboard_weekly";
@@ -262,6 +264,16 @@ public final class AppPreferences {
                 .putBoolean(KEY_DASHBOARD_ADDITIONAL_LIMITS, additionalLimits)
                 .putBoolean(KEY_DASHBOARD_USAGE_CREDITS, usageCredits)
                 .putBoolean(KEY_DASHBOARD_RESET_CREDITS, resetCredits)
+                .apply();
+    }
+
+    public static List<String> getDashboardItemOrder(Context context) {
+        return DashboardOrder.parse(prefs(context).getString(KEY_DASHBOARD_ITEM_ORDER, ""));
+    }
+
+    public static void setDashboardItemOrder(Context context, List<String> order) {
+        prefs(context).edit()
+                .putString(KEY_DASHBOARD_ITEM_ORDER, DashboardOrder.serialize(order))
                 .apply();
     }
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardOrder.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardOrder.java
@@ -1,0 +1,138 @@
+package dev.bennett.codexmeter;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.json.JSONArray;
+
+/**
+ * Stable dashboard item ids and order merging. Pure Java so {@link ParserSelfTest}
+ * can cover reordering without the Android SDK.
+ */
+public final class DashboardOrder {
+    public static final String FIVE_HOUR = "five_hour";
+    public static final String WEEKLY = "weekly";
+    public static final String USAGE_CREDITS = "usage_credits";
+    public static final String RESET_CREDITS = "reset_credits";
+
+    private static final String ADDITIONAL_PREFIX = "additional:";
+
+    private DashboardOrder() {
+    }
+
+    public static String additionalPrimary(String limitId) {
+        return ADDITIONAL_PREFIX + cleanId(limitId) + ":primary";
+    }
+
+    public static String additionalSecondary(String limitId) {
+        return ADDITIONAL_PREFIX + cleanId(limitId) + ":secondary";
+    }
+
+    public static boolean isAdditional(String id) {
+        return id != null && id.startsWith(ADDITIONAL_PREFIX);
+    }
+
+    /**
+     * Keep preferred order for items that still exist, then append any newly
+     * available items in their natural (API / default) order.
+     */
+    public static List<String> merge(List<String> preferred, List<String> available) {
+        List<String> availableClean = dedupe(available);
+        LinkedHashSet<String> availableSet = new LinkedHashSet<>(availableClean);
+        List<String> merged = new ArrayList<>();
+        if (preferred != null) {
+            for (String id : preferred) {
+                if (id != null && availableSet.remove(id)) {
+                    merged.add(id);
+                }
+            }
+        }
+        for (String id : availableClean) {
+            if (availableSet.contains(id)) {
+                merged.add(id);
+            }
+        }
+        return merged;
+    }
+
+    public static List<String> defaultAvailable(UsageSnapshot snapshot,
+            boolean includeResetCredits) {
+        List<String> available = new ArrayList<>();
+        if (snapshot != null) {
+            if (snapshot.fiveHour != null) {
+                available.add(FIVE_HOUR);
+            }
+            if (snapshot.weekly != null) {
+                available.add(WEEKLY);
+            }
+            if (snapshot.additionalLimits != null) {
+                for (UsageLimit limit : snapshot.additionalLimits) {
+                    if (limit == null) {
+                        continue;
+                    }
+                    if (limit.primary != null) {
+                        available.add(additionalPrimary(limit.id));
+                    }
+                    if (limit.secondary != null) {
+                        available.add(additionalSecondary(limit.id));
+                    }
+                }
+            }
+            if (snapshot.usageCredits != null && snapshot.usageCredits.isDashboardVisible()) {
+                available.add(USAGE_CREDITS);
+            }
+        }
+        if (includeResetCredits) {
+            available.add(RESET_CREDITS);
+        }
+        return available;
+    }
+
+    public static String serialize(List<String> order) {
+        JSONArray array = new JSONArray();
+        if (order != null) {
+            for (String id : dedupe(order)) {
+                array.put(id);
+            }
+        }
+        return array.toString();
+    }
+
+    public static List<String> parse(String json) {
+        List<String> order = new ArrayList<>();
+        if (json == null || json.trim().isEmpty()) {
+            return order;
+        }
+        try {
+            JSONArray array = new JSONArray(json);
+            for (int i = 0; i < array.length(); i++) {
+                String id = array.optString(i, "").trim();
+                if (!id.isEmpty()) {
+                    order.add(id);
+                }
+            }
+        } catch (Exception ignored) {
+            return new ArrayList<>();
+        }
+        return dedupe(order);
+    }
+
+    private static List<String> dedupe(List<String> values) {
+        LinkedHashSet<String> unique = new LinkedHashSet<>();
+        if (values != null) {
+            for (String value : values) {
+                if (value != null) {
+                    String clean = value.trim();
+                    if (!clean.isEmpty()) {
+                        unique.add(clean);
+                    }
+                }
+            }
+        }
+        return new ArrayList<>(unique);
+    }
+
+    private static String cleanId(String limitId) {
+        return limitId == null ? "" : limitId.trim();
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
@@ -1,0 +1,274 @@
+package dev.bennett.codexmeter;
+
+import android.annotation.SuppressLint;
+import android.os.Bundle;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import dev.oneuiproject.oneui.layout.ToolbarLayout;
+import dev.oneuiproject.oneui.widget.CardItemView;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * One UI edit screen for dashboard order. Uses SESL RecyclerView + ItemTouchHelper
+ * drag handles so limits (including auto-detected SPARK windows) and credits can be
+ * moved above or below each other.
+ */
+public final class DashboardReorderActivity extends AppCompatActivity {
+    private final List<ReorderItem> items = new ArrayList<>();
+    private Adapter adapter;
+    private ItemTouchHelper itemTouchHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        Ui.applySelectedTheme(this);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_dashboard_reorder);
+        ToolbarLayout toolbar = findViewById(R.id.dashboard_reorder_toolbar);
+        Ui.configureReachToolbar(toolbar, "Edit dashboard", true);
+
+        boolean dark = Ui.isDark(this);
+        TextView help = findViewById(R.id.dashboard_reorder_help);
+        help.setTextColor(Ui.secondaryText(dark));
+
+        loadItems();
+        RecyclerView list = findViewById(R.id.dashboard_reorder_list);
+        list.setLayoutManager(new LinearLayoutManager(this));
+        list.seslSetFillBottomEnabled(true);
+        list.seslSetLastRoundedCorner(true);
+        adapter = new Adapter();
+        list.setAdapter(adapter);
+        itemTouchHelper = new ItemTouchHelper(new ItemTouchHelper.SimpleCallback(
+                ItemTouchHelper.UP | ItemTouchHelper.DOWN, 0) {
+            @Override
+            public boolean onMove(@NonNull RecyclerView recyclerView,
+                    @NonNull RecyclerView.ViewHolder viewHolder,
+                    @NonNull RecyclerView.ViewHolder target) {
+                int from = viewHolder.getBindingAdapterPosition();
+                int to = target.getBindingAdapterPosition();
+                if (from == RecyclerView.NO_POSITION || to == RecyclerView.NO_POSITION
+                        || from == to) {
+                    return false;
+                }
+                Collections.swap(items, from, to);
+                adapter.notifyItemMoved(from, to);
+                persistOrder();
+                return true;
+            }
+
+            @Override
+            public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int direction) {
+                // Reorder only.
+            }
+
+            @Override
+            public boolean isLongPressDragEnabled() {
+                return true;
+            }
+        });
+        itemTouchHelper.attachToRecyclerView(list);
+    }
+
+    private void loadItems() {
+        items.clear();
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
+        boolean showResetCredits = AppPreferences.showDashboardResetCredits(this)
+                && SecureTokenStore.isSignedIn(this)
+                && (AppPreferences.loadResetCredits(this) != null
+                || (snapshot != null && snapshot.resetCreditsAvailable >= 0));
+        List<String> natural = naturalOrder(snapshot, showResetCredits);
+        List<String> ordered = DashboardOrder.merge(
+                AppPreferences.getDashboardItemOrder(this), natural);
+        for (String id : ordered) {
+            ReorderItem item = describe(id, snapshot);
+            if (item != null) {
+                items.add(item);
+            }
+        }
+    }
+
+    private List<String> naturalOrder(UsageSnapshot snapshot, boolean showResetCredits) {
+        List<String> available = new ArrayList<>();
+        if (snapshot == null) {
+            if (showResetCredits) {
+                available.add(DashboardOrder.RESET_CREDITS);
+            }
+            return available;
+        }
+        if (AppPreferences.showDashboardFiveHour(this) && snapshot.fiveHour != null) {
+            available.add(DashboardOrder.FIVE_HOUR);
+        }
+        if (AppPreferences.showDashboardWeekly(this) && snapshot.weekly != null) {
+            available.add(DashboardOrder.WEEKLY);
+        }
+        if (AppPreferences.showDashboardAdditionalLimits(this)
+                && snapshot.additionalLimits != null) {
+            for (UsageLimit limit : snapshot.additionalLimits) {
+                if (limit == null) {
+                    continue;
+                }
+                if (limit.primary != null) {
+                    available.add(DashboardOrder.additionalPrimary(limit.id));
+                }
+                if (limit.secondary != null) {
+                    available.add(DashboardOrder.additionalSecondary(limit.id));
+                }
+            }
+        }
+        if (AppPreferences.showDashboardUsageCredits(this)
+                && snapshot.usageCredits != null
+                && snapshot.usageCredits.isDashboardVisible()) {
+            available.add(DashboardOrder.USAGE_CREDITS);
+        }
+        if (showResetCredits) {
+            available.add(DashboardOrder.RESET_CREDITS);
+        }
+        return available;
+    }
+
+    private ReorderItem describe(String id, UsageSnapshot snapshot) {
+        if (DashboardOrder.FIVE_HOUR.equals(id)) {
+            return new ReorderItem(id, "5-hour limit", "Standard Codex window",
+                    R.drawable.ic_oui_time);
+        }
+        if (DashboardOrder.WEEKLY.equals(id)) {
+            return new ReorderItem(id, "Weekly limit", "Standard Codex window",
+                    R.drawable.ic_oui_calendar_week);
+        }
+        if (DashboardOrder.USAGE_CREDITS.equals(id)) {
+            return new ReorderItem(id, "Usage-credit balance",
+                    "Hidden automatically when at or near zero",
+                    R.drawable.ic_oui_battery);
+        }
+        if (DashboardOrder.RESET_CREDITS.equals(id)) {
+            return new ReorderItem(id, "Reset credits",
+                    "Earned credits that can reset usage windows",
+                    R.drawable.ic_oui_refresh);
+        }
+        if (DashboardOrder.isAdditional(id) && snapshot != null
+                && snapshot.additionalLimits != null) {
+            for (UsageLimit limit : snapshot.additionalLimits) {
+                if (limit == null) {
+                    continue;
+                }
+                if (DashboardOrder.additionalPrimary(limit.id).equals(id)
+                        && limit.primary != null) {
+                    return new ReorderItem(id,
+                            limit.displayName() + " · " + cadenceLabel(limit.primary),
+                            "Auto-detected additional limit",
+                            limit.primary.windowSeconds >= 86_400L
+                                    ? R.drawable.ic_oui_calendar_week
+                                    : R.drawable.ic_oui_time);
+                }
+                if (DashboardOrder.additionalSecondary(limit.id).equals(id)
+                        && limit.secondary != null) {
+                    return new ReorderItem(id,
+                            limit.displayName() + " · " + cadenceLabel(limit.secondary),
+                            "Auto-detected additional limit",
+                            limit.secondary.windowSeconds >= 86_400L
+                                    ? R.drawable.ic_oui_calendar_week
+                                    : R.drawable.ic_oui_time);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String cadenceLabel(UsageWindow window) {
+        long seconds = window.windowSeconds;
+        if (seconds >= 432_000L && seconds <= 777_600L) {
+            return "Weekly";
+        }
+        if (seconds >= 10_800L && seconds <= 28_800L) {
+            long hours = Math.max(1L, Math.round(seconds / 3600.0d));
+            return hours + "-hour";
+        }
+        if (seconds % 86_400L == 0L) {
+            return (seconds / 86_400L) + "-day";
+        }
+        if (seconds % 3_600L == 0L) {
+            return (seconds / 3_600L) + "-hour";
+        }
+        return "Usage";
+    }
+
+    private void persistOrder() {
+        List<String> ids = new ArrayList<>(items.size());
+        for (ReorderItem item : items) {
+            ids.add(item.id);
+        }
+        AppPreferences.setDashboardItemOrder(this, ids);
+    }
+
+    private static final class ReorderItem {
+        final String id;
+        final String title;
+        final String summary;
+        final int iconRes;
+
+        ReorderItem(String id, String title, String summary, int iconRes) {
+            this.id = id;
+            this.title = title;
+            this.summary = summary;
+            this.iconRes = iconRes;
+        }
+    }
+
+    private final class Adapter extends RecyclerView.Adapter<Holder> {
+        @NonNull
+        @Override
+        public Holder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            CardItemView row = new CardItemView(parent.getContext());
+            row.setLayoutParams(new RecyclerView.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+            return new Holder(row);
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull Holder holder, int position) {
+            holder.bind(items.get(position));
+        }
+
+        @Override
+        public int getItemCount() {
+            return items.size();
+        }
+    }
+
+    private final class Holder extends RecyclerView.ViewHolder {
+        private final CardItemView row;
+
+        Holder(CardItemView row) {
+            super(row);
+            this.row = row;
+        }
+
+        @SuppressLint("ClickableViewAccessibility")
+        void bind(ReorderItem item) {
+            row.setTitle(item.title);
+            row.setSummary(item.summary);
+            row.setIcon(getDrawable(item.iconRes));
+            row.setShowTopDivider(getBindingAdapterPosition() > 0);
+            ImageView handle = row.getEndImageView();
+            handle.setVisibility(View.VISIBLE);
+            handle.setImageResource(R.drawable.ic_oui_reorder);
+            handle.setContentDescription("Drag to reorder");
+            handle.setOnTouchListener((view, event) -> {
+                if (event.getActionMasked() == MotionEvent.ACTION_DOWN
+                        && itemTouchHelper != null) {
+                    itemTouchHelper.startDrag(Holder.this);
+                }
+                return false;
+            });
+        }
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -29,6 +29,8 @@ import android.widget.TextView;
 import android.widget.Toast;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -38,6 +40,7 @@ import dev.bennett.codexmeter.wear.PhoneWearSync;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class MainActivity extends AppCompatActivity {
+    private static final int MENU_EDIT_DASHBOARD = 8100;
     private static final int MENU_SETTINGS = 8101;
     private String appliedTheme;
     private boolean appliedMaterialYou;
@@ -110,7 +113,10 @@ public final class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        menu.add(Menu.NONE, MENU_SETTINGS, 0, "Settings")
+        menu.add(Menu.NONE, MENU_EDIT_DASHBOARD, 0, "Edit")
+                .setIcon(R.drawable.ic_oui_reorder)
+                .setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
+        menu.add(Menu.NONE, MENU_SETTINGS, 1, "Settings")
                 .setIcon(R.drawable.ic_oui_settings_outline)
                 .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
         return true;
@@ -118,6 +124,10 @@ public final class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == MENU_EDIT_DASHBOARD) {
+            Ui.startSecondaryActivity(this, DashboardReorderActivity.class);
+            return true;
+        }
         if (item.getItemId() == MENU_SETTINGS) {
             Ui.startSecondaryActivity(this, SettingsActivity.class);
             return true;
@@ -281,15 +291,7 @@ public final class MainActivity extends AppCompatActivity {
                 signIn.setOnClickListener(view -> startOrContinueSignIn());
                 this.content.addView(signIn, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
                 Ui.addSpacer(this.content, 20);
-            }
-            UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
-            boolean showResetCredits = AppPreferences.showDashboardResetCredits(this)
-                    && signedIn
-                    && (AppPreferences.loadResetCredits(this) != null
-                    || (snapshot != null && snapshot.resetCreditsAvailable >= 0));
-            if (showResetCredits) {
-                this.content.addView(buildResetCreditsCard());
-            } else if (signedIn && dashboard.getChildCount() == 0) {
+            } else if (dashboard.getChildCount() == 0) {
                 TextView empty = Ui.text(this,
                         "No dashboard items are available. Refresh usage or choose items in "
                                 + "Settings → Refresh & usage.",
@@ -335,37 +337,94 @@ public final class MainActivity extends AppCompatActivity {
         if (!signedIn || snapshot == null) {
             return column;
         }
+        boolean showResetCredits = AppPreferences.showDashboardResetCredits(this)
+                && (AppPreferences.loadResetCredits(this) != null
+                || snapshot.resetCreditsAvailable >= 0);
+        List<String> available = availableDashboardIds(snapshot, showResetCredits);
+        List<String> ordered = DashboardOrder.merge(
+                AppPreferences.getDashboardItemOrder(this), available);
         boolean inverted = false;
+        for (String id : ordered) {
+            View card = buildDashboardCard(id, snapshot, inverted);
+            if (card == null) {
+                continue;
+            }
+            addDashboardCard(column, card);
+            if (!DashboardOrder.USAGE_CREDITS.equals(id)
+                    && !DashboardOrder.RESET_CREDITS.equals(id)) {
+                inverted = !inverted;
+            }
+        }
+        return column;
+    }
+
+    private List<String> availableDashboardIds(UsageSnapshot snapshot, boolean showResetCredits) {
+        List<String> available = new ArrayList<>();
         if (AppPreferences.showDashboardFiveHour(this) && snapshot.fiveHour != null) {
-            addDashboardCard(column, buildMetricCard(
-                    "5-hour", snapshot, snapshot.fiveHour, inverted));
-            inverted = !inverted;
+            available.add(DashboardOrder.FIVE_HOUR);
         }
         if (AppPreferences.showDashboardWeekly(this) && snapshot.weekly != null) {
-            addDashboardCard(column, buildMetricCard(
-                    "Weekly", snapshot, snapshot.weekly, inverted));
-            inverted = !inverted;
+            available.add(DashboardOrder.WEEKLY);
         }
-        if (AppPreferences.showDashboardAdditionalLimits(this)) {
+        if (AppPreferences.showDashboardAdditionalLimits(this)
+                && snapshot.additionalLimits != null) {
             for (UsageLimit limit : snapshot.additionalLimits) {
+                if (limit == null) {
+                    continue;
+                }
                 if (limit.primary != null) {
-                    addDashboardCard(column, buildMetricCard(
-                            limitTitle(limit) + " · " + cadenceLabel(limit.primary),
-                            snapshot, limit.primary, inverted));
-                    inverted = !inverted;
+                    available.add(DashboardOrder.additionalPrimary(limit.id));
                 }
                 if (limit.secondary != null) {
-                    addDashboardCard(column, buildMetricCard(
-                            limitTitle(limit) + " · " + cadenceLabel(limit.secondary),
-                            snapshot, limit.secondary, inverted));
-                    inverted = !inverted;
+                    available.add(DashboardOrder.additionalSecondary(limit.id));
                 }
             }
         }
-        if (AppPreferences.showDashboardUsageCredits(this) && snapshot.usageCredits != null) {
-            addDashboardCard(column, buildUsageCreditsCard(snapshot.usageCredits));
+        if (AppPreferences.showDashboardUsageCredits(this)
+                && snapshot.usageCredits != null
+                && snapshot.usageCredits.isDashboardVisible()) {
+            available.add(DashboardOrder.USAGE_CREDITS);
         }
-        return column;
+        if (showResetCredits) {
+            available.add(DashboardOrder.RESET_CREDITS);
+        }
+        return available;
+    }
+
+    private View buildDashboardCard(String id, UsageSnapshot snapshot, boolean invertedWave) {
+        if (DashboardOrder.FIVE_HOUR.equals(id) && snapshot.fiveHour != null) {
+            return buildMetricCard("5-hour", snapshot, snapshot.fiveHour, invertedWave);
+        }
+        if (DashboardOrder.WEEKLY.equals(id) && snapshot.weekly != null) {
+            return buildMetricCard("Weekly", snapshot, snapshot.weekly, invertedWave);
+        }
+        if (DashboardOrder.USAGE_CREDITS.equals(id) && snapshot.usageCredits != null
+                && snapshot.usageCredits.isDashboardVisible()) {
+            return buildUsageCreditsCard(snapshot.usageCredits);
+        }
+        if (DashboardOrder.RESET_CREDITS.equals(id)) {
+            return buildResetCreditsCard();
+        }
+        if (DashboardOrder.isAdditional(id) && snapshot.additionalLimits != null) {
+            for (UsageLimit limit : snapshot.additionalLimits) {
+                if (limit == null) {
+                    continue;
+                }
+                if (DashboardOrder.additionalPrimary(limit.id).equals(id)
+                        && limit.primary != null) {
+                    return buildMetricCard(
+                            limitTitle(limit) + " · " + cadenceLabel(limit.primary),
+                            snapshot, limit.primary, invertedWave);
+                }
+                if (DashboardOrder.additionalSecondary(limit.id).equals(id)
+                        && limit.secondary != null) {
+                    return buildMetricCard(
+                            limitTitle(limit) + " · " + cadenceLabel(limit.secondary),
+                            snapshot, limit.secondary, invertedWave);
+                }
+            }
+        }
+        return null;
     }
 
     private void addDashboardCard(LinearLayout column, View card) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -457,6 +457,14 @@ public final class SettingsActivity extends AppCompatActivity {
                 PhoneWearSync.pushSettings(requireContext());
                 return true;
             });
+
+            Preference reorder = findPreference("dashboard_reorder");
+            if (reorder != null) {
+                reorder.setOnPreferenceClickListener(preference -> {
+                    Ui.startSecondaryActivity(requireActivity(), DashboardReorderActivity.class);
+                    return true;
+                });
+            }
         }
 
         private void bindUsagePace() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -180,6 +180,8 @@ public final class SettingsTransferStore {
                 AppPreferences.showDashboardAdditionalLimits(context));
         json.put("dashboard_usage_credits", AppPreferences.showDashboardUsageCredits(context));
         json.put("dashboard_reset_credits", AppPreferences.showDashboardResetCredits(context));
+        json.put("dashboard_item_order",
+                DashboardOrder.serialize(AppPreferences.getDashboardItemOrder(context)));
         json.put("usage_pace_enabled", UsagePacePreferences.isEnabled(context));
         json.put("usage_pace_sensitivity", UsagePacePreferences.getSensitivity(context));
         json.put("automatic_update_checks", UpdatePreferences.automaticChecks(context));
@@ -241,6 +243,10 @@ public final class SettingsTransferStore {
                         AppPreferences.showDashboardUsageCredits(context)),
                 json.optBoolean("dashboard_reset_credits",
                         AppPreferences.showDashboardResetCredits(context)));
+        if (json.has("dashboard_item_order")) {
+            AppPreferences.setDashboardItemOrder(context,
+                    DashboardOrder.parse(json.optString("dashboard_item_order", "")));
+        }
         UsagePacePreferences.setEnabled(context, json.optBoolean("usage_pace_enabled",
                 UsagePacePreferences.isEnabled(context)));
         UsagePacePreferences.setSensitivity(context, json.optString("usage_pace_sensitivity",

--- a/android/app/src/main/res/layout/activity_dashboard_reorder.xml
+++ b/android/app/src/main/res/layout/activity_dashboard_reorder.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dev.oneuiproject.oneui.layout.ToolbarLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/dashboard_reorder_toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:expanded="true"
+    app:expandable="true"
+    app:showNavButtonAsBack="true"
+    app:title="Edit dashboard">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="24dp">
+
+        <TextView
+            android:id="@+id/dashboard_reorder_help"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="4dp"
+            android:paddingBottom="12dp"
+            android:text="Drag items using the handle to move them above or below each other. Zero usage-credit balances stay hidden automatically."
+            android:textSize="14sp" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/dashboard_reorder_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:clipToPadding="false"
+            android:overScrollMode="ifContentScrolls"
+            android:scrollbars="vertical" />
+    </LinearLayout>
+
+</dev.oneuiproject.oneui.layout.ToolbarLayout>

--- a/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
+++ b/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
@@ -21,6 +21,10 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Dashboard">
+        <Preference
+            android:key="dashboard_reorder"
+            android:summary="Drag 5-hour, weekly, Spark, and credit cards above or below each other"
+            android:title="Reorder dashboard items" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_five_hour"
@@ -39,7 +43,7 @@
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_usage_credits"
-            android:summary="Purchased credits returned by OpenAI"
+            android:summary="Purchased credits; auto-hidden at zero, near-zero, or negative"
             android:title="Usage-credit balance" />
         <SwitchPreferenceCompat
             android:defaultValue="true"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -44,6 +44,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/wear/WearSurfaceMode.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/WearGlanceFormat.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageParser.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardOrder.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/CelebrationDetector.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/RateLimitResetCredit.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java" \
@@ -427,6 +428,23 @@ test -f "$ROOT/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.j
 grep -q 'UsagePaceDemoActivity' "$ROOT/app/src/debug/AndroidManifest.xml"
 grep -q 'usage_pace_enabled_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
+grep -q 'dashboard_reorder' \
+  "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
+grep -q 'auto-hidden at zero' \
+  "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
+grep -q 'DashboardReorderActivity' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'isDashboardVisible' \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java"
+grep -q 'testDashboardOrder' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'MENU_EDIT_DASHBOARD' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'ItemTouchHelper' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java"
+grep -q 'dashboard_item_order' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardOrder.java"
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java"
+test -f "$ROOT/app/src/main/res/layout/activity_dashboard_reorder.xml"
 grep -q 'usage_pace_sensitivity_ui' \
   "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
 grep -q '<item>off</item>' \

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
@@ -1,10 +1,14 @@
 package dev.bennett.codexmeter;
 
+import java.math.BigDecimal;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 /** Purchased usage-credit state returned by the main Codex usage endpoint. */
 public final class UsageCredits {
+    /** Hide balances at/under this amount; near-zero scrap is not useful on the dashboard. */
+    private static final BigDecimal VISIBLE_BALANCE_THRESHOLD = new BigDecimal("0.01");
+
     public final boolean hasCredits;
     public final boolean unlimited;
     public final String balance;
@@ -14,6 +18,25 @@ public final class UsageCredits {
         this.unlimited = unlimited;
         String cleanBalance = balance == null ? "" : balance.trim();
         this.balance = hasCredits || unlimited ? cleanBalance : "";
+    }
+
+    /**
+     * Whether the usage-credit card should appear on the dashboard. Zero, near-zero,
+     * and negative balances auto-hide and are not user-configurable.
+     */
+    public boolean isDashboardVisible() {
+        if (unlimited) {
+            return true;
+        }
+        if (balance.isEmpty()) {
+            return hasCredits;
+        }
+        try {
+            BigDecimal amount = new BigDecimal(balance.replace(",", ""));
+            return amount.compareTo(VISIBLE_BALANCE_THRESHOLD) >= 0;
+        } catch (NumberFormatException ignored) {
+            return hasCredits;
+        }
     }
 
     public JSONObject toJson() throws JSONException {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -19,6 +19,7 @@ public final class ParserSelfTest {
         testPrimaryLimitWinsOverAdditional();
         testOptionalUsageSections();
         testUsageCredits();
+        testDashboardOrder();
         testMalformedWindowIgnored();
         testZeroDurationWindowIgnored();
         testNextResetSelection();
@@ -622,6 +623,78 @@ public final class ParserSelfTest {
         check(none.usageCredits != null && none.usageCredits.balance.isEmpty()
                         && !none.hasDisplayableData(),
                 "zero balance for an account without purchased credits is not standalone data");
+        check(!none.usageCredits.isDashboardVisible(),
+                "zero / no-purchase credits auto-hide on the dashboard");
+
+        UsageSnapshot zeroBalance = UsageParser.parse(
+                "{\"credits\":{\"has_credits\":true,\"balance\":\"0\"}}", 6L);
+        check(zeroBalance.usageCredits != null
+                        && !zeroBalance.usageCredits.isDashboardVisible(),
+                "explicit zero balance auto-hides");
+        check(!new UsageCredits(true, false, "0.009").isDashboardVisible(),
+                "near-zero balance auto-hides");
+        check(!new UsageCredits(true, false, "-3").isDashboardVisible(),
+                "negative balance auto-hides");
+        check(new UsageCredits(true, false, "0.01").isDashboardVisible(),
+                "meaningful positive balance remains visible");
+        check(new UsageCredits(true, true, "0").isDashboardVisible(),
+                "unlimited credits remain visible even with a zero balance string");
+    }
+
+    private static void testDashboardOrder() throws Exception {
+        UsageSnapshot snapshot = UsageParser.parse(
+                "{\"plan_type\":\"pro\",\"rate_limit\":{"
+                        + "\"primary_window\":{\"used_percent\":10,"
+                        + "\"limit_window_seconds\":18000,\"reset_at\":1},"
+                        + "\"secondary_window\":{\"used_percent\":20,"
+                        + "\"limit_window_seconds\":604800,\"reset_at\":2}},"
+                        + "\"additional_rate_limits\":[{"
+                        + "\"limit_name\":\"GPT-5.3-Codex-Spark\","
+                        + "\"metered_feature\":\"codex_bengalfox\","
+                        + "\"rate_limit\":{\"primary_window\":{\"used_percent\":5,"
+                        + "\"limit_window_seconds\":18000},"
+                        + "\"secondary_window\":{\"used_percent\":8,"
+                        + "\"limit_window_seconds\":604800}}}],"
+                        + "\"credits\":{\"has_credits\":true,\"balance\":\"12\"}}",
+                9L);
+        List<String> natural = DashboardOrder.defaultAvailable(snapshot, true);
+        check(natural.indexOf(DashboardOrder.FIVE_HOUR) == 0, "default starts with 5-hour");
+        check(natural.contains(DashboardOrder.WEEKLY), "weekly present by default");
+        check(natural.contains(DashboardOrder.additionalPrimary(
+                        snapshot.additionalLimits.get(0).id)),
+                "spark primary window is reorderable");
+        check(natural.contains(DashboardOrder.USAGE_CREDITS),
+                "visible usage credits are reorderable");
+        check(natural.get(natural.size() - 1).equals(DashboardOrder.RESET_CREDITS),
+                "reset credits trail by default");
+
+        List<String> preferred = Arrays.asList(
+                DashboardOrder.USAGE_CREDITS,
+                DashboardOrder.WEEKLY,
+                "stale-item",
+                DashboardOrder.FIVE_HOUR);
+        List<String> merged = DashboardOrder.merge(preferred, natural);
+        check(DashboardOrder.USAGE_CREDITS.equals(merged.get(0)),
+                "preferred order is preserved for still-available items");
+        check(DashboardOrder.WEEKLY.equals(merged.get(1)), "weekly follows credits when preferred");
+        check(DashboardOrder.FIVE_HOUR.equals(merged.get(2)), "five-hour follows weekly");
+        check(!merged.contains("stale-item"), "unknown ids are dropped");
+        check(merged.contains(DashboardOrder.additionalPrimary(
+                        snapshot.additionalLimits.get(0).id)),
+                "new spark windows append after preferred ids");
+
+        String serialized = DashboardOrder.serialize(merged);
+        List<String> parsed = DashboardOrder.parse(serialized);
+        check(parsed.equals(merged), "dashboard order survives JSON round-trip");
+
+        UsageSnapshot zeroCredits = UsageParser.parse(
+                "{\"credits\":{\"has_credits\":true,\"balance\":\"0\"},"
+                        + "\"rate_limit\":{\"primary_window\":{\"used_percent\":1,"
+                        + "\"limit_window_seconds\":18000,\"reset_at\":1}}}",
+                10L);
+        List<String> withoutCredits = DashboardOrder.defaultAvailable(zeroCredits, false);
+        check(!withoutCredits.contains(DashboardOrder.USAGE_CREDITS),
+                "zero usage credits are omitted from reorderable items");
     }
 
     private static void testMalformedWindowIgnored() throws Exception {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Auto-hide the purchased usage-credit balance when it is zero, near-zero (`< 0.01`), or negative. This is not configurable.
- Add One UI edit/reorder for dashboard cards (5-hour, weekly, auto-detected GPT-5.3 SPARK windows, usage credits, reset credits) via SESL `RecyclerView` + `ItemTouchHelper` drag handles.
- Entry points: dashboard toolbar **Edit**, and Settings → Refresh & usage → **Reorder dashboard items**.
- Persist order in preferences (and settings transfer), merging saved order with newly detected limits.

## Emulator demo (API 30, software GPU / TCG)
Verified on a software-bound Android emulator with the debug demo seeder:

[demo-dashboard-credits-reorder.mp4](https://cursor.com/agents/bc-f198513f-dea9-4515-9d7f-ccded324ffc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo-dashboard-credits-reorder.mp4)

[Credits visible](https://cursor.com/agents/bc-f198513f-dea9-4515-9d7f-ccded324ffc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo-credits-visible.png)
[Reorder edit with drag handles](https://cursor.com/agents/bc-f198513f-dea9-4515-9d7f-ccded324ffc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo-reorder-edit.png)
[After drag Spark above weekly](https://cursor.com/agents/bc-f198513f-dea9-4515-9d7f-ccded324ffc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo-reorder-after-drag.png)
[Zero credits auto-hidden](https://cursor.com/agents/bc-f198513f-dea9-4515-9d7f-ccded324ffc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo-zero-credits-hidden.png)
[Reorder omits zero credits](https://cursor.com/agents/bc-f198513f-dea9-4515-9d7f-ccded324ffc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo-reorder-zero-credits-omitted.png)

## Test plan
- [x] `./run-tests.sh` (includes `isDashboardVisible` + `DashboardOrder` coverage)
- [x] `:app:assembleDebug`
- [x] Emulator: seed demo with credits → balance card shows (`2,500 credits`)
- [x] Emulator: seed with `zero_usage_credits` → balance card gone; reset credits remain
- [x] Emulator: Edit/reorder drag Spark between 5-hour and weekly; order persisted in prefs
- [x] Emulator: zero-credit state omits usage credits from reorder list


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f198513f-dea9-4515-9d7f-ccded324ffc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f198513f-dea9-4515-9d7f-ccded324ffc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

