### PR TITLE
Prepare Codex Meter 2.6.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.7.0 — 2026-07-26
+## 2.6.5 — 2026-07-26
 
 ### Added
 
@@ -18,7 +18,7 @@
 
 - Expanded regression coverage for usage-credit auto-hide, dashboard section order merging, Wear modular tile metadata, and widget configuration wiring (#67, #68, #75).
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.0...v2.7.0 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.0...v2.6.5 <!-- pragma: allowlist secret -->
 
 ## 2.6.0 — 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.7.0 — 2026-07-26
+
+### Added
+
+- Local usage history with burn charts and trend-aware pace estimates on Android (#68).
+- Responsive single-dial home and lock widgets that adapt to available size, with clarified Both windows / 5-hour only / Weekly only allowance labels (#68).
+- Samsung One UI Watch modular tile metadata (2×2 overview and 2×1 focused tiles), redesigned Wear tiles with One UI Sans and battery-style dials, and adaptive complications across short/long text, ranged/goal progress, and image slots (#67).
+- Drag-to-reorder dashboard sections for the 5-hour limit, weekly limit, additional model limits, and usage-credit balance, with a One UI edit screen and Settings entry (#75).
+
+### Changed
+
+- Usage-credit balance cards auto-hide when the balance is empty, effectively zero, negative, or absent (#75).
+- Widget allowance configuration uses shared One UI choice dialogs on phone and lock widgets (#68).
+
+### Development
+
+- Expanded regression coverage for usage-credit auto-hide, dashboard section order merging, Wear modular tile metadata, and widget configuration wiring (#67, #68, #75).
+
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.0...v2.7.0 <!-- pragma: allowlist secret -->
+
 ## 2.6.0 — 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
 
-## Android — Version 2.7.0
+## Android — Version 2.6.5
 
-Version 2.7.0 adds local usage history with burn charts, responsive single-dial widgets, One UI Watch modular tiles and adaptive complications, drag-to-reorder dashboard sections, and automatic hiding of empty usage-credit balances.
+Version 2.6.5 adds local usage history with burn charts, responsive single-dial widgets, One UI Watch modular tiles and adaptive complications, drag-to-reorder dashboard sections, and automatic hiding of empty usage-credit balances.
 
 On compatible Galaxy Watches, those five standard AndroidX Tiles also advertise Samsung's private modular-card hints: the overview requests a 2×2 footprint and the focused usage, reset, and monitor Tiles request 2×1 footprints. Their diagonal One UI gradient cards use the same rounded 228-degree usage-dial geometry and One UI Sans typography as the phone's battery-style widgets. Other Wear OS tile hosts ignore the sizing hints and keep the normal full-screen carousel presentation. Samsung does not document third-party eligibility for modular placement, so final grid behavior remains firmware-dependent.
 
@@ -96,7 +96,7 @@ xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.7.0`) runs the full CI pipeline and publishes the signed phone APK, signed Wear OS APK, and their SHA-256 checksums to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
+Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.6.5`) runs the full CI pipeline and publishes the signed phone APK, signed Wear OS APK, and their SHA-256 checksums to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
 
 ## Platform stability
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
 
-## Android — Version 2.6.0
+## Android — Version 2.7.0
 
-Version 2.6.0 adds adaptive Automatic refresh scheduling and an adaptive usage dashboard: named additional rate limits, purchased usage credits, hide-missing windows, and per-section visibility controls on Android and iOS, plus the One UI design library bump to `0.9.14+oneui8`.
+Version 2.7.0 adds local usage history with burn charts, responsive single-dial widgets, One UI Watch modular tiles and adaptive complications, drag-to-reorder dashboard sections, and automatic hiding of empty usage-credit balances.
 
 On compatible Galaxy Watches, those five standard AndroidX Tiles also advertise Samsung's private modular-card hints: the overview requests a 2×2 footprint and the focused usage, reset, and monitor Tiles request 2×1 footprints. Their diagonal One UI gradient cards use the same rounded 228-degree usage-dial geometry and One UI Sans typography as the phone's battery-style widgets. Other Wear OS tile hosts ignore the sizing hints and keep the normal full-screen carousel presentation. Samsung does not document third-party eligibility for modular placement, so final grid behavior remains firmware-dependent.
 
@@ -96,7 +96,7 @@ xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
 
 ## Releases
 
-Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.6.0`) runs the full CI pipeline and publishes the signed phone APK, signed Wear OS APK, and their SHA-256 checksums to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
+Creating a `v*` tag that matches the Gradle `versionName` in `android/app/build.gradle.kts` (for example `v2.7.0`) runs the full CI pipeline and publishes the signed phone APK, signed Wear OS APK, and their SHA-256 checksums to GitHub Releases. CI authenticates and decrypts the persistent PKCS#12 release keystore `android/ci/release-keystore.p12.enc` (alias `codexmeter`) using the `ANDROID_SIGNING_PASSWORD` repository Actions secret, so every release is signed with the same certificate and installs in place over previous releases. Release notes are taken from the root `CHANGELOG.md`.
 
 ## Platform stability
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22
-        versionName = "2.6.0"
+        versionCode = 23
+        versionName = "2.7.0"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 23
-        versionName = "2.7.0"
+        versionName = "2.6.5"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -35,13 +35,13 @@ public final class AppConstants {
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
     public static final int VERSION_CODE = 23;
-    public static final String VERSION_NAME = "2.7.0";
+    public static final String VERSION_NAME = "2.6.5";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.7.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.6.5 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 22;
-    public static final String VERSION_NAME = "2.6.0";
+    public static final int VERSION_CODE = 23;
+    public static final String VERSION_NAME = "2.7.0";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.6.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.7.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.7.0"
+VERSION_NAME="2.6.5"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.6.0"
+VERSION_NAME="2.7.0"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -70,14 +70,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.6.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 22' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.6.0"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 22' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.6.0"' "$ROOT/wear/build.gradle.kts"
-grep -q 'versionCode = 22' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.6.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.6.0"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.7.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 23' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.7.0"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 23' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.7.0"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionCode = 23' "$ROOT/wear/build.gradle.kts"
+grep -q 'codex-meter-android/2.7.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.7.0"' "$ROOT/build.sh"
 WORKFLOW="$ROOT/../.github/workflows/build-apk.yml"
 grep -Fq 'release-dist/CodexMeter-Wear-$VERSION_NAME.apk' "$WORKFLOW"
 grep -Fq '"platforms;android-37.0"' "$WORKFLOW"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -70,14 +70,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.7.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME = "2.6.5"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
 grep -q 'VERSION_CODE = 23' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.7.0"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.6.5"' "$ROOT/app/build.gradle.kts"
 grep -q 'versionCode = 23' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.7.0"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionName = "2.6.5"' "$ROOT/wear/build.gradle.kts"
 grep -q 'versionCode = 23' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.7.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.7.0"' "$ROOT/build.sh"
+grep -q 'codex-meter-android/2.6.5' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.6.5"' "$ROOT/build.sh"
 WORKFLOW="$ROOT/../.github/workflows/build-apk.yml"
 grep -Fq 'release-dist/CodexMeter-Wear-$VERSION_NAME.apk' "$WORKFLOW"
 grep -Fq '"platforms;android-37.0"' "$WORKFLOW"

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -376,7 +376,7 @@ public final class ParserSelfTest {
         check(!clearRoundTrip.signedIn,
                 "Wear usage clear payload preserves signed-out state");
         WearSyncStatus status = new WearSyncStatus(true, true, 3000L,
-                "Network unavailable", "2.6.0", 4000L);
+                "Network unavailable", "2.7.0", 4000L);
         WearSyncStatus statusRoundTrip = WearSyncStatus.fromJson(status.toJson());
         check(statusRoundTrip != null && statusRoundTrip.signedIn,
                 "Wear status preserves phone sign-in state");

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -376,7 +376,7 @@ public final class ParserSelfTest {
         check(!clearRoundTrip.signedIn,
                 "Wear usage clear payload preserves signed-out state");
         WearSyncStatus status = new WearSyncStatus(true, true, 3000L,
-                "Network unavailable", "2.7.0", 4000L);
+                "Network unavailable", "2.6.5", 4000L);
         WearSyncStatus statusRoundTrip = WearSyncStatus.fromJson(status.toJson());
         check(statusRoundTrip != null && statusRoundTrip.signedIn,
                 "Wear status preserves phone sign-in state");

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 22
-        versionName = "2.6.0"
+        versionCode = 23
+        versionName = "2.7.0"
     }
 
     signingConfigs {

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         minSdk = 30
         targetSdk = 36
         versionCode = 23
-        versionName = "2.7.0"
+        versionName = "2.6.5"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump Android phone + Wear to version code **23** / **2.6.5** across Gradle, `AppConstants`, `build.sh`, and release self-checks.
- Document post-`v2.6.0` changes from merged PRs **#67**, **#68**, and **#75** in `CHANGELOG.md` and refresh the README version blurb.

### Included since v2.6.0

- **#75** — Auto-hide empty usage-credit balance and One UI dashboard reordering
- **#67** — One UI Watch modular tiles and adaptive complications
- **#68** — Local usage history and responsive single-dial widgets

This PR only prepares version metadata and release notes — it does **not** create the `v2.6.5` tag or GitHub Release. After merge, tagging `v2.6.5` on the merge commit will trigger CI to publish the signed phone + Wear APKs.

## Testing

- `./run-tests.sh` passed (parser/updater/OAuth/onboarding/widget/Wear checks + version guards for 2.6.5 / code 23)
- `./build.sh` produced `android/dist/CodexMeter-2.6.5.apk` and `CodexMeter-Wear-2.6.5.apk` (APK Signature Scheme v2)
- `./lint.sh` passed (`:app:lintRelease` + `:wear:lintRelease`)
- [ ] Tag `v2.6.5` after merge (will push/create release once instructed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2ed86b0-53b5-4a48-ae4c-a8371d8926a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2ed86b0-53b5-4a48-ae4c-a8371d8926a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

