### PR TITLE
Auto-hide empty usage-credit balance and add One UI dashboard reordering

### DIFF
--- a/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
+++ b/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
@@ -49,6 +49,9 @@ public final class UsagePaceDemoActivity extends Activity {
             return;
         }
         try {
+            // Optional overrides for demoing the non-configurable zero-balance auto-hide.
+            String creditsBalance = getIntent().getStringExtra("credits_balance");
+            boolean creditsNone = getIntent().getBooleanExtra("credits_none", false);
             long now = System.currentTimeMillis();
             long fiveHourReset = now - TimeUnit.HOURS.toMillis(1)
                     + TimeUnit.HOURS.toMillis(5);
@@ -69,7 +72,10 @@ public final class UsagePaceDemoActivity extends Activity {
                                     (now + TimeUnit.HOURS.toMillis(3)) / 1000L),
                             new UsageWindow(42, TimeUnit.DAYS.toSeconds(7), 0L,
                                     (now + TimeUnit.DAYS.toMillis(5)) / 1000L))),
-                    new UsageCredits(true, false, "2500"),
+                    creditsNone
+                            ? new UsageCredits(false, false, "")
+                            : new UsageCredits(true, false,
+                                    creditsBalance == null ? "2500" : creditsBalance),
                     3,
                     now);
             SecureTokenStore.save(this, new AuthTokens(

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,9 @@
             android:name="dev.bennett.codexmeter.UsageHistoryActivity"
             android:exported="false"/>
         <activity
+            android:name="dev.bennett.codexmeter.DashboardReorderActivity"
+            android:exported="false"/>
+        <activity
             android:name="dev.bennett.codexmeter.AboutActivity"
             android:exported="false"/>
         <activity

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -12,6 +12,7 @@ public final class AppPreferences {
     private static final String KEY_DASHBOARD_ADDITIONAL_LIMITS = "dashboard_additional_limits";
     private static final String KEY_DASHBOARD_FIVE_HOUR = "dashboard_five_hour";
     private static final String KEY_DASHBOARD_RESET_CREDITS = "dashboard_reset_credits";
+    private static final String KEY_DASHBOARD_SECTION_ORDER = "dashboard_section_order";
     private static final String KEY_DASHBOARD_USAGE_CREDITS = "dashboard_usage_credits";
     private static final String KEY_DASHBOARD_WEEKLY = "dashboard_weekly";
     private static final String KEY_MATERIAL_YOU = "material_you";
@@ -293,6 +294,20 @@ public final class AppPreferences {
                 .putBoolean(KEY_DASHBOARD_USAGE_CREDITS, usageCredits)
                 .putBoolean(KEY_DASHBOARD_RESET_CREDITS, resetCredits)
                 .apply();
+    }
+
+    /** Saved dashboard section order as a comma-separated {@link DashboardSections} key list. */
+    public static String getDashboardOrder(Context context) {
+        return prefs(context).getString(KEY_DASHBOARD_SECTION_ORDER, "");
+    }
+
+    public static void setDashboardOrder(Context context, java.util.List<String> order) {
+        String csv = DashboardSections.serialize(order);
+        if (csv.isEmpty()) {
+            prefs(context).edit().remove(KEY_DASHBOARD_SECTION_ORDER).apply();
+        } else {
+            prefs(context).edit().putString(KEY_DASHBOARD_SECTION_ORDER, csv).apply();
+        }
     }
 
     private static boolean validRefresh(int i) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
@@ -1,0 +1,257 @@
+package dev.bennett.codexmeter;
+
+import android.annotation.SuppressLint;
+import android.content.res.ColorStateList;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * One UI edit screen for arranging the dashboard sections. Rows are dragged with the SESL
+ * RecyclerView ItemTouchHelper, either from the reorder handle or with a long-press, and the
+ * order is saved immediately so the dashboard rebuilds on return.
+ */
+public final class DashboardReorderActivity extends AppCompatActivity {
+    private final List<SectionItem> items = new ArrayList<>();
+    private boolean dark;
+
+    private static final class SectionItem {
+        final String key;
+        final String title;
+        final String summary;
+
+        SectionItem(String key, String title, String summary) {
+            this.key = key;
+            this.title = title;
+            this.summary = summary;
+        }
+    }
+
+    @Override
+    protected void onCreate(Bundle state) {
+        Ui.applySelectedTheme(this);
+        super.onCreate(state);
+        this.dark = Ui.isDark(this);
+        LinearLayout content = Ui.installPage(this, "Edit dashboard", true).content;
+
+        TextView hint = Ui.text(this,
+                "Drag the handles to arrange your usage cards. Model-specific limits such as "
+                        + "GPT-5.3-Codex-Spark appear here automatically once OpenAI reports "
+                        + "them for your account.",
+                14.0f, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams hintParams = new LinearLayout.LayoutParams(-1, -2);
+        hintParams.setMargins(Ui.dp(this, 6), Ui.dp(this, 2), Ui.dp(this, 6), Ui.dp(this, 16));
+        content.addView(hint, hintParams);
+
+        buildItems();
+
+        RoundedLinearLayout listCard = Ui.cardGroup(this, dark);
+        RecyclerView recycler = new RecyclerView(this);
+        recycler.setLayoutManager(new LinearLayoutManager(this));
+        recycler.setNestedScrollingEnabled(false);
+        SectionAdapter adapter = new SectionAdapter();
+        recycler.setAdapter(adapter);
+        ItemTouchHelper touchHelper = new ItemTouchHelper(new ReorderCallback());
+        touchHelper.attachToRecyclerView(recycler);
+        adapter.touchHelper = touchHelper;
+        listCard.addView(recycler, new LinearLayout.LayoutParams(-1, -2));
+        content.addView(listCard);
+
+        TextView note = Ui.text(this,
+                "Changes are saved instantly. The usage-credit balance stays hidden whenever "
+                        + "it is zero or below, no matter where it is placed.",
+                12.0f, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(-1, -2);
+        noteParams.setMargins(Ui.dp(this, 6), Ui.dp(this, 14), Ui.dp(this, 6), 0);
+        content.addView(note, noteParams);
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+
+    private void buildItems() {
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
+        List<UsageLimit> limits = snapshot == null
+                ? Collections.<UsageLimit>emptyList() : snapshot.additionalLimits;
+        List<String> ordered = DashboardSections.resolveOrder(
+                AppPreferences.getDashboardOrder(this), DashboardSections.defaultOrder(limits));
+        for (String key : ordered) {
+            if (DashboardSections.FIVE_HOUR.equals(key)) {
+                items.add(new SectionItem(key, "5-hour limit", "Rolling 5-hour Codex window"));
+            } else if (DashboardSections.WEEKLY.equals(key)) {
+                items.add(new SectionItem(key, "Weekly limit", "Rolling 7-day Codex window"));
+            } else if (DashboardSections.USAGE_CREDITS.equals(key)) {
+                items.add(new SectionItem(key, "Usage-credit balance",
+                        "Hidden automatically at a zero or negative balance"));
+            } else {
+                UsageLimit match = null;
+                for (UsageLimit limit : limits) {
+                    if (limit != null && DashboardSections.limitKey(limit).equals(key)) {
+                        match = limit;
+                        break;
+                    }
+                }
+                items.add(new SectionItem(key,
+                        match == null ? "Additional limit" : match.displayName(),
+                        "Model-specific limit · detected automatically"));
+            }
+        }
+    }
+
+    private void persistOrder() {
+        List<String> order = new ArrayList<>();
+        for (SectionItem item : items) {
+            order.add(item.key);
+        }
+        AppPreferences.setDashboardOrder(this, order);
+    }
+
+    private final class SectionAdapter extends RecyclerView.Adapter<SectionHolder> {
+        ItemTouchHelper touchHelper;
+
+        @Override
+        public SectionHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            LinearLayout row = Ui.horizontal(DashboardReorderActivity.this,
+                    Gravity.CENTER_VERTICAL);
+            row.setMinimumHeight(Ui.dp(DashboardReorderActivity.this, 72));
+            row.setPadding(Ui.dp(DashboardReorderActivity.this, 22),
+                    Ui.dp(DashboardReorderActivity.this, 12),
+                    Ui.dp(DashboardReorderActivity.this, 16),
+                    Ui.dp(DashboardReorderActivity.this, 12));
+            row.setBackgroundColor(Ui.cardColor(DashboardReorderActivity.this, dark));
+            row.setLayoutParams(new RecyclerView.LayoutParams(-1, -2));
+
+            LinearLayout labels = new LinearLayout(DashboardReorderActivity.this);
+            labels.setOrientation(LinearLayout.VERTICAL);
+            TextView title = Ui.text(DashboardReorderActivity.this, "", 17.0f, Ui.mainText(dark));
+            labels.addView(title);
+            TextView summary = Ui.text(DashboardReorderActivity.this, "", 13.0f,
+                    Ui.secondaryText(dark));
+            LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-2, -2);
+            summaryParams.setMargins(0, Ui.dp(DashboardReorderActivity.this, 2), 0, 0);
+            labels.addView(summary, summaryParams);
+            row.addView(labels, new LinearLayout.LayoutParams(0, -2, 1.0f));
+
+            ImageView handle = new ImageView(DashboardReorderActivity.this);
+            handle.setImageResource(R.drawable.ic_oui_reorder);
+            handle.setImageTintList(ColorStateList.valueOf(Ui.secondaryText(dark)));
+            handle.setContentDescription("Reorder");
+            int pad = Ui.dp(DashboardReorderActivity.this, 12);
+            handle.setPadding(pad, pad, pad, pad);
+            row.addView(handle, new LinearLayout.LayoutParams(
+                    Ui.dp(DashboardReorderActivity.this, 48),
+                    Ui.dp(DashboardReorderActivity.this, 48)));
+
+            SectionHolder holder = new SectionHolder(row, title, summary, handle);
+            bindDragHandle(holder);
+            return holder;
+        }
+
+        @SuppressLint("ClickableViewAccessibility")
+        private void bindDragHandle(SectionHolder holder) {
+            holder.handle.setOnTouchListener((view, event) -> {
+                if (event.getActionMasked() == MotionEvent.ACTION_DOWN && touchHelper != null) {
+                    touchHelper.startDrag(holder);
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        @Override
+        public void onBindViewHolder(SectionHolder holder, int position) {
+            SectionItem item = items.get(position);
+            holder.title.setText(item.title);
+            holder.summary.setText(item.summary);
+        }
+
+        @Override
+        public int getItemCount() {
+            return items.size();
+        }
+    }
+
+    private static final class SectionHolder extends RecyclerView.ViewHolder {
+        final TextView title;
+        final TextView summary;
+        final ImageView handle;
+
+        SectionHolder(View row, TextView title, TextView summary, ImageView handle) {
+            super(row);
+            this.title = title;
+            this.summary = summary;
+            this.handle = handle;
+        }
+    }
+
+    private final class ReorderCallback extends ItemTouchHelper.Callback {
+        @Override
+        public int getMovementFlags(RecyclerView recyclerView, RecyclerView.ViewHolder holder) {
+            return makeMovementFlags(ItemTouchHelper.UP | ItemTouchHelper.DOWN, 0);
+        }
+
+        @Override
+        public boolean isLongPressDragEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder from,
+                RecyclerView.ViewHolder to) {
+            int fromPosition = from.getBindingAdapterPosition();
+            int toPosition = to.getBindingAdapterPosition();
+            if (fromPosition < 0 || toPosition < 0) {
+                return false;
+            }
+            if (fromPosition < toPosition) {
+                for (int i = fromPosition; i < toPosition; i++) {
+                    Collections.swap(items, i, i + 1);
+                }
+            } else {
+                for (int i = fromPosition; i > toPosition; i--) {
+                    Collections.swap(items, i, i - 1);
+                }
+            }
+            recyclerView.getAdapter().notifyItemMoved(fromPosition, toPosition);
+            persistOrder();
+            return true;
+        }
+
+        @Override
+        public void onSelectedChanged(RecyclerView.ViewHolder holder, int actionState) {
+            super.onSelectedChanged(holder, actionState);
+            if (actionState == ItemTouchHelper.ACTION_STATE_DRAG && holder != null) {
+                holder.itemView.setAlpha(0.85f);
+                holder.itemView.setElevation(Ui.dp(holder.itemView.getContext(), 4));
+            }
+        }
+
+        @Override
+        public void clearView(RecyclerView recyclerView, RecyclerView.ViewHolder holder) {
+            super.clearView(recyclerView, holder);
+            holder.itemView.setAlpha(1.0f);
+            holder.itemView.setElevation(0.0f);
+            persistOrder();
+        }
+
+        @Override
+        public void onSwiped(RecyclerView.ViewHolder holder, int direction) {
+        }
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
@@ -26,6 +26,7 @@ import java.util.List;
  */
 public final class DashboardReorderActivity extends AppCompatActivity {
     private final List<SectionItem> items = new ArrayList<>();
+    private RecyclerView recycler;
     private boolean dark;
 
     private static final class SectionItem {
@@ -46,6 +47,10 @@ public final class DashboardReorderActivity extends AppCompatActivity {
         super.onCreate(state);
         this.dark = Ui.isDark(this);
         LinearLayout content = Ui.installPage(this, "Edit dashboard", true).content;
+        // Pull-to-refresh would swallow downward drag gestures while rearranging rows.
+        androidx.swiperefreshlayout.widget.SwipeRefreshLayout refresh =
+                findViewById(R.id.dashboard_refresh);
+        refresh.setEnabled(false);
 
         TextView hint = Ui.text(this,
                 "Drag the handles to arrange your usage cards. Model-specific limits such as "
@@ -59,7 +64,7 @@ public final class DashboardReorderActivity extends AppCompatActivity {
         buildItems();
 
         RoundedLinearLayout listCard = Ui.cardGroup(this, dark);
-        RecyclerView recycler = new RecyclerView(this);
+        recycler = new RecyclerView(this);
         recycler.setLayoutManager(new LinearLayoutManager(this));
         recycler.setNestedScrollingEnabled(false);
         SectionAdapter adapter = new SectionAdapter();
@@ -111,6 +116,16 @@ public final class DashboardReorderActivity extends AppCompatActivity {
                         match == null ? "Additional limit" : match.displayName(),
                         "Model-specific limit · detected automatically"));
             }
+        }
+    }
+
+    /**
+     * Stops the scroll containers above the list from intercepting the vertical drag while
+     * leaving the RecyclerView itself free to run the ItemTouchHelper reorder gesture.
+     */
+    private void lockAncestorScrolling() {
+        if (recycler != null && recycler.getParent() != null) {
+            recycler.getParent().requestDisallowInterceptTouchEvent(true);
         }
     }
 
@@ -167,6 +182,7 @@ public final class DashboardReorderActivity extends AppCompatActivity {
         private void bindDragHandle(SectionHolder holder) {
             holder.handle.setOnTouchListener((view, event) -> {
                 if (event.getActionMasked() == MotionEvent.ACTION_DOWN && touchHelper != null) {
+                    lockAncestorScrolling();
                     touchHelper.startDrag(holder);
                     return true;
                 }
@@ -237,6 +253,7 @@ public final class DashboardReorderActivity extends AppCompatActivity {
         public void onSelectedChanged(RecyclerView.ViewHolder holder, int actionState) {
             super.onSelectedChanged(holder, actionState);
             if (actionState == ItemTouchHelper.ACTION_STATE_DRAG && holder != null) {
+                lockAncestorScrolling();
                 holder.itemView.setAlpha(0.85f);
                 holder.itemView.setElevation(Ui.dp(holder.itemView.getContext(), 4));
             }

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -29,7 +29,11 @@ import android.widget.TextView;
 import android.widget.Toast;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import androidx.appcompat.app.AppCompatActivity;
@@ -39,6 +43,7 @@ import dev.bennett.codexmeter.wear.PhoneWearSync;
 /* JADX INFO: loaded from: classes.dex */
 public final class MainActivity extends AppCompatActivity {
     private static final int MENU_SETTINGS = 8101;
+    private static final int MENU_REORDER = 8102;
     private String appliedTheme;
     private boolean appliedMaterialYou;
     private LinearLayout content;
@@ -110,7 +115,10 @@ public final class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        menu.add(Menu.NONE, MENU_SETTINGS, 0, "Settings")
+        menu.add(Menu.NONE, MENU_REORDER, 0, "Edit dashboard")
+                .setIcon(R.drawable.ic_oui_edit_outline)
+                .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        menu.add(Menu.NONE, MENU_SETTINGS, 1, "Settings")
                 .setIcon(R.drawable.ic_oui_settings_outline)
                 .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
         return true;
@@ -120,6 +128,10 @@ public final class MainActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == MENU_SETTINGS) {
             Ui.startSecondaryActivity(this, SettingsActivity.class);
+            return true;
+        }
+        if (item.getItemId() == MENU_REORDER) {
+            Ui.startSecondaryActivity(this, DashboardReorderActivity.class);
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -338,35 +350,64 @@ public final class MainActivity extends AppCompatActivity {
         if (!signedIn || snapshot == null) {
             return column;
         }
-        boolean inverted = false;
+        Map<String, List<UsageLimit>> limitsByKey = new LinkedHashMap<>();
+        for (UsageLimit limit : snapshot.additionalLimits) {
+            String key = DashboardSections.limitKey(limit);
+            List<UsageLimit> group = limitsByKey.get(key);
+            if (group == null) {
+                group = new ArrayList<>();
+                limitsByKey.put(key, group);
+            }
+            group.add(limit);
+        }
+        List<String> available = new ArrayList<>();
         if (AppPreferences.showDashboardFiveHour(this) && snapshot.fiveHour != null) {
-            addDashboardCard(column, buildMetricCard(
-                    "5-hour", snapshot, snapshot.fiveHour, inverted));
-            inverted = !inverted;
+            available.add(DashboardSections.FIVE_HOUR);
         }
         if (AppPreferences.showDashboardWeekly(this) && snapshot.weekly != null) {
-            addDashboardCard(column, buildMetricCard(
-                    "Weekly", snapshot, snapshot.weekly, inverted));
-            inverted = !inverted;
+            available.add(DashboardSections.WEEKLY);
         }
         if (AppPreferences.showDashboardAdditionalLimits(this)) {
-            for (UsageLimit limit : snapshot.additionalLimits) {
-                if (limit.primary != null) {
-                    addDashboardCard(column, buildMetricCard(
-                            limitTitle(limit) + " · " + cadenceLabel(limit.primary),
-                            snapshot, limit.primary, inverted));
-                    inverted = !inverted;
+            available.addAll(limitsByKey.keySet());
+        }
+        // Zero, near-zero, and negative balances are always hidden regardless of settings.
+        if (AppPreferences.showDashboardUsageCredits(this) && snapshot.usageCredits != null
+                && snapshot.usageCredits.shouldDisplay()) {
+            available.add(DashboardSections.USAGE_CREDITS);
+        }
+        boolean inverted = false;
+        for (String key : DashboardSections.resolveOrder(
+                AppPreferences.getDashboardOrder(this), available)) {
+            if (DashboardSections.FIVE_HOUR.equals(key)) {
+                addDashboardCard(column, buildMetricCard(
+                        "5-hour", snapshot, snapshot.fiveHour, inverted));
+                inverted = !inverted;
+            } else if (DashboardSections.WEEKLY.equals(key)) {
+                addDashboardCard(column, buildMetricCard(
+                        "Weekly", snapshot, snapshot.weekly, inverted));
+                inverted = !inverted;
+            } else if (DashboardSections.USAGE_CREDITS.equals(key)) {
+                addDashboardCard(column, buildUsageCreditsCard(snapshot.usageCredits));
+            } else {
+                List<UsageLimit> group = limitsByKey.get(key);
+                if (group == null) {
+                    continue;
                 }
-                if (limit.secondary != null) {
-                    addDashboardCard(column, buildMetricCard(
-                            limitTitle(limit) + " · " + cadenceLabel(limit.secondary),
-                            snapshot, limit.secondary, inverted));
-                    inverted = !inverted;
+                for (UsageLimit limit : group) {
+                    if (limit.primary != null) {
+                        addDashboardCard(column, buildMetricCard(
+                                limitTitle(limit) + " · " + cadenceLabel(limit.primary),
+                                snapshot, limit.primary, inverted));
+                        inverted = !inverted;
+                    }
+                    if (limit.secondary != null) {
+                        addDashboardCard(column, buildMetricCard(
+                                limitTitle(limit) + " · " + cadenceLabel(limit.secondary),
+                                snapshot, limit.secondary, inverted));
+                        inverted = !inverted;
+                    }
                 }
             }
-        }
-        if (AppPreferences.showDashboardUsageCredits(this) && snapshot.usageCredits != null) {
-            addDashboardCard(column, buildUsageCreditsCard(snapshot.usageCredits));
         }
         return column;
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -427,6 +427,11 @@ public final class SettingsActivity extends AppCompatActivity {
         }
 
         private void bindRefresh() {
+            findPreference("dashboard_reorder_ui").setOnPreferenceClickListener(preference -> {
+                Ui.startSecondaryActivity(requireActivity(), DashboardReorderActivity.class);
+                return true;
+            });
+
             SwitchPreferenceCompat onLaunch = findPreference("refresh_on_launch");
             onLaunch.setEnabled(true);
             onLaunch.setChecked(AppPreferences.getRefreshOnLaunch(requireContext()));

--- a/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
+++ b/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
@@ -21,6 +21,10 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Dashboard">
+        <Preference
+            android:key="dashboard_reorder_ui"
+            android:summary="Drag usage cards above or below each other"
+            android:title="Reorder dashboard" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_five_hour"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -29,6 +29,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageLimit.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/DashboardSections.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSample.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageHistory.java" \
@@ -83,6 +84,23 @@ grep -Fq '"platforms;android-37.0"' "$WORKFLOW"
 grep -q 'BenItBuhner/Codex-Meter/releases?per_page=30' "$ROOT/app/build.gradle.kts" # pragma: allowlist secret
 ! grep -R -q 'thatjoshguy67/Codex-Meter' \
   "$ROOT/app/src" "$ROOT/app/build.gradle.kts"
+
+# Dashboard reorder + usage-credit auto-hide wiring.
+grep -q 'testUsageCreditsAutoHide' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'testDashboardSectionOrder' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'DashboardReorderActivity' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'snapshot.usageCredits.shouldDisplay()' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'DashboardSections.resolveOrder' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'ItemTouchHelper' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java"
+grep -q 'ic_oui_reorder' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java"
+grep -q 'dashboard_reorder_ui' \
+  "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
+grep -q 'dashboard_reorder_ui' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
 
 grep -q 'android.permission.ACCESS_NETWORK_STATE' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'android.permission.POST_NOTIFICATIONS' "$ROOT/app/src/main/AndroidManifest.xml"

--- a/android/shared/src/main/java/dev/bennett/codexmeter/DashboardSections.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/DashboardSections.java
@@ -1,0 +1,117 @@
+package dev.bennett.codexmeter;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Stable keys and ordering rules for the movable dashboard sections: the built-in 5-hour and
+ * weekly windows, every automatically detected additional limit (for example
+ * GPT-5.3-Codex-Spark), and the usage-credit balance. The saved order is a comma-separated key
+ * list; unknown saved keys are dropped and newly detected sections slot into their default
+ * position, so accounts gaining or losing model-specific limits never lose their arrangement.
+ */
+public final class DashboardSections {
+    public static final String FIVE_HOUR = "five_hour";
+    public static final String WEEKLY = "weekly";
+    public static final String USAGE_CREDITS = "usage_credits";
+    private static final String LIMIT_PREFIX = "limit:";
+
+    private DashboardSections() {
+    }
+
+    /** Stable key for an additional limit, preferring the API id over display names. */
+    public static String limitKey(UsageLimit limit) {
+        String identity = limit.id;
+        if (identity.isEmpty()) {
+            identity = limit.name;
+        }
+        if (identity.isEmpty()) {
+            identity = limit.meteredFeature;
+        }
+        if (identity.isEmpty()) {
+            identity = "additional";
+        }
+        return LIMIT_PREFIX + identity.toLowerCase(Locale.ROOT).replace(',', '_');
+    }
+
+    public static boolean isLimitKey(String key) {
+        return key != null && key.startsWith(LIMIT_PREFIX);
+    }
+
+    /** Default order: 5-hour, weekly, detected additional limits, usage credits. */
+    public static List<String> defaultOrder(List<UsageLimit> additionalLimits) {
+        List<String> order = new ArrayList<>();
+        order.add(FIVE_HOUR);
+        order.add(WEEKLY);
+        if (additionalLimits != null) {
+            for (UsageLimit limit : additionalLimits) {
+                if (limit != null && !order.contains(limitKey(limit))) {
+                    order.add(limitKey(limit));
+                }
+            }
+        }
+        order.add(USAGE_CREDITS);
+        return order;
+    }
+
+    /**
+     * Applies a saved order to the currently available section keys. Saved keys that are no
+     * longer available are ignored; available keys missing from the saved order are inserted
+     * right after the nearest preceding available key that survived, so new sections appear in
+     * their natural position instead of being dumped at the end.
+     */
+    public static List<String> resolveOrder(String savedCsv, List<String> available) {
+        List<String> availableKeys = new ArrayList<>(new LinkedHashSet<>(available));
+        List<String> result = new ArrayList<>();
+        for (String key : parseCsv(savedCsv)) {
+            if (availableKeys.contains(key) && !result.contains(key)) {
+                result.add(key);
+            }
+        }
+        for (int i = 0; i < availableKeys.size(); i++) {
+            String key = availableKeys.get(i);
+            if (result.contains(key)) {
+                continue;
+            }
+            int insertAt = 0;
+            for (int previous = 0; previous < i; previous++) {
+                int position = result.indexOf(availableKeys.get(previous));
+                if (position >= 0) {
+                    insertAt = Math.max(insertAt, position + 1);
+                }
+            }
+            result.add(insertAt, key);
+        }
+        return result;
+    }
+
+    public static String serialize(List<String> order) {
+        StringBuilder csv = new StringBuilder();
+        for (String key : order) {
+            if (key == null || key.trim().isEmpty()) {
+                continue;
+            }
+            if (csv.length() > 0) {
+                csv.append(',');
+            }
+            csv.append(key.trim());
+        }
+        return csv.toString();
+    }
+
+    private static List<String> parseCsv(String csv) {
+        List<String> keys = new ArrayList<>();
+        if (csv == null || csv.trim().isEmpty()) {
+            return keys;
+        }
+        for (String part : csv.split(",")) {
+            String key = part.trim();
+            if (!key.isEmpty()) {
+                keys.add(key);
+            }
+        }
+        return keys;
+    }
+}

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
@@ -1,10 +1,17 @@
 package dev.bennett.codexmeter;
 
+import java.math.BigDecimal;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 /** Purchased usage-credit state returned by the main Codex usage endpoint. */
 public final class UsageCredits {
+    /**
+     * Balances below this render as "0" with the two fraction digits used across the app,
+     * so they are treated as exhausted and never displayed.
+     */
+    private static final BigDecimal NEAR_ZERO_BALANCE = new BigDecimal("0.005");
+
     public final boolean hasCredits;
     public final boolean unlimited;
     public final String balance;
@@ -14,6 +21,38 @@ public final class UsageCredits {
         this.unlimited = unlimited;
         String cleanBalance = balance == null ? "" : balance.trim();
         this.balance = hasCredits || unlimited ? cleanBalance : "";
+    }
+
+    /**
+     * Whether the balance is worth surfacing anywhere in the UI. This is intentionally not
+     * configurable: zero, effectively-zero, and negative balances always hide the card, as does
+     * an account without purchased credits. Unlimited plans and unparseable non-empty balances
+     * remain visible.
+     */
+    public boolean shouldDisplay() {
+        if (unlimited) {
+            return true;
+        }
+        if (!hasCredits) {
+            return false;
+        }
+        if (balance.isEmpty()) {
+            return true;
+        }
+        BigDecimal amount = numericBalance();
+        return amount == null || amount.compareTo(NEAR_ZERO_BALANCE) >= 0;
+    }
+
+    /** Numeric balance, or null when the reported balance is empty or not a number. */
+    public BigDecimal numericBalance() {
+        if (balance.isEmpty()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(balance.replace(",", ""));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
     }
 
     public JSONObject toJson() throws JSONException {

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java
@@ -121,8 +121,7 @@ public final class UsageSnapshot {
 
     public boolean hasDisplayableData() {
         return fiveHour != null || weekly != null || !additionalLimits.isEmpty()
-                || (usageCredits != null && (usageCredits.hasCredits
-                || usageCredits.unlimited || !usageCredits.balance.isEmpty()))
+                || (usageCredits != null && usageCredits.shouldDisplay())
                 || resetCreditsAvailable >= 0;
     }
 

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -19,6 +19,8 @@ public final class ParserSelfTest {
         testPrimaryLimitWinsOverAdditional();
         testOptionalUsageSections();
         testUsageCredits();
+        testUsageCreditsAutoHide();
+        testDashboardSectionOrder();
         testMalformedWindowIgnored();
         testZeroDurationWindowIgnored();
         testNextResetSelection();
@@ -664,6 +666,81 @@ public final class ParserSelfTest {
         check(none.usageCredits != null && none.usageCredits.balance.isEmpty()
                         && !none.hasDisplayableData(),
                 "zero balance for an account without purchased credits is not standalone data");
+    }
+
+    private static void testUsageCreditsAutoHide() {
+        check(new UsageCredits(true, false, "2500").shouldDisplay(),
+                "positive usage-credit balance stays visible");
+        check(new UsageCredits(true, false, "0.01").shouldDisplay(),
+                "smallest renderable balance stays visible");
+        check(new UsageCredits(false, true, "").shouldDisplay(),
+                "unlimited plans always show the credits card");
+        check(new UsageCredits(true, false, "").shouldDisplay(),
+                "credits without a reported amount stay visible");
+        check(new UsageCredits(true, false, "12k credits").shouldDisplay(),
+                "unparseable non-empty balance stays visible rather than silently vanishing");
+        check(!new UsageCredits(true, false, "0").shouldDisplay(),
+                "zero balance is always hidden");
+        check(!new UsageCredits(true, false, "0.00").shouldDisplay(),
+                "fractional zero balance is always hidden");
+        check(!new UsageCredits(true, false, "0.004").shouldDisplay(),
+                "balance that would render as 0 is always hidden");
+        check(!new UsageCredits(true, false, "-12.5").shouldDisplay(),
+                "negative balance is always hidden");
+        check(!new UsageCredits(false, false, "500").shouldDisplay(),
+                "no purchased credits hides the card entirely");
+        UsageSnapshot zeroOnly = new UsageSnapshot("plus", true, false, null, null,
+                java.util.Collections.emptyList(), new UsageCredits(true, false, "0"), -1, 9L);
+        check(!zeroOnly.hasDisplayableData(),
+                "snapshot with only a zero balance has nothing to display");
+        System.out.println("Usage-credit auto-hide: zero, near-zero, and negative balances "
+                + "never render.");
+    }
+
+    private static void testDashboardSectionOrder() {
+        UsageLimit spark = new UsageLimit("codex-spark", "GPT-5.3-Codex-Spark",
+                "codex_bengalfox", true, false,
+                new UsageWindow(24, 18000L, 0L, 2_000_000_000L), null);
+        String sparkKey = DashboardSections.limitKey(spark);
+        check("limit:codex-spark".equals(sparkKey), "limit key prefers the API id");
+        check("limit:gpt-5.3-codex-spark".equals(DashboardSections.limitKey(new UsageLimit(
+                        "", "GPT-5.3-Codex-Spark", "", true, false,
+                        new UsageWindow(1, 18000L, 0L, 2_000_000_000L), null))),
+                "limit key falls back to the display name");
+        List<String> defaults = DashboardSections.defaultOrder(Arrays.asList(spark));
+        check(defaults.equals(Arrays.asList(
+                        DashboardSections.FIVE_HOUR, DashboardSections.WEEKLY, sparkKey,
+                        DashboardSections.USAGE_CREDITS)),
+                "default order is 5-hour, weekly, detected limits, credits");
+
+        check(DashboardSections.resolveOrder("", defaults).equals(defaults),
+                "no saved order keeps the defaults");
+        List<String> saved = DashboardSections.resolveOrder(
+                "usage_credits, limit:codex-spark ,five_hour,weekly", defaults);
+        check(saved.equals(Arrays.asList(DashboardSections.USAGE_CREDITS, sparkKey,
+                        DashboardSections.FIVE_HOUR, DashboardSections.WEEKLY)),
+                "saved order is applied with whitespace tolerated");
+        List<String> withoutSpark = DashboardSections.resolveOrder(
+                "weekly,five_hour,usage_credits",
+                DashboardSections.defaultOrder(Arrays.asList(spark)));
+        check(withoutSpark.equals(Arrays.asList(DashboardSections.WEEKLY,
+                        DashboardSections.FIVE_HOUR, sparkKey, DashboardSections.USAGE_CREDITS)),
+                "newly detected Spark limit slots in before credits, not at the end");
+        List<String> staleKeys = DashboardSections.resolveOrder(
+                "limit:old-model,weekly,five_hour",
+                Arrays.asList(DashboardSections.FIVE_HOUR, DashboardSections.WEEKLY));
+        check(staleKeys.equals(Arrays.asList(DashboardSections.WEEKLY,
+                        DashboardSections.FIVE_HOUR)),
+                "keys for limits no longer reported are dropped");
+        check(DashboardSections.serialize(saved)
+                        .equals("usage_credits,limit:codex-spark,five_hour,weekly"),
+                "order round-trips through the stored CSV form");
+        check(DashboardSections.resolveOrder(null,
+                        Arrays.asList(DashboardSections.FIVE_HOUR))
+                        .equals(Arrays.asList(DashboardSections.FIVE_HOUR)),
+                "null saved order is tolerated");
+        System.out.println("Dashboard sections: saved order honored, auto-detected limits "
+                + "keep a stable slot.");
     }
 
     private static void testMalformedWindowIgnored() throws Exception {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Usage-credit auto-hide (non-configurable):** the usage-credit balance card is now hidden entirely whenever the balance is zero, effectively zero (would render as "0" at two fraction digits), or negative, and when the account has no purchased credits. Unlimited plans and accounts with a real balance are unaffected. Logic lives in `UsageCredits.shouldDisplay()` in the shared core and is enforced in `MainActivity` and `UsageSnapshot.hasDisplayableData()`.
- **Reorderable dashboard sections:** the 5-hour limit, weekly limit, every automatically detected additional limit (e.g. GPT-5.3-Codex-Spark), and the usage-credit balance can now be dragged above or below each other. A new One UI edit screen (`DashboardReorderActivity`) uses the SESL RecyclerView `ItemTouchHelper` with native `ic_oui_reorder` drag handles; reordering works via the handle or long-press, and saves instantly.
- Order persistence and merging rules live in the new shared `DashboardSections` model: saved keys for limits that disappear are dropped, and newly detected model-specific limits slot into their natural position instead of the end.
- Entry points: an "Edit dashboard" toolbar action on the main dashboard and a "Reorder dashboard" preference under Settings → Refresh &amp; usage → Dashboard.
- The debug-only `UsagePaceDemoActivity` gains `credits_balance` / `credits_none` intent extras for demoing the auto-hide.

## Testing

- `./run-tests.sh` passes, including new `testUsageCreditsAutoHide` and `testDashboardSectionOrder` self-tests plus new source-level wiring checks.
- `android/build.sh` (phone + Wear release APKs) and `android/lint.sh` pass.
- Verified end-to-end on a software-rendered (no-KVM, pure TCG) Android 11 emulator with the debug APK.

## Emulator demo

Reorder end-to-end (drag "Usage-credit balance" to the top in the edit screen, then app restart proving the persisted order):

[reorder_dashboard_drag_and_persist_demo.mp4](https://cursor.com/agents/bc-8a69a18a-817b-4134-a84c-670d9ac5630e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freorder_dashboard_drag_and_persist_demo.mp4)

| Positive balance (visible) | Zero balance (auto-hidden) | Negative balance (auto-hidden) |
| --- | --- | --- |
| [2,500 credits visible](https://cursor.com/agents/bc-8a69a18a-817b-4134-a84c-670d9ac5630e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcredits_2500_visible_default_order.png) | [Zero balance hidden](https://cursor.com/agents/bc-8a69a18a-817b-4134-a84c-670d9ac5630e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcredits_zero_balance_auto_hidden.png) | [Negative balance hidden](https://cursor.com/agents/bc-8a69a18a-817b-4134-a84c-670d9ac5630e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcredits_negative_balance_auto_hidden.png) |

| Edit screen after drag | Dashboard after reorder |
| --- | --- |
| [Edit dashboard screen with credits first](https://cursor.com/agents/bc-8a69a18a-817b-4134-a84c-670d9ac5630e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_dashboard_screen_credits_dragged_first.png) | [Dashboard with credits first](https://cursor.com/agents/bc-8a69a18a-817b-4134-a84c-670d9ac5630e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_credits_first_after_reorder.png) |


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a69a18a-817b-4134-a84c-670d9ac5630e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a69a18a-817b-4134-a84c-670d9ac5630e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

