### PR TITLE
Hide empty reset-credit and usage-history dashboard cards

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
@@ -78,9 +78,10 @@ public final class DashboardReorderActivity extends AppCompatActivity {
         content.addView(listCard);
 
         TextView note = Ui.text(this,
-                "Changes are saved instantly. The usage-credit balance stays hidden whenever "
-                        + "it is zero or below, no matter where it is placed or whether it is "
-                        + "switched on.",
+                "Changes are saved instantly. Usage-credit balance and reset credits stay hidden "
+                        + "when they have nothing to show (zero or below), and 5-hour, weekly, "
+                        + "and usage-history cards appear only while OpenAI reports data for them "
+                        + "— no matter where each card is placed or whether its switch is on.",
                 12.0f, Ui.secondaryText(dark));
         LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(-1, -2);
         noteParams.setMargins(Ui.dp(this, 6), Ui.dp(this, 14), Ui.dp(this, 6), 0);
@@ -109,10 +110,10 @@ public final class DashboardReorderActivity extends AppCompatActivity {
                         "Hidden automatically at a zero or negative balance"));
             } else if (DashboardSections.USAGE_HISTORY.equals(key)) {
                 items.add(new SectionItem(key, "Usage history",
-                        "Local burn charts for your usage windows"));
+                        "Shown only when a 5-hour or weekly window is available"));
             } else if (DashboardSections.RESET_CREDITS.equals(key)) {
                 items.add(new SectionItem(key, "Reset credits",
-                        "Earned credits that can reset usage windows"));
+                        "Hidden automatically when no resets are available"));
             } else {
                 UsageLimit match = null;
                 for (UsageLimit limit : limits) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -367,13 +367,15 @@ public final class MainActivity extends AppCompatActivity {
                     && snapshot.usageCredits.shouldDisplay()) {
                 available.add(DashboardSections.USAGE_CREDITS);
             }
+            // Usage history only appears once at least one window can feed a burn chart.
+            if (AppPreferences.showDashboardUsageHistory(this)
+                    && snapshot.fetchedAtMillis > 0L
+                    && (snapshot.fiveHour != null || snapshot.weekly != null)) {
+                available.add(DashboardSections.USAGE_HISTORY);
+            }
         }
-        if (AppPreferences.showDashboardUsageHistory(this)) {
-            available.add(DashboardSections.USAGE_HISTORY);
-        }
-        if (AppPreferences.showDashboardResetCredits(this)
-                && (AppPreferences.loadResetCredits(this) != null
-                || (snapshot != null && snapshot.resetCreditsAvailable >= 0))) {
+        // Zero available resets always hide the card, even when the Edit dashboard switch is on.
+        if (AppPreferences.showDashboardResetCredits(this) && shouldShowResetCreditsCard(snapshot)) {
             available.add(DashboardSections.RESET_CREDITS);
         }
         boolean inverted = false;
@@ -752,6 +754,19 @@ public final class MainActivity extends AppCompatActivity {
 
     private void openResetCredits() {
         Ui.startSecondaryActivity(this, ResetCreditActivity.class);
+    }
+
+    /**
+     * Prefer the detailed reset-credits cache; fall back to the usage-endpoint summary count.
+     * Unknown inventory never surfaces an empty card.
+     */
+    private boolean shouldShowResetCreditsCard(UsageSnapshot snapshot) {
+        ResetCreditsSnapshot credits = AppPreferences.loadResetCredits(this);
+        if (credits != null) {
+            return credits.shouldDisplay();
+        }
+        return snapshot != null
+                && ResetCreditsSnapshot.shouldDisplayCount(snapshot.resetCreditsAvailable);
     }
 
     private LinearLayout buildWidgetCard() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java
@@ -30,6 +30,23 @@ public final class ResetCreditsSnapshot {
         return new ResetCreditsSnapshot(i, Collections.emptyList(), j);
     }
 
+    /**
+     * Whether inventory is worth surfacing on the dashboard. Zero available resets always
+     * hide the card, even when the Edit dashboard switch is on — matching usage-credit
+     * auto-hide and data-gated 5-hour / weekly cards.
+     */
+    public boolean shouldDisplay() {
+        return availableCount > 0;
+    }
+
+    /**
+     * Same rule for a summary count from the usage endpoint when the detailed credits
+     * snapshot is not cached yet. Negative / unknown counts never display.
+     */
+    public static boolean shouldDisplayCount(int availableCount) {
+        return availableCount > 0;
+    }
+
     public RateLimitResetCredit nextExpiringAvailable(long nowMillis) {
         List<RateLimitResetCredit> available = availableCreditsByExpiry(nowMillis);
         return available.isEmpty() ? null : available.get(0);

--- a/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
+++ b/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
@@ -43,17 +43,17 @@
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_usage_credits"
-            android:summary="Purchased credits returned by OpenAI"
+            android:summary="Hidden automatically at a zero or negative balance"
             android:title="Usage-credit balance" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_usage_history"
-            android:summary="Local burn charts for your usage windows"
+            android:summary="Shown only when a 5-hour or weekly window is available"
             android:title="Usage history" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_reset_credits"
-            android:summary="Earned credits that can reset usage windows"
+            android:summary="Hidden automatically when no resets are available"
             android:title="Reset credits" />
     </PreferenceCategory>
 

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -85,12 +85,17 @@ grep -q 'BenItBuhner/Codex-Meter/releases?per_page=30' "$ROOT/app/build.gradle.k
 ! grep -R -q 'thatjoshguy67/Codex-Meter' \
   "$ROOT/app/src" "$ROOT/app/build.gradle.kts"
 
-# Dashboard reorder + usage-credit auto-hide wiring.
+# Dashboard reorder + usage-credit / reset-credit auto-hide wiring.
 grep -q 'testUsageCreditsAutoHide' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'testResetCreditsAutoHide' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'testDashboardSectionOrder' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'DashboardReorderActivity' "$ROOT/app/src/main/AndroidManifest.xml"
 grep -q 'snapshot.usageCredits.shouldDisplay()' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'shouldShowResetCreditsCard' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'public boolean shouldDisplay()' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java"
 grep -q 'DashboardSections.resolveOrder' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'ItemTouchHelper' \
@@ -125,6 +130,11 @@ grep -q 'weeklyWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'fiveWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
+# The usage-history section itself also hides until a window can feed a chart.
+grep -q 'snapshot.fiveHour != null || snapshot.weekly != null' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'Hidden automatically when no resets are available' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java"
 
 # Reset/usage-credit dashboard cards use bold in-card titles with left-aligned icon rows,
 # matching the other dashboard cards, instead of external One UI separators or centered blocks.

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java
@@ -122,7 +122,7 @@ public final class UsageSnapshot {
     public boolean hasDisplayableData() {
         return fiveHour != null || weekly != null || !additionalLimits.isEmpty()
                 || (usageCredits != null && usageCredits.shouldDisplay())
-                || resetCreditsAvailable >= 0;
+                || resetCreditsAvailable > 0;
     }
 
     private long earlierFutureReset(long current, UsageWindow window, long now) {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -20,6 +20,7 @@ public final class ParserSelfTest {
         testOptionalUsageSections();
         testUsageCredits();
         testUsageCreditsAutoHide();
+        testResetCreditsAutoHide();
         testDashboardSectionOrder();
         testMalformedWindowIgnored();
         testZeroDurationWindowIgnored();
@@ -695,6 +696,30 @@ public final class ParserSelfTest {
                 "snapshot with only a zero balance has nothing to display");
         System.out.println("Usage-credit auto-hide: zero, near-zero, and negative balances "
                 + "never render.");
+    }
+
+    private static void testResetCreditsAutoHide() {
+        check(new ResetCreditsSnapshot(3, java.util.Collections.emptyList(), 1L).shouldDisplay(),
+                "positive reset-credit inventory stays visible");
+        check(new ResetCreditsSnapshot(1, java.util.Collections.emptyList(), 1L).shouldDisplay(),
+                "single available reset stays visible");
+        check(!new ResetCreditsSnapshot(0, java.util.Collections.emptyList(), 1L).shouldDisplay(),
+                "zero available resets always hide the card");
+        check(ResetCreditsSnapshot.shouldDisplayCount(2),
+                "usage-endpoint summary count above zero stays visible");
+        check(!ResetCreditsSnapshot.shouldDisplayCount(0),
+                "usage-endpoint summary of zero hides the card");
+        check(!ResetCreditsSnapshot.shouldDisplayCount(-1),
+                "unknown reset-credit count never displays");
+        UsageSnapshot zeroResetsOnly = new UsageSnapshot("plus", true, false, null, null,
+                java.util.Collections.emptyList(), null, 0, 10L);
+        check(!zeroResetsOnly.hasDisplayableData(),
+                "snapshot with only a zero reset-credit count has nothing to display");
+        UsageSnapshot positiveResetsOnly = new UsageSnapshot("plus", true, false, null, null,
+                java.util.Collections.emptyList(), null, 2, 11L);
+        check(positiveResetsOnly.hasDisplayableData(),
+                "snapshot with available resets remains displayable");
+        System.out.println("Reset-credit auto-hide: zero inventory never renders on the dashboard.");
     }
 
     private static void testDashboardSectionOrder() {

--- a/ios/CodexMeter/Views/DashboardView.swift
+++ b/ios/CodexMeter/Views/DashboardView.swift
@@ -45,6 +45,17 @@ struct DashboardView: View {
             || !additionalWindows.isEmpty
     }
 
+    /// Prefer the detailed credits snapshot; fall back to the usage-endpoint summary count.
+    private var shouldShowResetCredits: Bool {
+        if let credits = model.credits {
+            return credits.shouldDisplay
+        }
+        guard let count = model.usage?.resetCreditsAvailable else {
+            return false
+        }
+        return count > 0
+    }
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: AppChrome.sectionSpacing) {
@@ -111,11 +122,11 @@ struct DashboardView: View {
                     }
 
                     if model.settings.showUsageCredits,
-                       let usageCredits = model.usage?.usageCredits {
+                       let usageCredits = model.usage?.usageCredits,
+                       usageCredits.shouldDisplay {
                         UsageCreditsCard(credits: usageCredits)
                     }
-                    if model.settings.showResetCredits,
-                       model.credits != nil || model.usage?.resetCreditsAvailable != nil {
+                    if model.settings.showResetCredits, shouldShowResetCredits {
                         ResetCreditsCard()
                     }
                     PrivacyFootnote()

--- a/ios/CodexMeter/Views/SettingsView.swift
+++ b/ios/CodexMeter/Views/SettingsView.swift
@@ -53,7 +53,7 @@ struct SettingsView: View {
             } header: {
                 Text("Dashboard")
             } footer: {
-                Text("Enabled items still appear only when OpenAI returns data for them. Additional limits include temporary model-specific allowances.")
+                Text("Enabled items still appear only when OpenAI returns data for them. Usage-credit balance and reset credits also stay hidden when the inventory is zero. Additional limits include temporary model-specific allowances.")
             }
 
             Section {

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
@@ -122,6 +122,10 @@ public struct UsageLimit: Codable, Sendable, Equatable, Identifiable {
 }
 
 public struct UsageCredits: Codable, Sendable, Equatable {
+    /// Balances below this render as "0" with the two fraction digits used across the app,
+    /// so they are treated as exhausted and never displayed.
+    private static let nearZeroBalance = Decimal(string: "0.005")!
+
     public let hasCredits: Bool
     public let unlimited: Bool
     public let balance: String?
@@ -132,6 +136,26 @@ public struct UsageCredits: Codable, Sendable, Equatable {
         let cleanBalance = balance?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.balance = (hasCredits || unlimited) && cleanBalance?.isEmpty == false
             ? cleanBalance : nil
+    }
+
+    /// Whether the balance is worth surfacing anywhere in the UI. Zero, effectively-zero,
+    /// and negative balances always hide the card, as does an account without purchased
+    /// credits. Unlimited plans and unparseable non-empty balances remain visible.
+    public var shouldDisplay: Bool {
+        if unlimited {
+            return true
+        }
+        if !hasCredits {
+            return false
+        }
+        guard let balance, !balance.isEmpty else {
+            return true
+        }
+        let normalized = balance.replacingOccurrences(of: ",", with: "")
+        guard let amount = Decimal(string: normalized) else {
+            return true
+        }
+        return amount >= Self.nearZeroBalance
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -194,8 +218,8 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
 
     public var hasDisplayableData: Bool {
         fiveHour != nil || weekly != nil || !additionalLimits.isEmpty
-            || usageCredits?.hasCredits == true || usageCredits?.unlimited == true
-            || usageCredits?.balance != nil || resetCreditsAvailable != nil
+            || usageCredits?.shouldDisplay == true
+            || (resetCreditsAvailable ?? 0) > 0
     }
 
     public func isStale(at date: Date = Date(), maxAge: TimeInterval) -> Bool {
@@ -305,6 +329,12 @@ public struct ResetCreditsSnapshot: Codable, Sendable, Equatable {
         self.availableCount = max(0, availableCount)
         self.credits = credits
         self.fetchedAt = fetchedAt
+    }
+
+    /// Whether inventory is worth surfacing on the dashboard. Zero available resets always
+    /// hide the card, even when the Settings toggle is on.
+    public var shouldDisplay: Bool {
+        availableCount > 0
     }
 
     public static func summary(availableCount: Int, fetchedAt: Date) -> Self {

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/ModelsAndFormattingTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/ModelsAndFormattingTests.swift
@@ -148,6 +148,44 @@ final class ModelsAndFormattingTests: XCTestCase {
         )
     }
 
+    func testUsageAndResetCreditsAutoHide() {
+        XCTAssertTrue(UsageCredits(hasCredits: true, unlimited: false, balance: "2500").shouldDisplay)
+        XCTAssertTrue(UsageCredits(hasCredits: true, unlimited: false, balance: "0.01").shouldDisplay)
+        XCTAssertTrue(UsageCredits(hasCredits: false, unlimited: true, balance: nil).shouldDisplay)
+        XCTAssertTrue(UsageCredits(hasCredits: true, unlimited: false, balance: nil).shouldDisplay)
+        XCTAssertTrue(UsageCredits(hasCredits: true, unlimited: false, balance: "12k credits").shouldDisplay)
+        XCTAssertFalse(UsageCredits(hasCredits: true, unlimited: false, balance: "0").shouldDisplay)
+        XCTAssertFalse(UsageCredits(hasCredits: true, unlimited: false, balance: "0.00").shouldDisplay)
+        XCTAssertFalse(UsageCredits(hasCredits: true, unlimited: false, balance: "0.004").shouldDisplay)
+        XCTAssertFalse(UsageCredits(hasCredits: true, unlimited: false, balance: "-12.5").shouldDisplay)
+        XCTAssertFalse(UsageCredits(hasCredits: false, unlimited: false, balance: "500").shouldDisplay)
+
+        XCTAssertTrue(ResetCreditsSnapshot.summary(availableCount: 2, fetchedAt: .now).shouldDisplay)
+        XCTAssertFalse(ResetCreditsSnapshot.summary(availableCount: 0, fetchedAt: .now).shouldDisplay)
+
+        let zeroResetsOnly = UsageSnapshot(
+            planType: "plus",
+            allowed: true,
+            limitReached: false,
+            fiveHour: nil,
+            weekly: nil,
+            resetCreditsAvailable: 0,
+            fetchedAt: Date(timeIntervalSince1970: 1)
+        )
+        XCTAssertFalse(zeroResetsOnly.hasDisplayableData)
+
+        let positiveResetsOnly = UsageSnapshot(
+            planType: "plus",
+            allowed: true,
+            limitReached: false,
+            fiveHour: nil,
+            weekly: nil,
+            resetCreditsAvailable: 3,
+            fetchedAt: Date(timeIntervalSince1970: 1)
+        )
+        XCTAssertTrue(positiveResetsOnly.hasDisplayableData)
+    }
+
     func testResetOutcomeMessagesAndRoundTrip() throws {
         let success = ResetConsumeResult(
             outcome: .reset,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Zero available resets (and other empty inventory) no longer leave a useless card on the dashboard when the Edit dashboard / Settings toggle is still on.

### Changes
- **Reset credits:** auto-hide when available count is `0` (or unknown), even if the section switch is enabled — same spirit as usage-credit auto-hide and data-gated 5-hour / weekly cards.
- **Usage history (Android):** hide the whole section until OpenAI reports a 5-hour or weekly window that can feed a burn chart.
- **Usage credits (iOS):** port `shouldDisplay` so zero / near-zero / negative balances hide like Android.
- Edit-dashboard copy and Settings summaries updated to document the auto-hide rules.
- Regression coverage on Android (`ParserSelfTest`) and iOS (`ModelsAndFormattingTests`).

### Verification
- `./run-tests.sh` passed (includes new `testResetCreditsAutoHide`)
- `./build.sh` passed (phone + Wear release APKs)
- `./lint.sh` passed
- iOS: `swift test` not available on this Linux VM; CodexMeterCore changes mirror Android predicates and add XCTest coverage for macOS CI

### Platforms
Android phone dashboard + iOS dashboard / CodexMeterCore.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e2914cb-bc02-46c7-bf44-6c5c471f412c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e2914cb-bc02-46c7-bf44-6c5c471f412c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

