### PR TITLE
Reorderable reset-credits section and consistent in-card titles for credit cards (2.6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.6.7 — 2026-07-26
+
+### Fixed
+
+- Reset credits is now a real dashboard section that reorders and hides with the rest of the cards, so the usage-history chart (or any other card) can be placed below it instead of the reset-credit card being pinned to the bottom of the page.
+- Reset-credit and usage-credit cards use bold in-card titles with left-aligned icon rows, matching the 5-hour, weekly, and usage-history cards, instead of external One UI section separators that looked inconsistent.
+
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.6...v2.6.7 <!-- pragma: allowlist secret -->
+
 ## 2.6.6 — 2026-07-26
 
 ### Added

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 24
-        versionName = "2.6.6"
+        versionCode = 25
+        versionName = "2.6.7"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 24;
-    public static final String VERSION_NAME = "2.6.6";
+    public static final int VERSION_CODE = 25;
+    public static final String VERSION_NAME = "2.6.7";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.6.6 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.6.7 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -306,6 +306,10 @@ public final class AppPreferences {
         return prefs(context).getBoolean(KEY_DASHBOARD_RESET_CREDITS, true);
     }
 
+    public static void setShowDashboardResetCredits(Context context, boolean show) {
+        prefs(context).edit().putBoolean(KEY_DASHBOARD_RESET_CREDITS, show).apply();
+    }
+
     /** Hidden section keys (currently model-specific limits) as a {@link DashboardSections} CSV. */
     public static String getDashboardHiddenSections(Context context) {
         return prefs(context).getString(KEY_DASHBOARD_HIDDEN_SECTIONS, "");

--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
@@ -110,6 +110,9 @@ public final class DashboardReorderActivity extends AppCompatActivity {
             } else if (DashboardSections.USAGE_HISTORY.equals(key)) {
                 items.add(new SectionItem(key, "Usage history",
                         "Local burn charts for your usage windows"));
+            } else if (DashboardSections.RESET_CREDITS.equals(key)) {
+                items.add(new SectionItem(key, "Reset credits",
+                        "Earned credits that can reset usage windows"));
             } else {
                 UsageLimit match = null;
                 for (UsageLimit limit : limits) {
@@ -156,6 +159,9 @@ public final class DashboardReorderActivity extends AppCompatActivity {
         if (DashboardSections.USAGE_HISTORY.equals(key)) {
             return AppPreferences.showDashboardUsageHistory(this);
         }
+        if (DashboardSections.RESET_CREDITS.equals(key)) {
+            return AppPreferences.showDashboardResetCredits(this);
+        }
         return !AppPreferences.isDashboardSectionHidden(this, key);
     }
 
@@ -168,6 +174,8 @@ public final class DashboardReorderActivity extends AppCompatActivity {
             AppPreferences.setShowDashboardUsageCredits(this, visible);
         } else if (DashboardSections.USAGE_HISTORY.equals(key)) {
             AppPreferences.setShowDashboardUsageHistory(this, visible);
+        } else if (DashboardSections.RESET_CREDITS.equals(key)) {
+            AppPreferences.setShowDashboardResetCredits(this, visible);
         } else {
             AppPreferences.setDashboardSectionHidden(this, key, !visible);
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.ColorStateList;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -35,8 +36,6 @@ import java.util.concurrent.Executors;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import dev.bennett.codexmeter.wear.PhoneWearSync;
-import dev.oneuiproject.oneui.widget.CardItemView;
-import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 
 /* JADX INFO: loaded from: classes.dex */
 public final class MainActivity extends AppCompatActivity {
@@ -292,14 +291,7 @@ public final class MainActivity extends AppCompatActivity {
                 this.content.addView(signIn, new LinearLayout.LayoutParams(-1, Ui.dp(this, 60)));
                 Ui.addSpacer(this.content, 20);
             }
-            UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
-            boolean showResetCredits = AppPreferences.showDashboardResetCredits(this)
-                    && signedIn
-                    && (AppPreferences.loadResetCredits(this) != null
-                    || (snapshot != null && snapshot.resetCreditsAvailable >= 0));
-            if (showResetCredits) {
-                this.content.addView(buildResetCreditsCard());
-            } else if (signedIn && dashboard.getChildCount() == 0) {
+            if (signedIn && dashboard.getChildCount() == 0) {
                 TextView empty = Ui.text(this,
                         "No dashboard items are available. Refresh usage or choose items in "
                                 + "Settings → Refresh & usage.",
@@ -379,6 +371,11 @@ public final class MainActivity extends AppCompatActivity {
         if (AppPreferences.showDashboardUsageHistory(this)) {
             available.add(DashboardSections.USAGE_HISTORY);
         }
+        if (AppPreferences.showDashboardResetCredits(this)
+                && (AppPreferences.loadResetCredits(this) != null
+                || (snapshot != null && snapshot.resetCreditsAvailable >= 0))) {
+            available.add(DashboardSections.RESET_CREDITS);
+        }
         boolean inverted = false;
         for (String key : DashboardSections.resolveOrder(
                 AppPreferences.getDashboardOrder(this), available)) {
@@ -391,10 +388,11 @@ public final class MainActivity extends AppCompatActivity {
                         "Weekly", snapshot, snapshot.weekly, inverted));
                 inverted = !inverted;
             } else if (DashboardSections.USAGE_CREDITS.equals(key)) {
-                // The One UI separator provides section spacing; skip the usual card spacer.
-                column.addView(buildUsageCreditsCard(snapshot.usageCredits));
+                addDashboardCard(column, buildUsageCreditsCard(snapshot.usageCredits));
             } else if (DashboardSections.USAGE_HISTORY.equals(key)) {
                 addDashboardCard(column, buildUsageHistoryCard());
+            } else if (DashboardSections.RESET_CREDITS.equals(key)) {
+                addDashboardCard(column, buildResetCreditsCard());
             } else {
                 List<UsageLimit> group = limitsByKey.get(key);
                 if (group == null) {
@@ -506,20 +504,40 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     private LinearLayout buildUsageCreditsCard(UsageCredits credits) {
-        LinearLayout column = new LinearLayout(this);
-        column.setOrientation(LinearLayout.VERTICAL);
-        column.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
-        column.addView(Ui.separator(this, "Usage credits"));
+        LinearLayout card = Ui.card(this, this.dark);
+        TextView title = Ui.text(this, "Usage credits", 18, Ui.mainText(this.dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        card.addView(buildIconDetailRow(R.drawable.ic_oui_credit_card_outline,
+                usageCreditBalance(credits), usageCreditsSummary(credits)));
+        return card;
+    }
 
-        RoundedLinearLayout card = Ui.seslRowCard(this, this.dark);
-        card.addView(Ui.actionRow(
-                this,
-                usageCreditBalance(credits),
-                usageCreditsSummary(credits),
-                R.drawable.ic_oui_credit_card_outline,
-                null));
-        column.addView(card);
-        return column;
+    /** Left-aligned icon + value + summary row used inside the credit dashboard cards. */
+    private LinearLayout buildIconDetailRow(int icon, String value, String summary) {
+        LinearLayout row = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
+        ImageView image = new ImageView(this);
+        image.setImageResource(icon);
+        image.setImageTintList(ColorStateList.valueOf(Ui.mainText(this.dark)));
+        row.addView(image, new LinearLayout.LayoutParams(Ui.dp(this, 30), Ui.dp(this, 30)));
+
+        LinearLayout labels = new LinearLayout(this);
+        labels.setOrientation(LinearLayout.VERTICAL);
+        TextView valueText = Ui.text(this, value, 17.0f, Ui.mainText(this.dark));
+        valueText.setTypeface(Ui.mediumTypeface(this));
+        labels.addView(valueText);
+        TextView summaryText = Ui.text(this, summary, 13.0f, Ui.secondaryText(this.dark));
+        LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-2, -2);
+        summaryParams.setMargins(0, Ui.dp(this, 2), 0, 0);
+        labels.addView(summaryText, summaryParams);
+        LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(0, -2, 1.0f);
+        labelParams.setMargins(Ui.dp(this, 16), 0, 0, 0);
+        row.addView(labels, labelParams);
+
+        LinearLayout.LayoutParams rowParams = new LinearLayout.LayoutParams(-1, -2);
+        rowParams.setMargins(0, Ui.dp(this, 12), 0, 0);
+        row.setLayoutParams(rowParams);
+        return row;
     }
 
     private static String usageCreditBalance(UsageCredits credits) {
@@ -682,22 +700,16 @@ public final class MainActivity extends AppCompatActivity {
         long now = System.currentTimeMillis();
         long nextExpiry = credits == null ? 0L : credits.nextExpiryMillis(now);
 
-        LinearLayout column = new LinearLayout(this);
-        column.setOrientation(LinearLayout.VERTICAL);
-        column.setLayoutParams(new LinearLayout.LayoutParams(-1, -2));
-        column.addView(Ui.separator(this, "Reset credits"));
-
-        RoundedLinearLayout card = Ui.seslRowCard(this, this.dark);
-        CardItemView row = Ui.actionRow(
-                this,
+        LinearLayout card = Ui.card(this, this.dark);
+        TextView title = Ui.text(this, "Reset credits", 18, Ui.mainText(this.dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        card.addView(buildIconDetailRow(R.drawable.ic_oui_battery,
                 resetCreditsTitle(signedIn, available),
-                resetCreditsSummary(signedIn, available, nextExpiry, now),
-                R.drawable.ic_oui_battery,
-                signedIn ? view -> openResetCredits() : null);
-        card.addView(row);
-        column.addView(card);
+                resetCreditsSummary(signedIn, available, nextExpiry, now)));
 
         if (signedIn) {
+            card.setOnClickListener(view -> openResetCredits());
             Button button = Ui.nativePrimaryButton(this,
                     available > 0 ? "Use 1 reset" : "No resets available");
             button.setEnabled(available > 0);
@@ -705,9 +717,9 @@ public final class MainActivity extends AppCompatActivity {
             LinearLayout.LayoutParams buttonParams =
                     new LinearLayout.LayoutParams(-1, Ui.dp(this, 60.0f));
             buttonParams.setMargins(0, Ui.dp(this, 16.0f), 0, 0);
-            column.addView(button, buttonParams);
+            card.addView(button, buttonParams);
         }
-        return column;
+        return card;
     }
 
     private static String resetCreditsTitle(boolean signedIn, int available) {

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.6.6"
+VERSION_NAME="2.6.7"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -70,14 +70,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.6.6"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 24' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.6.6"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 24' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.6.6"' "$ROOT/wear/build.gradle.kts"
-grep -q 'versionCode = 24' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.6.6' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.6.6"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.6.7"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 25' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.6.7"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 25' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.6.7"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionCode = 25' "$ROOT/wear/build.gradle.kts"
+grep -q 'codex-meter-android/2.6.7' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.6.7"' "$ROOT/build.sh"
 WORKFLOW="$ROOT/../.github/workflows/build-apk.yml"
 grep -Fq 'release-dist/CodexMeter-Wear-$VERSION_NAME.apk' "$WORKFLOW"
 grep -Fq '"platforms;android-37.0"' "$WORKFLOW"
@@ -126,21 +126,34 @@ grep -q 'weeklyWindow != null && snapshot.fetchedAtMillis > 0L' \
 grep -q 'fiveWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
 
-# Reset/usage-credit sections keep the One UI Separator + CardItemView design (left-aligned
-# rows with icons) instead of the old centered blocks.
-grep -Fq 'Ui.separator(this, "Reset credits")' \
+# Reset/usage-credit dashboard cards use bold in-card titles with left-aligned icon rows,
+# matching the other dashboard cards, instead of external One UI separators or centered blocks.
+grep -Fq 'Ui.text(this, "Reset credits", 18' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
-grep -Fq 'Ui.separator(this, "Usage credits")' \
+grep -Fq 'Ui.text(this, "Usage credits", 18' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'buildIconDetailRow' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'ic_oui_battery' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'ic_oui_credit_card_outline' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+! grep -q 'Ui.separator' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -Fq 'Ui.separator(this, "Available credits")' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java"
 grep -Fq 'Ui.separator(this, "Credit expirations")' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditActivity.java"
 ! grep -q 'ic_reset_credit_details' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+# Reset credits is an orderable dashboard section, not a card pinned below the dashboard.
+grep -q 'RESET_CREDITS = "reset_credits"' \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/DashboardSections.java"
+grep -q 'DashboardSections.RESET_CREDITS.equals(key)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'DashboardSections.RESET_CREDITS.equals(key)' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java"
+! grep -q 'this.content.addView(buildResetCreditsCard())' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 
 grep -q 'android.permission.ACCESS_NETWORK_STATE' "$ROOT/app/src/main/AndroidManifest.xml"

--- a/android/shared/src/main/java/dev/bennett/codexmeter/DashboardSections.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/DashboardSections.java
@@ -19,6 +19,7 @@ public final class DashboardSections {
     public static final String WEEKLY = "weekly";
     public static final String USAGE_CREDITS = "usage_credits";
     public static final String USAGE_HISTORY = "usage_history";
+    public static final String RESET_CREDITS = "reset_credits";
     private static final String LIMIT_PREFIX = "limit:";
 
     private DashboardSections() {
@@ -43,7 +44,10 @@ public final class DashboardSections {
         return key != null && key.startsWith(LIMIT_PREFIX);
     }
 
-    /** Default order: 5-hour, weekly, detected additional limits, usage credits, history. */
+    /**
+     * Default order: 5-hour, weekly, detected additional limits, usage credits, history,
+     * reset credits.
+     */
     public static List<String> defaultOrder(List<UsageLimit> additionalLimits) {
         List<String> order = new ArrayList<>();
         order.add(FIVE_HOUR);
@@ -57,6 +61,7 @@ public final class DashboardSections {
         }
         order.add(USAGE_CREDITS);
         order.add(USAGE_HISTORY);
+        order.add(RESET_CREDITS);
         return order;
     }
 

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -710,8 +710,9 @@ public final class ParserSelfTest {
         List<String> defaults = DashboardSections.defaultOrder(Arrays.asList(spark));
         check(defaults.equals(Arrays.asList(
                         DashboardSections.FIVE_HOUR, DashboardSections.WEEKLY, sparkKey,
-                        DashboardSections.USAGE_CREDITS, DashboardSections.USAGE_HISTORY)),
-                "default order is 5-hour, weekly, detected limits, credits, history");
+                        DashboardSections.USAGE_CREDITS, DashboardSections.USAGE_HISTORY,
+                        DashboardSections.RESET_CREDITS)),
+                "default order is 5-hour, weekly, detected limits, credits, history, resets");
 
         check(DashboardSections.resolveOrder("", defaults).equals(defaults),
                 "no saved order keeps the defaults");
@@ -719,15 +720,15 @@ public final class ParserSelfTest {
                 "usage_credits, limit:codex-spark ,five_hour,weekly", defaults);
         check(saved.equals(Arrays.asList(DashboardSections.USAGE_CREDITS, sparkKey,
                         DashboardSections.FIVE_HOUR, DashboardSections.WEEKLY,
-                        DashboardSections.USAGE_HISTORY)),
-                "saved order is applied with whitespace tolerated and the new history "
-                        + "section slots in at its default position");
+                        DashboardSections.USAGE_HISTORY, DashboardSections.RESET_CREDITS)),
+                "saved order is applied with whitespace tolerated and the new history and "
+                        + "reset-credit sections slot in at their default positions");
         List<String> withoutSpark = DashboardSections.resolveOrder(
                 "weekly,five_hour,usage_credits",
                 DashboardSections.defaultOrder(Arrays.asList(spark)));
         check(withoutSpark.equals(Arrays.asList(DashboardSections.WEEKLY,
                         DashboardSections.FIVE_HOUR, sparkKey, DashboardSections.USAGE_CREDITS,
-                        DashboardSections.USAGE_HISTORY)),
+                        DashboardSections.USAGE_HISTORY, DashboardSections.RESET_CREDITS)),
                 "newly detected Spark limit slots in before credits, not at the end");
         List<String> staleKeys = DashboardSections.resolveOrder(
                 "limit:old-model,weekly,five_hour",
@@ -736,7 +737,8 @@ public final class ParserSelfTest {
                         DashboardSections.FIVE_HOUR)),
                 "keys for limits no longer reported are dropped");
         check(DashboardSections.serialize(saved)
-                        .equals("usage_credits,limit:codex-spark,five_hour,weekly,usage_history"),
+                        .equals("usage_credits,limit:codex-spark,five_hour,weekly,"
+                                + "usage_history,reset_credits"),
                 "order round-trips through the stored CSV form");
         check(DashboardSections.resolveOrder(null,
                         Arrays.asList(DashboardSections.FIVE_HOUR))

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 24
-        versionName = "2.6.6"
+        versionCode = 25
+        versionName = "2.6.7"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the two remaining dashboard issues and bumps the release to **2.6.7** (versionCode 25):

- **Usage chart can now actually be repositioned to the bottom** — the reset-credits card was appended to the page *after* the ordered dashboard in `MainActivity.rebuild()`, so it was pinned below everything and no card (including usage history) could ever be placed after it. Reset credits is now a real `DashboardSections.RESET_CREDITS` section: it renders inside the ordered loop, drags like every other row on the Edit dashboard screen, and hides via the same `dashboard_reset_credits` preference the Settings switch uses.
- **Consistent card design** — the reset-credit and usage-credit cards no longer use external One UI `Separator` headers above bare row-cards. They are proper dashboard cards with a bold in-card title (18sp medium, same as the usage-history card) and a left-aligned icon row (`ic_oui_battery` / `ic_oui_credit_card_outline`) for the value + summary, via a shared `buildIconDetailRow` helper. The reset-credits card keeps its tap-to-open-details behavior and the "Use 1 reset" button. The `ResetCreditActivity` detail screen keeps its sectioned Separator layout, which is appropriate there.

## Supporting changes

- `AppPreferences.setShowDashboardResetCredits` write-through setter for the edit-screen toggle.
- `ParserSelfTest` default-order expectations include `reset_credits`; `run-tests.sh` guards the in-card title design, the icon rows, the absence of `Ui.separator` in `MainActivity`, and that reset credits is no longer pinned outside the dashboard.
- Version bump 2.6.6 → 2.6.7 across `AppConstants`, both Gradle files, `build.sh`, `run-tests.sh`, and `CHANGELOG.md`.

## Testing

- `./run-tests.sh` — all self-tests and wiring checks pass.
- `./build.sh` — signed `CodexMeter-2.6.7.apk` + `CodexMeter-Wear-2.6.7.apk` build successfully; `./lint.sh` clean.
- **Emulator demo** — verified on a software-emulated (QEMU TCG, no KVM) Android 14 x86_64 AVD with the debug APK and the seeded demo fixture.

### Demo evidence

New card design and final order after moving usage history below reset credits (scroll from top to bottom):

[demo_dashboard_new_order_and_card_design.mp4](https://cursor.com/agents/bc-ed7286ec-eb12-4157-ad23-ce3374835024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_dashboard_new_order_and_card_design.mp4)

Full end-to-end reorder flow (before-order → Edit dashboard → drag "Usage history" below "Reset credits" → dashboard shows the new order); slow transitions are emulator software-rendering lag:

[emulator_demo_reorder_history_below_reset_credits.mp4](https://cursor.com/agents/bc-ed7286ec-eb12-4157-ad23-ce3374835024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Femulator_demo_reorder_history_below_reset_credits.mp4)

[Usage credits card with bold in-card title and icon row](https://cursor.com/agents/bc-ed7286ec-eb12-4157-ad23-ce3374835024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_usage_credits_card_new_design.png)
[Reset credits card before reorder (still below usage history)](https://cursor.com/agents/bc-ed7286ec-eb12-4157-ad23-ce3374835024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_reset_credits_card_new_design_before_reorder.png)
[Edit dashboard screen with the new Reset credits row](https://cursor.com/agents/bc-ed7286ec-eb12-4157-ad23-ce3374835024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_edit_dashboard_reset_credits_row.png)
[Dashboard after reorder: usage history below reset credits](https://cursor.com/agents/bc-ed7286ec-eb12-4157-ad23-ce3374835024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_usage_history_moved_below_reset_credits.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed7286ec-eb12-4157-ad23-ce3374835024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed7286ec-eb12-4157-ad23-ce3374835024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

