### PR TITLE
Add widget layout and meter customization (home + lock)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ build/
 android/dist/
 android/.gradle/
 android/.local-signing/
+android/local.properties
+local.properties
 .gradle/
 .local-signing/
 dist/

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -394,13 +394,50 @@ public final class AppPreferences {
 
     public static WidgetOptions loadDefaultWidgetOptions(Context context) {
         SharedPreferences sharedPreferencesPrefs = prefs(context);
-        return batteryStyle(new WidgetOptions(sharedPreferencesPrefs.getString("default_style", WidgetOptions.STYLE_RINGS), sharedPreferencesPrefs.getString("default_density", "auto"), sharedPreferencesPrefs.getString("default_surface_style", WidgetOptions.SURFACE_ONE_UI), sharedPreferencesPrefs.getString("default_graphic_scale", "auto"), sharedPreferencesPrefs.getString("default_theme", WidgetOptions.THEME_SYSTEM), sharedPreferencesPrefs.getString("default_accent", WidgetOptions.ACCENT_BLUE), sharedPreferencesPrefs.getInt("default_opacity", 88), sharedPreferencesPrefs.getString("default_reset_mode", WidgetOptions.RESET_ABSOLUTE), sharedPreferencesPrefs.getString("default_display_mode", WidgetOptions.DISPLAY_REMAINING), sharedPreferencesPrefs.getString("default_metric_mode", WidgetOptions.METRIC_BOTH), false, sharedPreferencesPrefs.getBoolean("default_show_plan", false), sharedPreferencesPrefs.getBoolean("default_show_updated", false), sharedPreferencesPrefs.getBoolean("default_show_refresh", true), sharedPreferencesPrefs.getBoolean("default_show_reset_credits", false), sharedPreferencesPrefs.getBoolean("default_show_reset_action", false)))
+        return normalizeLoaded(new WidgetOptions(
+                sharedPreferencesPrefs.getString("default_style", WidgetOptions.STYLE_AUTO),
+                sharedPreferencesPrefs.getString("default_density", "auto"),
+                sharedPreferencesPrefs.getString("default_surface_style", WidgetOptions.SURFACE_ONE_UI),
+                sharedPreferencesPrefs.getString("default_graphic_scale", "auto"),
+                sharedPreferencesPrefs.getString("default_theme", WidgetOptions.THEME_SYSTEM),
+                sharedPreferencesPrefs.getString("default_accent", WidgetOptions.ACCENT_BLUE),
+                sharedPreferencesPrefs.getInt("default_opacity", 88),
+                sharedPreferencesPrefs.getString("default_reset_mode", WidgetOptions.RESET_ABSOLUTE),
+                sharedPreferencesPrefs.getString("default_display_mode", WidgetOptions.DISPLAY_REMAINING),
+                sharedPreferencesPrefs.getString("default_metric_mode", WidgetOptions.METRIC_BOTH),
+                false,
+                sharedPreferencesPrefs.getBoolean("default_show_plan", false),
+                sharedPreferencesPrefs.getBoolean("default_show_updated", false),
+                sharedPreferencesPrefs.getBoolean("default_show_refresh", true),
+                sharedPreferencesPrefs.getBoolean("default_show_reset_credits", false),
+                sharedPreferencesPrefs.getBoolean("default_show_reset_action", false))
                 .withPercentSymbol(sharedPreferencesPrefs.getBoolean(
-                        "default_show_percent_symbol", true));
+                        "default_show_percent_symbol", true))
+                .withVisibleMeters(sharedPreferencesPrefs.getString("default_visible_meters", "")));
     }
 
     public static void saveDefaultWidgetOptions(Context context, WidgetOptions widgetOptions) {
-        prefs(context).edit().putString("default_style", widgetOptions.layout).putString("default_layout", widgetOptions.layout).putString("default_density", widgetOptions.density).putString("default_surface_style", widgetOptions.surfaceStyle).putString("default_graphic_scale", widgetOptions.graphicScale).putString("default_theme", widgetOptions.theme).putString("default_accent", widgetOptions.accent).putInt("default_opacity", widgetOptions.opacity).putString("default_reset_mode", widgetOptions.resetMode).putString("default_display_mode", widgetOptions.displayMode).putString("default_metric_mode", widgetOptions.metricMode).putBoolean("default_show_title", widgetOptions.showTitle).putBoolean("default_show_plan", widgetOptions.showPlan).putBoolean("default_show_updated", widgetOptions.showUpdated).putBoolean("default_show_refresh", widgetOptions.showRefresh).putBoolean("default_show_reset_credits", widgetOptions.showResetCredits).putBoolean("default_show_reset_action", widgetOptions.showResetAction).putBoolean("default_show_percent_symbol", widgetOptions.showPercentSymbol).apply();
+        prefs(context).edit()
+                .putString("default_style", widgetOptions.layout)
+                .putString("default_layout", widgetOptions.layout)
+                .putString("default_density", widgetOptions.density)
+                .putString("default_surface_style", widgetOptions.surfaceStyle)
+                .putString("default_graphic_scale", widgetOptions.graphicScale)
+                .putString("default_theme", widgetOptions.theme)
+                .putString("default_accent", widgetOptions.accent)
+                .putInt("default_opacity", widgetOptions.opacity)
+                .putString("default_reset_mode", widgetOptions.resetMode)
+                .putString("default_display_mode", widgetOptions.displayMode)
+                .putString("default_metric_mode", widgetOptions.metricMode)
+                .putString("default_visible_meters", widgetOptions.visibleMeters)
+                .putBoolean("default_show_title", widgetOptions.showTitle)
+                .putBoolean("default_show_plan", widgetOptions.showPlan)
+                .putBoolean("default_show_updated", widgetOptions.showUpdated)
+                .putBoolean("default_show_refresh", widgetOptions.showRefresh)
+                .putBoolean("default_show_reset_credits", widgetOptions.showResetCredits)
+                .putBoolean("default_show_reset_action", widgetOptions.showResetAction)
+                .putBoolean("default_show_percent_symbol", widgetOptions.showPercentSymbol)
+                .apply();
     }
 
     public static WidgetOptions loadWidgetOptions(Context context, int i) {
@@ -410,9 +447,42 @@ public final class AppPreferences {
         SharedPreferences sharedPreferencesPrefs = prefs(context);
         WidgetOptions widgetOptionsLoadDefaultWidgetOptions = loadDefaultWidgetOptions(context);
         String str = "widget_" + i + "_";
-        return batteryStyle(new WidgetOptions(sharedPreferencesPrefs.getString(str + "style", widgetOptionsLoadDefaultWidgetOptions.layout), sharedPreferencesPrefs.getString(str + "density", widgetOptionsLoadDefaultWidgetOptions.density), sharedPreferencesPrefs.getString(str + "surface_style", widgetOptionsLoadDefaultWidgetOptions.surfaceStyle), sharedPreferencesPrefs.getString(str + "graphic_scale", widgetOptionsLoadDefaultWidgetOptions.graphicScale), sharedPreferencesPrefs.getString(str + "theme", widgetOptionsLoadDefaultWidgetOptions.theme), sharedPreferencesPrefs.getString(str + "accent", widgetOptionsLoadDefaultWidgetOptions.accent), sharedPreferencesPrefs.getInt(str + "opacity", widgetOptionsLoadDefaultWidgetOptions.opacity), sharedPreferencesPrefs.getString(str + "reset_mode", widgetOptionsLoadDefaultWidgetOptions.resetMode), sharedPreferencesPrefs.getString(str + "display_mode", widgetOptionsLoadDefaultWidgetOptions.displayMode), sharedPreferencesPrefs.getString(str + "metric_mode", widgetOptionsLoadDefaultWidgetOptions.metricMode), false, sharedPreferencesPrefs.getBoolean(str + "show_plan", widgetOptionsLoadDefaultWidgetOptions.showPlan), sharedPreferencesPrefs.getBoolean(str + "show_updated", widgetOptionsLoadDefaultWidgetOptions.showUpdated), sharedPreferencesPrefs.getBoolean(str + "show_refresh", widgetOptionsLoadDefaultWidgetOptions.showRefresh), sharedPreferencesPrefs.getBoolean(str + "show_reset_credits", widgetOptionsLoadDefaultWidgetOptions.showResetCredits), sharedPreferencesPrefs.getBoolean(str + "show_reset_action", widgetOptionsLoadDefaultWidgetOptions.showResetAction)))
+        return normalizeLoaded(new WidgetOptions(
+                sharedPreferencesPrefs.getString(str + "style",
+                        widgetOptionsLoadDefaultWidgetOptions.layout),
+                sharedPreferencesPrefs.getString(str + "density",
+                        widgetOptionsLoadDefaultWidgetOptions.density),
+                sharedPreferencesPrefs.getString(str + "surface_style",
+                        widgetOptionsLoadDefaultWidgetOptions.surfaceStyle),
+                sharedPreferencesPrefs.getString(str + "graphic_scale",
+                        widgetOptionsLoadDefaultWidgetOptions.graphicScale),
+                sharedPreferencesPrefs.getString(str + "theme",
+                        widgetOptionsLoadDefaultWidgetOptions.theme),
+                sharedPreferencesPrefs.getString(str + "accent",
+                        widgetOptionsLoadDefaultWidgetOptions.accent),
+                sharedPreferencesPrefs.getInt(str + "opacity",
+                        widgetOptionsLoadDefaultWidgetOptions.opacity),
+                sharedPreferencesPrefs.getString(str + "reset_mode",
+                        widgetOptionsLoadDefaultWidgetOptions.resetMode),
+                sharedPreferencesPrefs.getString(str + "display_mode",
+                        widgetOptionsLoadDefaultWidgetOptions.displayMode),
+                sharedPreferencesPrefs.getString(str + "metric_mode",
+                        widgetOptionsLoadDefaultWidgetOptions.metricMode),
+                false,
+                sharedPreferencesPrefs.getBoolean(str + "show_plan",
+                        widgetOptionsLoadDefaultWidgetOptions.showPlan),
+                sharedPreferencesPrefs.getBoolean(str + "show_updated",
+                        widgetOptionsLoadDefaultWidgetOptions.showUpdated),
+                sharedPreferencesPrefs.getBoolean(str + "show_refresh",
+                        widgetOptionsLoadDefaultWidgetOptions.showRefresh),
+                sharedPreferencesPrefs.getBoolean(str + "show_reset_credits",
+                        widgetOptionsLoadDefaultWidgetOptions.showResetCredits),
+                sharedPreferencesPrefs.getBoolean(str + "show_reset_action",
+                        widgetOptionsLoadDefaultWidgetOptions.showResetAction))
                 .withPercentSymbol(sharedPreferencesPrefs.getBoolean(str + "show_percent_symbol",
-                        widgetOptionsLoadDefaultWidgetOptions.showPercentSymbol));
+                        widgetOptionsLoadDefaultWidgetOptions.showPercentSymbol))
+                .withVisibleMeters(sharedPreferencesPrefs.getString(str + "visible_meters",
+                        widgetOptionsLoadDefaultWidgetOptions.visibleMeters)));
     }
 
     public static String getWidgetTapAction(Context context, int appWidgetId) {
@@ -431,22 +501,66 @@ public final class AppPreferences {
         }
     }
 
-    private static WidgetOptions batteryStyle(WidgetOptions options) {
-        return new WidgetOptions(WidgetOptions.STYLE_RINGS, WidgetOptions.DENSITY_AUTO,
+    /**
+     * Keeps One UI surface defaults and hides unused chrome flags without wiping the user's
+     * layout preference or visible-meters selection.
+     */
+    private static WidgetOptions normalizeLoaded(WidgetOptions options) {
+        return new WidgetOptions(options.layout, WidgetOptions.DENSITY_AUTO,
                 WidgetOptions.SURFACE_ONE_UI, "auto", options.theme, options.accent,
                 options.opacity, WidgetOptions.RESET_HIDDEN, options.displayMode, options.metricMode,
-                false, false, false, false, false, false);
+                false, false, false, false, false, false)
+                .withPercentSymbol(options.showPercentSymbol)
+                .withVisibleMeters(options.visibleMeters);
     }
 
     public static void saveWidgetOptions(Context context, int i, WidgetOptions widgetOptions) {
         String str = "widget_" + i + "_";
-        prefs(context).edit().putString(str + "style", widgetOptions.layout).putString(str + "layout", widgetOptions.layout).putString(str + "density", widgetOptions.density).putString(str + "surface_style", widgetOptions.surfaceStyle).putString(str + "graphic_scale", widgetOptions.graphicScale).putString(str + "theme", widgetOptions.theme).putString(str + "accent", widgetOptions.accent).putInt(str + "opacity", widgetOptions.opacity).putString(str + "reset_mode", widgetOptions.resetMode).putString(str + "display_mode", widgetOptions.displayMode).putString(str + "metric_mode", widgetOptions.metricMode).putBoolean(str + "show_title", widgetOptions.showTitle).putBoolean(str + "show_plan", widgetOptions.showPlan).putBoolean(str + "show_updated", widgetOptions.showUpdated).putBoolean(str + "show_refresh", widgetOptions.showRefresh).putBoolean(str + "show_reset_credits", widgetOptions.showResetCredits).putBoolean(str + "show_reset_action", widgetOptions.showResetAction).putBoolean(str + "show_percent_symbol", widgetOptions.showPercentSymbol).apply();
+        String metricMode = metricModeFromVisible(widgetOptions.effectiveVisibleMeters());
+        prefs(context).edit()
+                .putString(str + "style", widgetOptions.layout)
+                .putString(str + "layout", widgetOptions.layout)
+                .putString(str + "density", widgetOptions.density)
+                .putString(str + "surface_style", widgetOptions.surfaceStyle)
+                .putString(str + "graphic_scale", widgetOptions.graphicScale)
+                .putString(str + "theme", widgetOptions.theme)
+                .putString(str + "accent", widgetOptions.accent)
+                .putInt(str + "opacity", widgetOptions.opacity)
+                .putString(str + "reset_mode", widgetOptions.resetMode)
+                .putString(str + "display_mode", widgetOptions.displayMode)
+                .putString(str + "metric_mode", metricMode)
+                .putString(str + "visible_meters", widgetOptions.visibleMeters)
+                .putBoolean(str + "show_title", widgetOptions.showTitle)
+                .putBoolean(str + "show_plan", widgetOptions.showPlan)
+                .putBoolean(str + "show_updated", widgetOptions.showUpdated)
+                .putBoolean(str + "show_refresh", widgetOptions.showRefresh)
+                .putBoolean(str + "show_reset_credits", widgetOptions.showResetCredits)
+                .putBoolean(str + "show_reset_action", widgetOptions.showResetAction)
+                .putBoolean(str + "show_percent_symbol", widgetOptions.showPercentSymbol)
+                .apply();
+    }
+
+    private static String metricModeFromVisible(String visibleCsv) {
+        java.util.List<String> keys = WidgetMeters.parse(visibleCsv);
+        boolean five = WidgetMeters.contains(keys, WidgetMeters.FIVE_HOUR);
+        boolean weekly = WidgetMeters.contains(keys, WidgetMeters.WEEKLY);
+        if (five && !weekly) {
+            return WidgetOptions.METRIC_FIVE_HOUR;
+        }
+        if (weekly && !five) {
+            return WidgetOptions.METRIC_WEEKLY;
+        }
+        return WidgetOptions.METRIC_BOTH;
     }
 
     public static void deleteWidgetOptions(Context context, int i) {
         String str = "widget_" + i + "_";
         SharedPreferences.Editor editorEdit = prefs(context).edit();
-        for (String str2 : new String[]{"style", "layout", "density", "surface_style", "graphic_scale", "theme", "accent", "opacity", "reset_mode", "display_mode", "metric_mode", "show_title", "show_plan", "show_updated", "show_refresh", "show_reset_credits", "show_reset_action", "show_percent_symbol", "tap_action"}) {
+        for (String str2 : new String[]{"style", "layout", "density", "surface_style",
+                "graphic_scale", "theme", "accent", "opacity", "reset_mode", "display_mode",
+                "metric_mode", "visible_meters", "show_title", "show_plan", "show_updated",
+                "show_refresh", "show_reset_credits", "show_reset_action", "show_percent_symbol",
+                "tap_action"}) {
             editorEdit.remove(str + str2);
         }
         editorEdit.apply();
@@ -458,19 +572,36 @@ public final class AppPreferences {
         }
         SharedPreferences sharedPreferencesPrefs = prefs(context);
         String str = "lock_widget_" + i + "_";
-        return new LockWidgetOptions(sharedPreferencesPrefs.getString(str + "metric_mode", "both"), sharedPreferencesPrefs.getBoolean(str + "show_reset_credits", false), sharedPreferencesPrefs.getBoolean(str + "show_reset_action", false), sharedPreferencesPrefs.getBoolean(str + "show_countdown", true));
+        return new LockWidgetOptions(
+                sharedPreferencesPrefs.getString(str + "metric_mode", "both"),
+                sharedPreferencesPrefs.getBoolean(str + "show_reset_credits", false),
+                sharedPreferencesPrefs.getBoolean(str + "show_reset_action", false),
+                sharedPreferencesPrefs.getBoolean(str + "show_countdown", true),
+                sharedPreferencesPrefs.getString(str + "visible_meters", ""));
     }
 
     public static void saveLockWidgetOptions(Context context, int i, LockWidgetOptions lockWidgetOptions) {
         if (i != 0 && lockWidgetOptions != null) {
             String str = "lock_widget_" + i + "_";
-            prefs(context).edit().putString(str + "metric_mode", lockWidgetOptions.metricMode).putBoolean(str + "show_reset_credits", lockWidgetOptions.showResetCredits).putBoolean(str + "show_reset_action", lockWidgetOptions.showResetAction).putBoolean(str + "show_countdown", lockWidgetOptions.showCountdown).apply();
+            prefs(context).edit()
+                    .putString(str + "metric_mode", lockWidgetOptions.metricMode)
+                    .putBoolean(str + "show_reset_credits", lockWidgetOptions.showResetCredits)
+                    .putBoolean(str + "show_reset_action", lockWidgetOptions.showResetAction)
+                    .putBoolean(str + "show_countdown", lockWidgetOptions.showCountdown)
+                    .putString(str + "visible_meters", lockWidgetOptions.visibleMeters)
+                    .apply();
         }
     }
 
     public static void deleteLockWidgetOptions(Context context, int i) {
         String str = "lock_widget_" + i + "_";
-        prefs(context).edit().remove(str + "metric_mode").remove(str + "show_reset_credits").remove(str + "show_reset_action").remove(str + "show_countdown").apply();
+        prefs(context).edit()
+                .remove(str + "metric_mode")
+                .remove(str + "show_reset_credits")
+                .remove(str + "show_reset_action")
+                .remove(str + "show_countdown")
+                .remove(str + "visible_meters")
+                .apply();
     }
 
     public static void setOAuthPending(Context context, boolean z, String str) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
@@ -3,39 +3,40 @@ package dev.bennett.codexmeter;
 import android.content.Intent;
 import android.appwidget.AppWidgetManager;
 import android.os.Bundle;
+import android.view.Gravity;
 import android.view.View;
-import android.widget.AdapterView;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
-import dev.oneuiproject.oneui.widget.CardItemView;
+import androidx.appcompat.widget.SwitchCompat;
 import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 
-/* JADX INFO: loaded from: classes.dex */
 public final class LockWidgetConfigActivity extends AppCompatActivity {
     private int appWidgetId = 0;
     private boolean dark;
-    private CardItemView metricRow;
-    private Spinner metricSpinner;
     private ImageView preview;
     private CheckBox showCountdown;
     private CheckBox showResetAction;
     private CheckBox showResetCredits;
+    private TextView metersHint;
+    private final LinkedHashSet<String> selectedMeters = new LinkedHashSet<>();
 
-    @Override // android.app.Activity
+    @Override
     protected void onCreate(Bundle bundle) {
         Ui.applySelectedTheme(this);
         super.onCreate(bundle);
         setResult(0);
         this.appWidgetId = getIntent().getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, 0);
         if (this.appWidgetId == 0) {
-            Toast.makeText(this, "No lock-screen widget was selected.", 1).show();
+            Toast.makeText(this, "No lock-screen widget was selected.", Toast.LENGTH_LONG).show();
             finish();
         } else {
             this.dark = Ui.isDark(this);
@@ -55,93 +56,189 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
         page.preview.setBackgroundColor(Ui.controlSurface(this, this.dark));
         this.preview = new ImageView(this);
         this.preview.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
-        this.preview.setPadding(Ui.dp(this, 28.0f), Ui.dp(this, 28.0f), Ui.dp(this, 28.0f), Ui.dp(this, 28.0f));
+        this.preview.setPadding(Ui.dp(this, 28.0f), Ui.dp(this, 28.0f), Ui.dp(this, 28.0f),
+                Ui.dp(this, 28.0f));
         page.preview.addView(this.preview, new FrameLayout.LayoutParams(-1, -1));
+
+        LockWidgetOptions saved = AppPreferences.loadLockWidgetOptions(this, this.appWidgetId);
+        this.selectedMeters.clear();
+        for (String key : WidgetMeters.parse(saved.effectiveVisibleMeters())) {
+            if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)
+                    || WidgetMeters.isLimitKey(key)) {
+                this.selectedMeters.add(key);
+            }
+        }
+        if (this.selectedMeters.isEmpty()) {
+            this.selectedMeters.add(WidgetMeters.FIVE_HOUR);
+        }
+
+        linearLayout.addView(Ui.separator(this, "Meters"));
+        RoundedLinearLayout metersCard = Ui.seslCard(this, this.dark);
+        this.metersHint = Ui.text(this,
+                "Lock widgets show up to 2 meters. Extra selections are ignored.",
+                13.0f, Ui.secondaryText(this.dark));
+        this.metersHint.setPadding(0, 0, 0, Ui.dp(this, 8));
+        metersCard.addView(this.metersHint);
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
+        List<String> available = new ArrayList<>();
+        for (String key : WidgetMeters.availableKeys(snapshot)) {
+            if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)
+                    || WidgetMeters.isLimitKey(key)) {
+                available.add(key);
+            }
+        }
+        boolean first = true;
+        for (String key : available) {
+            SwitchCompat toggle = new SwitchCompat(this);
+            toggle.setChecked(this.selectedMeters.contains(key));
+            metersCard.addView(buildSwitchRow(WidgetMeters.configLabel(key, snapshot), toggle,
+                    !first));
+            first = false;
+            toggle.setOnCheckedChangeListener((button, checked) -> {
+                if (checked) {
+                    this.selectedMeters.add(key);
+                } else {
+                    this.selectedMeters.remove(key);
+                    if (this.selectedMeters.isEmpty()) {
+                        this.selectedMeters.add(key);
+                        button.setChecked(true);
+                        return;
+                    }
+                }
+                updateMetersHint();
+                updatePreview();
+            });
+        }
+        linearLayout.addView(metersCard);
 
         linearLayout.addView(Ui.separator(this, "Content"));
         RoundedLinearLayout contentCard = Ui.seslCard(this, this.dark);
-        LockWidgetOptions lockWidgetOptionsLoadLockWidgetOptions = AppPreferences.loadLockWidgetOptions(this, this.appWidgetId);
-        this.metricSpinner = Ui.spinner(this, WidgetOptionCatalog.METRIC_LABELS, this.dark);
-        WidgetOptionCatalog.selectString(this.metricSpinner, WidgetOptionCatalog.METRIC_VALUES, lockWidgetOptionsLoadLockWidgetOptions.metricMode);
-        this.metricRow = new CardItemView(this);
-        this.metricRow.setTitle("Usage windows");
-        this.metricRow.setSummary(WidgetOptionCatalog.METRIC_LABELS[
-                this.metricSpinner.getSelectedItemPosition()]);
-        this.metricRow.setShowBottomDivider(false);
-        this.metricRow.setOnClickListener(view -> OneUiChoiceDialog.show(this,
-                "Usage windows", WidgetOptionCatalog.METRIC_LABELS,
-                this.metricSpinner.getSelectedItemPosition(),
-                position -> this.metricSpinner.setSelection(position)));
-        contentCard.addView(this.metricRow);
-        this.showCountdown = Ui.checkbox(this, "Show live time until reset", lockWidgetOptionsLoadLockWidgetOptions.showCountdown, this.dark);
-        this.showResetCredits = Ui.checkbox(this, "Show reset-credit count", lockWidgetOptionsLoadLockWidgetOptions.showResetCredits, this.dark);
-        this.showResetAction = Ui.checkbox(this, "Tap tile to open Use reset confirmation", lockWidgetOptionsLoadLockWidgetOptions.showResetAction, this.dark);
+        this.showCountdown = Ui.checkbox(this, "Show live time until reset", saved.showCountdown,
+                this.dark);
+        this.showResetCredits = Ui.checkbox(this, "Show reset-credit count", saved.showResetCredits,
+                this.dark);
+        this.showResetAction = Ui.checkbox(this, "Tap tile to open Use reset confirmation",
+                saved.showResetAction, this.dark);
         contentCard.addView(this.showCountdown);
         contentCard.addView(this.showResetCredits);
         contentCard.addView(this.showResetAction);
-        TextView textViewText = Ui.text(this, "A reset is never consumed directly from the lock screen. The tile opens a confirmation screen first.", 12.0f, Ui.secondaryText(this.dark));
+        TextView textViewText = Ui.text(this,
+                "A reset is never consumed directly from the lock screen. The tile opens a confirmation screen first.",
+                12.0f, Ui.secondaryText(this.dark));
         LinearLayout.LayoutParams layoutParams3 = new LinearLayout.LayoutParams(-1, -2);
         layoutParams3.setMargins(0, Ui.dp(this, 12.0f), 0, 0);
         contentCard.addView(textViewText, layoutParams3);
         linearLayout.addView(contentCard);
 
-        AdapterView.OnItemSelectedListener previewSelectionListener = new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                LockWidgetConfigActivity.this.metricRow.setSummary(
-                        WidgetOptionCatalog.METRIC_LABELS[position]);
-                LockWidgetConfigActivity.this.updatePreview();
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-            }
-        };
-        this.metricSpinner.setOnItemSelectedListener(previewSelectionListener);
-        CompoundButton.OnCheckedChangeListener previewCheckListener = new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                LockWidgetConfigActivity.this.updatePreview();
-            }
-        };
+        CompoundButton.OnCheckedChangeListener previewCheckListener =
+                (buttonView, isChecked) -> updatePreview();
         this.showCountdown.setOnCheckedChangeListener(previewCheckListener);
         this.showResetCredits.setOnCheckedChangeListener(previewCheckListener);
         this.showResetAction.setOnCheckedChangeListener(previewCheckListener);
 
-        page.cancel.setOnClickListener(new View.OnClickListener() {
-            @Override // android.view.View.OnClickListener
-            public void onClick(View view) {
-                LockWidgetConfigActivity.this.finish();
-            }
-        });
-        page.save.setOnClickListener(new View.OnClickListener() {
-            @Override // android.view.View.OnClickListener
-            public void onClick(View view) {
-                LockWidgetConfigActivity.this.save();
-            }
-        });
+        page.cancel.setOnClickListener(view -> finish());
+        page.save.setOnClickListener(view -> save());
+        updateMetersHint();
         updatePreview();
     }
 
+    private LinearLayout buildSwitchRow(String title, SwitchCompat toggle, boolean topDivider) {
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.VERTICAL);
+        if (topDivider) {
+            View divider = new View(this);
+            divider.setBackgroundColor(Ui.divider(this.dark));
+            LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 1));
+            dividerParams.setMargins(0, Ui.dp(this, 4), 0, Ui.dp(this, 4));
+            row.addView(divider, dividerParams);
+        }
+        LinearLayout content = new LinearLayout(this);
+        content.setGravity(Gravity.CENTER_VERTICAL);
+        content.setMinimumHeight(Ui.dp(this, 52));
+        content.addView(Ui.text(this, title, 16, Ui.mainText(this.dark)),
+                new LinearLayout.LayoutParams(0, -2, 1));
+        content.addView(toggle, new LinearLayout.LayoutParams(-2, -2));
+        content.setOnClickListener(view -> toggle.toggle());
+        row.addView(content, new LinearLayout.LayoutParams(-1, -2));
+        return row;
+    }
+
+    private void updateMetersHint() {
+        if (this.metersHint == null) {
+            return;
+        }
+        int selected = this.selectedMeters.size();
+        int capacity = WidgetMeters.lockSlotCapacity(true);
+        String message = "Lock widgets show up to " + capacity + " meters.";
+        if (selected > capacity) {
+            message += " " + (selected - capacity)
+                    + " extra selection" + (selected - capacity == 1 ? " is" : "s are")
+                    + " ignored until you deselect others.";
+        }
+        this.metersHint.setText(message);
+    }
+
     private LockWidgetOptions currentOptions() {
-        return new LockWidgetOptions(WidgetOptionCatalog.METRIC_VALUES[this.metricSpinner.getSelectedItemPosition()], this.showResetCredits.isChecked(), this.showResetAction.isChecked(), this.showCountdown.isChecked());
+        String visible = WidgetMeters.serialize(new ArrayList<>(this.selectedMeters));
+        boolean five = this.selectedMeters.contains(WidgetMeters.FIVE_HOUR);
+        boolean weekly = this.selectedMeters.contains(WidgetMeters.WEEKLY);
+        String metricMode = WidgetOptions.METRIC_BOTH;
+        if (five && !weekly && this.selectedMeters.size() == 1) {
+            metricMode = WidgetOptions.METRIC_FIVE_HOUR;
+        } else if (weekly && !five && this.selectedMeters.size() == 1) {
+            metricMode = WidgetOptions.METRIC_WEEKLY;
+        }
+        return new LockWidgetOptions(metricMode, this.showResetCredits.isChecked(),
+                this.showResetAction.isChecked(), this.showCountdown.isChecked(), visible);
     }
 
     private void updatePreview() {
-        if (this.preview == null || this.metricSpinner == null || this.showCountdown == null) {
+        if (this.preview == null || this.showCountdown == null) {
             return;
+        }
+        LockWidgetOptions options = currentOptions();
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
+        List<String> available = WidgetMeters.availableKeys(snapshot);
+        List<String> visible = WidgetMeters.cap(
+                WidgetMeters.resolveVisible(options.effectiveVisibleMeters(), available), 2);
+        int primary = 73;
+        int secondary = 44;
+        if (!visible.isEmpty()) {
+            primary = previewRemaining(visible.get(0), snapshot, 73);
+        }
+        if (visible.size() > 1) {
+            secondary = previewRemaining(visible.get(1), snapshot, 44);
+        } else if (options.singleMetric()) {
+            secondary = -1;
         }
         this.preview.setImageBitmap(SamsungLockGraphics.render(this,
                 SamsungLockWidgetSupport.Shape.WIDE, SamsungLockWidgetSupport.Style.DIALS,
-                73, 44, true, 180, 82, currentOptions(), 2));
+                primary, secondary < 0 ? primary : secondary, true, 180, 82, options, 2));
+    }
+
+    private static int previewRemaining(String key, UsageSnapshot snapshot, int fallback) {
+        if (WidgetMeters.FIVE_HOUR.equals(key) && snapshot != null && snapshot.fiveHour != null) {
+            return snapshot.fiveHour.remainingPercent();
+        }
+        if (WidgetMeters.WEEKLY.equals(key) && snapshot != null && snapshot.weekly != null) {
+            return snapshot.weekly.remainingPercent();
+        }
+        UsageLimit limit = WidgetMeters.findLimit(key, snapshot);
+        if (limit != null) {
+            UsageWindow window = WidgetMeters.isLimitPrimary(key) ? limit.primary : limit.secondary;
+            if (window != null) {
+                return window.remainingPercent();
+            }
+        }
+        return fallback;
     }
 
     public void save() {
         AppPreferences.saveLockWidgetOptions(this, this.appWidgetId, currentOptions());
         SamsungLockWidgetSupport.updateById(this, this.appWidgetId);
-        setResult(-1, new Intent().putExtra(
+        setResult(RESULT_OK, new Intent().putExtra(
                 AppWidgetManager.EXTRA_APPWIDGET_ID, this.appWidgetId));
-        Toast.makeText(this, "Lock-screen widget updated.", 0).show();
+        Toast.makeText(this, "Lock-screen widget updated.", Toast.LENGTH_SHORT).show();
         finish();
     }
 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
@@ -168,7 +168,7 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
             return;
         }
         int selected = this.selectedMeters.size();
-        int capacity = WidgetMeters.lockSlotCapacity(true);
+        int capacity = WidgetMeters.lockSlotCapacity();
         String message = "Lock widgets show up to " + capacity + " meters.";
         if (selected > capacity) {
             message += " " + (selected - capacity)
@@ -200,20 +200,32 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
         UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
         List<String> available = WidgetMeters.availableKeys(snapshot);
         List<String> visible = WidgetMeters.cap(
-                WidgetMeters.resolveVisible(options.effectiveVisibleMeters(), available), 2);
+                WidgetMeters.resolveVisible(options.effectiveVisibleMeters(), available),
+                WidgetMeters.lockSlotCapacity());
         int primary = 73;
-        int secondary = 44;
+        int secondary = -1;
+        int primaryIcon = R.drawable.ic_oui_time;
+        int secondaryIcon = R.drawable.ic_oui_calendar_week;
         if (!visible.isEmpty()) {
             primary = previewRemaining(visible.get(0), snapshot, 73);
+            primaryIcon = previewIcon(visible.get(0));
         }
         if (visible.size() > 1) {
             secondary = previewRemaining(visible.get(1), snapshot, 44);
-        } else if (options.singleMetric()) {
-            secondary = -1;
+            secondaryIcon = previewIcon(visible.get(1));
         }
         this.preview.setImageBitmap(SamsungLockGraphics.render(this,
                 SamsungLockWidgetSupport.Shape.WIDE, SamsungLockWidgetSupport.Style.DIALS,
-                primary, secondary < 0 ? primary : secondary, true, 180, 82, options, 2));
+                primary, secondary, true, 180, 82, options, 2,
+                primaryIcon, secondaryIcon));
+    }
+
+    private static int previewIcon(String key) {
+        if (WidgetMeters.WEEKLY.equals(key)
+                || (WidgetMeters.isLimitKey(key) && !WidgetMeters.isLimitPrimary(key))) {
+            return R.drawable.ic_oui_calendar_week;
+        }
+        return R.drawable.ic_oui_time;
     }
 
     private static int previewRemaining(String key, UsageSnapshot snapshot, int fallback) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetOptions.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetOptions.java
@@ -6,8 +6,14 @@ public final class LockWidgetOptions {
     public final boolean showCountdown;
     public final boolean showResetAction;
     public final boolean showResetCredits;
+    /** Ordered CSV of {@link WidgetMeters} keys; empty means migrate from {@link #metricMode}. */
+    public final String visibleMeters;
 
     public LockWidgetOptions(String str, boolean z, boolean z2, boolean z3) {
+        this(str, z, z2, z3, "");
+    }
+
+    public LockWidgetOptions(String str, boolean z, boolean z2, boolean z3, String visibleMeters) {
         if (!"five_hour".equals(str) && !"weekly".equals(str)) {
             str = "both";
         }
@@ -15,21 +21,34 @@ public final class LockWidgetOptions {
         this.showResetCredits = z;
         this.showResetAction = z2;
         this.showCountdown = z3;
+        this.visibleMeters = visibleMeters == null ? "" : visibleMeters.trim();
     }
 
     public static LockWidgetOptions defaults() {
-        return new LockWidgetOptions("both", false, false, true);
+        return new LockWidgetOptions("both", false, false, true,
+                WidgetMeters.serialize(WidgetMeters.defaultVisible()));
+    }
+
+    public LockWidgetOptions withVisibleMeters(String metersCsv) {
+        return new LockWidgetOptions(this.metricMode, this.showResetCredits, this.showResetAction,
+                this.showCountdown, metersCsv);
+    }
+
+    public String effectiveVisibleMeters() {
+        return WidgetMeters.effectiveVisibleCsv(this.visibleMeters, this.metricMode);
     }
 
     public boolean showsFiveHour() {
-        return !"weekly".equals(this.metricMode);
+        return WidgetMeters.contains(
+                WidgetMeters.parse(effectiveVisibleMeters()), WidgetMeters.FIVE_HOUR);
     }
 
     public boolean showsWeekly() {
-        return !"five_hour".equals(this.metricMode);
+        return WidgetMeters.contains(
+                WidgetMeters.parse(effectiveVisibleMeters()), WidgetMeters.WEEKLY);
     }
 
     public boolean singleMetric() {
-        return !"both".equals(this.metricMode);
+        return WidgetMeters.singleUsageMetric(WidgetMeters.parse(effectiveVisibleMeters()));
     }
 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/SamsungLockGraphics.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SamsungLockGraphics.java
@@ -22,6 +22,15 @@ final class SamsungLockGraphics {
     static Bitmap render(Context context, SamsungLockWidgetSupport.Shape shape,
             SamsungLockWidgetSupport.Style style, int fiveHour, int weekly, boolean signedIn,
             int requestedWidth, int requestedHeight, LockWidgetOptions options, int resetCredits) {
+        return render(context, shape, style, fiveHour, weekly, signedIn, requestedWidth,
+                requestedHeight, options, resetCredits,
+                R.drawable.ic_oui_time, R.drawable.ic_oui_calendar_week);
+    }
+
+    static Bitmap render(Context context, SamsungLockWidgetSupport.Shape shape,
+            SamsungLockWidgetSupport.Style style, int fiveHour, int weekly, boolean signedIn,
+            int requestedWidth, int requestedHeight, LockWidgetOptions options, int resetCredits,
+            int primaryIconRes, int secondaryIconRes) {
         int width = clamp(requestedWidth, 44, shape == SamsungLockWidgetSupport.Shape.SQUARE ? 96 : 200,
                 shape == SamsungLockWidgetSupport.Shape.SQUARE ? 56 : 124);
         int height = clamp(requestedHeight, 44, 96, 56);
@@ -41,12 +50,12 @@ final class SamsungLockGraphics {
         float dialScale = Math.min(1.0f, Math.min(height / 56.0f, width / 124.0f));
         float top = (height - (56.0f * dialScale)) / 2.0f;
         float spacer = (width - (92.0f * dialScale)) / 3.0f;
-        Drawable fiveHourIcon = context == null ? null : context.getDrawable(R.drawable.ic_oui_time);
-        Drawable weeklyIcon = context == null ? null : context.getDrawable(R.drawable.ic_oui_calendar_week);
+        Drawable primaryIcon = context == null ? null : context.getDrawable(primaryIconRes);
+        Drawable secondaryIcon = context == null ? null : context.getDrawable(secondaryIconRes);
         drawDial(canvas, paint, spacer + (23.0f * dialScale), top, dialScale,
-                fiveHour, fiveHourIcon);
+                fiveHour, primaryIcon);
         drawDial(canvas, paint, (2.0f * spacer) + (69.0f * dialScale), top, dialScale,
-                weekly, weeklyIcon);
+                weekly, secondaryIcon);
         return bitmap;
     }
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
@@ -239,7 +239,7 @@ final class SamsungLockWidgetSupport {
                 usageKeys.add(key);
             }
         }
-        usageKeys = new ArrayList<>(WidgetMeters.cap(usageKeys, WidgetMeters.lockSlotCapacity(true)));
+        usageKeys = new ArrayList<>(WidgetMeters.cap(usageKeys, WidgetMeters.lockSlotCapacity()));
         if (usageKeys.isEmpty()) {
             usageKeys.add(WidgetMeters.FIVE_HOUR);
         }
@@ -252,12 +252,14 @@ final class SamsungLockWidgetSupport {
         if (WidgetMeters.FIVE_HOUR.equals(key)) {
             return new LockMeterSlot(key, "5H",
                     remaining(snapshot == null ? null : snapshot.fiveHour),
-                    snapshot == null ? null : snapshot.fiveHour);
+                    snapshot == null ? null : snapshot.fiveHour,
+                    R.drawable.ic_oui_time);
         }
         if (WidgetMeters.WEEKLY.equals(key)) {
             return new LockMeterSlot(key, "W",
                     remaining(snapshot == null ? null : snapshot.weekly),
-                    snapshot == null ? null : snapshot.weekly);
+                    snapshot == null ? null : snapshot.weekly,
+                    R.drawable.ic_oui_calendar_week);
         }
         UsageLimit limit = WidgetMeters.findLimit(key, snapshot);
         UsageWindow window = limit == null ? null
@@ -266,7 +268,9 @@ final class SamsungLockWidgetSupport {
         if (label.length() > 6) {
             label = label.substring(0, 6);
         }
-        return new LockMeterSlot(key, label.toUpperCase(Locale.ROOT), remaining(window), window);
+        return new LockMeterSlot(key, label.toUpperCase(Locale.ROOT), remaining(window), window,
+                WidgetMeters.isLimitPrimary(key)
+                        ? R.drawable.ic_oui_time : R.drawable.ic_oui_calendar_week);
     }
 
     private static final class LockMeterSlot {
@@ -274,12 +278,14 @@ final class SamsungLockWidgetSupport {
         final String label;
         final int remaining;
         final UsageWindow window;
+        final int iconRes;
 
-        LockMeterSlot(String key, String label, int remaining, UsageWindow window) {
+        LockMeterSlot(String key, String label, int remaining, UsageWindow window, int iconRes) {
             this.key = key;
             this.label = label;
             this.remaining = remaining;
             this.window = window;
+            this.iconRes = iconRes;
         }
     }
 
@@ -369,11 +375,15 @@ final class SamsungLockWidgetSupport {
         RemoteViews remoteViews = new RemoteViews(context.getPackageName(), graphicLayout(shape, style));
         int i2 = binding.primaryRemaining;
         int i3 = binding.secondaryRemaining;
+        int primaryIconRes = binding.primary == null
+                ? R.drawable.ic_oui_time : binding.primary.iconRes;
+        int secondaryIconRes = binding.secondary == null
+                ? R.drawable.ic_oui_calendar_week : binding.secondary.iconRes;
         if (shape == Shape.WIDE) {
             int[] size = grantedSize(appWidgetManager, i, shape);
             remoteViews.setImageViewBitmap(R.id.lock_graphic_image,
                     SamsungLockGraphics.render(context, shape, style, i2, i3, z, size[0], size[1],
-                            lockWidgetOptions, i4));
+                            lockWidgetOptions, i4, primaryIconRes, secondaryIconRes));
             if (!z) {
                 remoteViews.setViewVisibility(R.id.lock_graphic_primary_group, View.VISIBLE);
                 remoteViews.setViewVisibility(R.id.lock_graphic_secondary_group, View.GONE);
@@ -388,7 +398,10 @@ final class SamsungLockWidgetSupport {
             return remoteViews;
         }
         int[] iArrGrantedSize = grantedSize(appWidgetManager, i, shape);
-        remoteViews.setImageViewBitmap(R.id.lock_graphic_image, SamsungLockGraphics.render(context, shape, style, i2, i3, z, iArrGrantedSize[0], iArrGrantedSize[1], lockWidgetOptions, i4));
+        remoteViews.setImageViewBitmap(R.id.lock_graphic_image,
+                SamsungLockGraphics.render(context, shape, style, i2, i3, z,
+                        iArrGrantedSize[0], iArrGrantedSize[1], lockWidgetOptions, i4,
+                        primaryIconRes, secondaryIconRes));
         if (z) {
             if (shape == Shape.SQUARE) {
                 remoteViews.setViewVisibility(R.id.lock_graphic_center_value, View.GONE);

--- a/android/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
@@ -186,13 +186,16 @@ final class SamsungLockWidgetSupport {
         int i2;
         boolean zIsSignedIn = SecureTokenStore.isSignedIn(context);
         UsageSnapshot usageSnapshotLoadSnapshot = AppPreferences.loadSnapshot(context);
-        int iRemaining = remaining(usageSnapshotLoadSnapshot == null ? null : usageSnapshotLoadSnapshot.fiveHour);
-        int iRemaining2 = remaining(usageSnapshotLoadSnapshot == null ? null : usageSnapshotLoadSnapshot.weekly);
         LockWidgetOptions lockWidgetOptionsLoadLockWidgetOptions = AppPreferences.loadLockWidgetOptions(context, i);
         ResetCreditsSnapshot resetCreditsSnapshotLoadResetCredits = AppPreferences.loadResetCredits(context);
         int i3 = resetCreditsSnapshotLoadResetCredits == null ? 0 : resetCreditsSnapshotLoadResetCredits.availableCount;
+        LockMeterBinding binding = bindLockMeters(usageSnapshotLoadSnapshot, lockWidgetOptionsLoadLockWidgetOptions);
+        int iRemaining = binding.primaryRemaining;
+        int iRemaining2 = binding.secondaryRemaining;
         if (metric != Metric.BOTH) {
-            int value = metric == Metric.FIVE_HOUR ? iRemaining : iRemaining2;
+            int value = metric == Metric.FIVE_HOUR
+                    ? remaining(usageSnapshotLoadSnapshot == null ? null : usageSnapshotLoadSnapshot.fiveHour)
+                    : remaining(usageSnapshotLoadSnapshot == null ? null : usageSnapshotLoadSnapshot.weekly);
             int[] size = grantedSize(appWidgetManager, i, Shape.SQUARE);
             RemoteViews single = new RemoteViews(context.getPackageName(), R.layout.widget_lock_dial_single);
             single.setImageViewBitmap(R.id.lock_graphic_image,
@@ -206,35 +209,115 @@ final class SamsungLockWidgetSupport {
             return single;
         }
         if (style == Style.NUMBERS) {
-            remoteViewsBuildArcViews = buildNumberViews(context, shape, zIsSignedIn, iRemaining,
-                    iRemaining2, lockWidgetOptionsLoadLockWidgetOptions, i3);
+            remoteViewsBuildArcViews = buildNumberViews(context, shape, zIsSignedIn, binding,
+                    lockWidgetOptionsLoadLockWidgetOptions, i3);
             i2 = shape == Shape.SQUARE ? R.id.lock_square_root : R.id.lock_wide_root;
         } else if (style == Style.BARS) {
-            remoteViewsBuildArcViews = buildNativeBarViews(context, shape, zIsSignedIn, iRemaining,
-                    iRemaining2, lockWidgetOptionsLoadLockWidgetOptions, i3);
+            remoteViewsBuildArcViews = buildNativeBarViews(context, shape, zIsSignedIn, binding,
+                    lockWidgetOptionsLoadLockWidgetOptions, i3);
             i2 = R.id.lock_graphic_root;
         } else {
             remoteViewsBuildArcViews = buildArcViews(context, appWidgetManager, i, shape, style,
-                    zIsSignedIn, iRemaining, iRemaining2, lockWidgetOptionsLoadLockWidgetOptions, i3);
+                    zIsSignedIn, binding, lockWidgetOptionsLoadLockWidgetOptions, i3);
             i2 = R.id.lock_graphic_root;
         }
-        applyCountdowns(remoteViewsBuildArcViews, shape, style, lockWidgetOptionsLoadLockWidgetOptions, usageSnapshotLoadSnapshot == null ? null : usageSnapshotLoadSnapshot.fiveHour, usageSnapshotLoadSnapshot == null ? null : usageSnapshotLoadSnapshot.weekly);
-        remoteViewsBuildArcViews.setContentDescription(i2, contentDescription(zIsSignedIn, iRemaining, iRemaining2, style, lockWidgetOptionsLoadLockWidgetOptions, i3));
+        applyCountdowns(remoteViewsBuildArcViews, shape, style, lockWidgetOptionsLoadLockWidgetOptions,
+                binding);
+        remoteViewsBuildArcViews.setContentDescription(i2, contentDescription(zIsSignedIn, binding, style, lockWidgetOptionsLoadLockWidgetOptions, i3));
         applyOpenIntent(context, remoteViewsBuildArcViews, i2, i, shape, style, lockWidgetOptionsLoadLockWidgetOptions, zIsSignedIn, i3);
         return remoteViewsBuildArcViews;
     }
 
-    private static RemoteViews buildNumberViews(Context context, Shape shape, boolean z, int i, int i2, LockWidgetOptions lockWidgetOptions, int i3) {
+    private static LockMeterBinding bindLockMeters(UsageSnapshot snapshot, LockWidgetOptions options) {
+        List<String> available = WidgetMeters.availableKeys(snapshot);
+        List<String> resolved = WidgetMeters.resolveVisible(
+                options == null ? "" : options.effectiveVisibleMeters(), available);
+        ArrayList<String> usageKeys = new ArrayList<>();
+        for (String key : resolved) {
+            if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)
+                    || WidgetMeters.isLimitKey(key)) {
+                usageKeys.add(key);
+            }
+        }
+        usageKeys = new ArrayList<>(WidgetMeters.cap(usageKeys, WidgetMeters.lockSlotCapacity(true)));
+        if (usageKeys.isEmpty()) {
+            usageKeys.add(WidgetMeters.FIVE_HOUR);
+        }
+        LockMeterSlot primary = lockSlot(usageKeys.get(0), snapshot);
+        LockMeterSlot secondary = usageKeys.size() > 1 ? lockSlot(usageKeys.get(1), snapshot) : null;
+        return new LockMeterBinding(primary, secondary);
+    }
+
+    private static LockMeterSlot lockSlot(String key, UsageSnapshot snapshot) {
+        if (WidgetMeters.FIVE_HOUR.equals(key)) {
+            return new LockMeterSlot(key, "5H",
+                    remaining(snapshot == null ? null : snapshot.fiveHour),
+                    snapshot == null ? null : snapshot.fiveHour);
+        }
+        if (WidgetMeters.WEEKLY.equals(key)) {
+            return new LockMeterSlot(key, "W",
+                    remaining(snapshot == null ? null : snapshot.weekly),
+                    snapshot == null ? null : snapshot.weekly);
+        }
+        UsageLimit limit = WidgetMeters.findLimit(key, snapshot);
+        UsageWindow window = limit == null ? null
+                : (WidgetMeters.isLimitPrimary(key) ? limit.primary : limit.secondary);
+        String label = WidgetMeters.shortLabel(key, snapshot);
+        if (label.length() > 6) {
+            label = label.substring(0, 6);
+        }
+        return new LockMeterSlot(key, label.toUpperCase(Locale.ROOT), remaining(window), window);
+    }
+
+    private static final class LockMeterSlot {
+        final String key;
+        final String label;
+        final int remaining;
+        final UsageWindow window;
+
+        LockMeterSlot(String key, String label, int remaining, UsageWindow window) {
+            this.key = key;
+            this.label = label;
+            this.remaining = remaining;
+            this.window = window;
+        }
+    }
+
+    private static final class LockMeterBinding {
+        final LockMeterSlot primary;
+        final LockMeterSlot secondary;
+        final int primaryRemaining;
+        final int secondaryRemaining;
+        final boolean showPrimary;
+        final boolean showSecondary;
+
+        LockMeterBinding(LockMeterSlot primary, LockMeterSlot secondary) {
+            this.primary = primary;
+            this.secondary = secondary;
+            this.showPrimary = primary != null;
+            this.showSecondary = secondary != null;
+            this.primaryRemaining = primary == null ? -1 : primary.remaining;
+            this.secondaryRemaining = secondary == null ? -1 : secondary.remaining;
+        }
+
+        boolean singleMetric() {
+            return showPrimary && !showSecondary;
+        }
+    }
+
+    private static RemoteViews buildNumberViews(Context context, Shape shape, boolean z,
+            LockMeterBinding binding, LockWidgetOptions lockWidgetOptions, int i3) {
         int i4 = shape == Shape.SQUARE ? R.layout.widget_lock_square : R.layout.widget_lock_wide;
         int i5 = shape == Shape.SQUARE ? R.id.lock_square_value : R.id.lock_wide_value;
         RemoteViews remoteViews = new RemoteViews(context.getPackageName(), i4);
         boolean z2 = lockWidgetOptions.showResetCredits || lockWidgetOptions.showResetAction;
-        remoteViews.setTextViewText(i5, numberText(z, i, i2, shape, lockWidgetOptions, i3));
-        remoteViews.setTextViewTextSize(i5, 2, numberTextSize(shape, lockWidgetOptions, z2));
+        remoteViews.setTextViewText(i5, numberText(z, binding, shape, lockWidgetOptions, i3));
+        remoteViews.setTextViewTextSize(i5, 2, numberTextSize(shape, binding.singleMetric(), z2));
         return remoteViews;
     }
 
-    private static RemoteViews buildNativeBarViews(Context context, Shape shape, boolean z, int i, int i2, LockWidgetOptions lockWidgetOptions, int i3) {
+    private static RemoteViews buildNativeBarViews(Context context, Shape shape, boolean z,
+            LockMeterBinding binding, LockWidgetOptions lockWidgetOptions, int i3) {
         float f;
         float f2;
         RemoteViews remoteViews = new RemoteViews(context.getPackageName(), shape == Shape.SQUARE ? R.layout.widget_lock_bars_square : R.layout.widget_lock_bars_wide);
@@ -248,26 +331,28 @@ final class SamsungLockWidgetSupport {
             remoteViews.setViewVisibility(R.id.lock_bar_primary_progress, View.GONE);
             return remoteViews;
         }
-        boolean zShowsFiveHour = lockWidgetOptions.showsFiveHour();
-        boolean zShowsWeekly = lockWidgetOptions.showsWeekly();
+        boolean zShowsFiveHour = binding.showPrimary;
+        boolean zShowsWeekly = binding.showSecondary;
         remoteViews.setViewVisibility(R.id.lock_bar_primary_group, zShowsFiveHour ? View.VISIBLE : View.GONE);
         remoteViews.setViewVisibility(R.id.lock_bar_secondary_group, zShowsWeekly ? View.VISIBLE : View.GONE);
         remoteViews.setViewVisibility(R.id.lock_bar_primary_progress, zShowsFiveHour ? View.VISIBLE : View.GONE);
         remoteViews.setViewVisibility(R.id.lock_bar_secondary_progress, zShowsWeekly ? View.VISIBLE : View.GONE);
         boolean z3 = z2 && zShowsFiveHour;
         boolean z4 = z2 && !zShowsFiveHour && zShowsWeekly;
-        remoteViews.setTextViewText(R.id.lock_bar_primary_label, labelWithReset("5H", z3, i3));
-        remoteViews.setTextViewText(R.id.lock_bar_secondary_label, labelWithReset("W", z4, i3));
-        remoteViews.setTextViewText(R.id.lock_bar_primary_value, compactValue(i));
-        remoteViews.setTextViewText(R.id.lock_bar_secondary_value, compactValue(i2));
-        remoteViews.setProgressBar(R.id.lock_bar_primary_progress, 100, progress(i), false);
-        remoteViews.setProgressBar(R.id.lock_bar_secondary_progress, 100, progress(i2), false);
-        if (lockWidgetOptions.singleMetric()) {
+        String primaryLabel = binding.primary == null ? "5H" : binding.primary.label;
+        String secondaryLabel = binding.secondary == null ? "W" : binding.secondary.label;
+        remoteViews.setTextViewText(R.id.lock_bar_primary_label, labelWithReset(primaryLabel, z3, i3));
+        remoteViews.setTextViewText(R.id.lock_bar_secondary_label, labelWithReset(secondaryLabel, z4, i3));
+        remoteViews.setTextViewText(R.id.lock_bar_primary_value, compactValue(binding.primaryRemaining));
+        remoteViews.setTextViewText(R.id.lock_bar_secondary_value, compactValue(binding.secondaryRemaining));
+        remoteViews.setProgressBar(R.id.lock_bar_primary_progress, 100, progress(binding.primaryRemaining), false);
+        remoteViews.setProgressBar(R.id.lock_bar_secondary_progress, 100, progress(binding.secondaryRemaining), false);
+        if (binding.singleMetric()) {
             f = shape == Shape.SQUARE ? 15.0f : 17.0f;
         } else {
             f = shape == Shape.SQUARE ? 10.0f : 11.0f;
         }
-        if (lockWidgetOptions.singleMetric()) {
+        if (binding.singleMetric()) {
             f2 = shape == Shape.SQUARE ? 9.0f : 10.0f;
         } else {
             f2 = shape == Shape.SQUARE ? 7.5f : 8.0f;
@@ -279,9 +364,11 @@ final class SamsungLockWidgetSupport {
         return remoteViews;
     }
 
-    private static RemoteViews buildArcViews(Context context, AppWidgetManager appWidgetManager, int i, Shape shape, Style style, boolean z, int i2, int i3, LockWidgetOptions lockWidgetOptions, int i4) {
+    private static RemoteViews buildArcViews(Context context, AppWidgetManager appWidgetManager, int i, Shape shape, Style style, boolean z, LockMeterBinding binding, LockWidgetOptions lockWidgetOptions, int i4) {
         String strSquareGraphicText;
         RemoteViews remoteViews = new RemoteViews(context.getPackageName(), graphicLayout(shape, style));
+        int i2 = binding.primaryRemaining;
+        int i3 = binding.secondaryRemaining;
         if (shape == Shape.WIDE) {
             int[] size = grantedSize(appWidgetManager, i, shape);
             remoteViews.setImageViewBitmap(R.id.lock_graphic_image,
@@ -296,8 +383,6 @@ final class SamsungLockWidgetSupport {
                 remoteViews.setTextViewTextSize(R.id.lock_graphic_primary_value, 2, 11.0f);
                 return remoteViews;
             }
-            boolean showFiveHour = lockWidgetOptions.showsFiveHour();
-            boolean showWeekly = lockWidgetOptions.showsWeekly();
             remoteViews.setViewVisibility(R.id.lock_graphic_primary_group, View.GONE);
             remoteViews.setViewVisibility(R.id.lock_graphic_secondary_group, View.GONE);
             return remoteViews;
@@ -316,12 +401,12 @@ final class SamsungLockWidgetSupport {
         boolean z2 = lockWidgetOptions.showResetCredits || lockWidgetOptions.showResetAction;
         if (shape == Shape.SQUARE) {
             if (z) {
-                strSquareGraphicText = squareGraphicText(i2, i3, lockWidgetOptions, z2, i4);
+                strSquareGraphicText = squareGraphicText(binding, lockWidgetOptions, z2, i4);
             } else {
                 strSquareGraphicText = "SIGN IN";
             }
             remoteViews.setTextViewText(R.id.lock_graphic_center_value, strSquareGraphicText);
-            remoteViews.setTextViewTextSize(R.id.lock_graphic_center_value, 2, z ? squareGraphicTextSize(lockWidgetOptions, z2) : 10.0f);
+            remoteViews.setTextViewTextSize(R.id.lock_graphic_center_value, 2, z ? squareGraphicTextSize(binding.singleMetric(), lockWidgetOptions.showCountdown, z2) : 10.0f);
         } else if (!z) {
             remoteViews.setViewVisibility(R.id.lock_graphic_primary_group, View.VISIBLE);
             remoteViews.setViewVisibility(R.id.lock_graphic_secondary_group, View.GONE);
@@ -329,19 +414,21 @@ final class SamsungLockWidgetSupport {
             remoteViews.setTextViewText(R.id.lock_graphic_primary_label, "");
             remoteViews.setTextViewTextSize(R.id.lock_graphic_primary_value, 2, 11.0f);
         } else {
-            boolean zShowsFiveHour = lockWidgetOptions.showsFiveHour();
-            boolean zShowsWeekly = lockWidgetOptions.showsWeekly();
+            boolean zShowsFiveHour = binding.showPrimary;
+            boolean zShowsWeekly = binding.showSecondary;
             remoteViews.setViewVisibility(R.id.lock_graphic_primary_group, zShowsFiveHour ? View.VISIBLE : View.GONE);
             remoteViews.setViewVisibility(R.id.lock_graphic_secondary_group, zShowsWeekly ? View.VISIBLE : View.GONE);
             remoteViews.setTextViewText(R.id.lock_graphic_primary_value, compactValue(i2));
             remoteViews.setTextViewText(R.id.lock_graphic_secondary_value, compactValue(i3));
-            remoteViews.setTextViewText(R.id.lock_graphic_primary_label, labelWithReset("5H", z2 && zShowsFiveHour, i4));
-            remoteViews.setTextViewText(R.id.lock_graphic_secondary_label, labelWithReset("W", z2 && !zShowsFiveHour && zShowsWeekly, i4));
-            float f = lockWidgetOptions.singleMetric() ? 20.0f : 17.0f;
+            String primaryLabel = binding.primary == null ? "5H" : binding.primary.label;
+            String secondaryLabel = binding.secondary == null ? "W" : binding.secondary.label;
+            remoteViews.setTextViewText(R.id.lock_graphic_primary_label, labelWithReset(primaryLabel, z2 && zShowsFiveHour, i4));
+            remoteViews.setTextViewText(R.id.lock_graphic_secondary_label, labelWithReset(secondaryLabel, z2 && !zShowsFiveHour && zShowsWeekly, i4));
+            float f = binding.singleMetric() ? 20.0f : 17.0f;
             if (lockWidgetOptions.showCountdown) {
                 f -= 2.0f;
             }
-            float f2 = lockWidgetOptions.singleMetric() ? 9.5f : 8.0f;
+            float f2 = binding.singleMetric() ? 9.5f : 8.0f;
             remoteViews.setTextViewTextSize(R.id.lock_graphic_primary_value, 2, f);
             remoteViews.setTextViewTextSize(R.id.lock_graphic_secondary_value, 2, f);
             remoteViews.setTextViewTextSize(R.id.lock_graphic_primary_label, 2, f2);
@@ -350,44 +437,51 @@ final class SamsungLockWidgetSupport {
         return remoteViews;
     }
 
-    private static String squareGraphicText(int i, int i2, LockWidgetOptions lockWidgetOptions, boolean z, int i3) {
+    private static String squareGraphicText(LockMeterBinding binding, LockWidgetOptions lockWidgetOptions, boolean z, int i3) {
         String str;
-        if ("five_hour".equals(lockWidgetOptions.metricMode)) {
-            str = compactValue(i) + "\n5H";
-        } else if ("weekly".equals(lockWidgetOptions.metricMode)) {
-            str = compactValue(i2) + "\nW";
+        if (binding.singleMetric()) {
+            String label = binding.primary == null ? "5H" : binding.primary.label;
+            str = compactValue(binding.primaryRemaining) + "\n" + label;
         } else {
-            str = "5H " + compactValue(i) + "\nW " + compactValue(i2);
+            String primaryLabel = binding.primary == null ? "5H" : binding.primary.label;
+            String secondaryLabel = binding.secondary == null ? "W" : binding.secondary.label;
+            str = primaryLabel + " " + compactValue(binding.primaryRemaining) + "\n"
+                    + secondaryLabel + " " + compactValue(binding.secondaryRemaining);
         }
         return z ? str + "\nR" + Math.max(0, i3) : str;
     }
 
-    private static float squareGraphicTextSize(LockWidgetOptions lockWidgetOptions, boolean z) {
-        if (lockWidgetOptions.singleMetric()) {
+    private static float squareGraphicTextSize(boolean singleMetric, boolean showCountdown, boolean z) {
+        if (singleMetric) {
             if (z) {
                 return 9.5f;
             }
-            return lockWidgetOptions.showCountdown ? 11.5f : 12.5f;
+            return showCountdown ? 11.5f : 12.5f;
         }
         if (z) {
             return 8.1f;
         }
-        return lockWidgetOptions.showCountdown ? 8.8f : 9.5f;
+        return showCountdown ? 8.8f : 9.5f;
     }
 
     private static String labelWithReset(String str, boolean z, int i) {
         return z ? str + " · R" + Math.max(0, i) : str;
     }
 
-    private static void applyCountdowns(RemoteViews remoteViews, Shape shape, Style style, LockWidgetOptions lockWidgetOptions, UsageWindow usageWindow, UsageWindow usageWindow2) {
+    private static void applyCountdowns(RemoteViews remoteViews, Shape shape, Style style,
+            LockWidgetOptions lockWidgetOptions, LockMeterBinding binding) {
+        UsageWindow primaryWindow = binding.primary == null ? null : binding.primary.window;
+        UsageWindow secondaryWindow = binding.secondary == null ? null : binding.secondary.window;
         if (style == Style.BARS || (shape == Shape.WIDE && (style == Style.RINGS || style == Style.DIALS))) {
-            applyCountdown(remoteViews, R.id.lock_primary_countdown, lockWidgetOptions.showCountdown && lockWidgetOptions.showsFiveHour(), usageWindow);
-            applyCountdown(remoteViews, R.id.lock_secondary_countdown, lockWidgetOptions.showCountdown && lockWidgetOptions.showsWeekly(), usageWindow2);
+            applyCountdown(remoteViews, R.id.lock_primary_countdown,
+                    lockWidgetOptions.showCountdown && binding.showPrimary, primaryWindow);
+            applyCountdown(remoteViews, R.id.lock_secondary_countdown,
+                    lockWidgetOptions.showCountdown && binding.showSecondary, secondaryWindow);
         } else {
-            if (!"five_hour".equals(lockWidgetOptions.metricMode)) {
-                usageWindow = "weekly".equals(lockWidgetOptions.metricMode) ? usageWindow2 : earlierWindow(usageWindow, usageWindow2);
-            }
-            applyCountdown(remoteViews, R.id.lock_countdown, lockWidgetOptions.showCountdown, usageWindow);
+            UsageWindow window = binding.singleMetric()
+                    ? primaryWindow
+                    : earlierWindow(primaryWindow, secondaryWindow);
+            applyCountdown(remoteViews, R.id.lock_countdown, lockWidgetOptions.showCountdown, window);
         }
     }
 
@@ -452,19 +546,24 @@ final class SamsungLockWidgetSupport {
         return style == Style.RINGS ? shape == Shape.SQUARE ? R.layout.widget_lock_rings_square : R.layout.widget_lock_rings_wide : shape == Shape.SQUARE ? R.layout.widget_lock_dials_square : R.layout.widget_lock_dials_wide;
     }
 
-    private static String numberText(boolean z, int i, int i2, Shape shape, LockWidgetOptions lockWidgetOptions, int i3) {
+    private static String numberText(boolean z, LockMeterBinding binding, Shape shape,
+            LockWidgetOptions lockWidgetOptions, int i3) {
         String str;
         if (!z) {
             return shape == Shape.SQUARE ? "SIGN\nIN" : "SIGN IN";
         }
-        if ("five_hour".equals(lockWidgetOptions.metricMode)) {
-            str = shape == Shape.SQUARE ? "5H\n" + value(i) : "5H " + value(i);
-        } else if ("weekly".equals(lockWidgetOptions.metricMode)) {
-            str = shape == Shape.SQUARE ? "W\n" + value(i2) : "W " + value(i2);
+        String primaryLabel = binding.primary == null ? "5H" : binding.primary.label;
+        String secondaryLabel = binding.secondary == null ? "W" : binding.secondary.label;
+        if (binding.singleMetric()) {
+            str = shape == Shape.SQUARE
+                    ? primaryLabel + "\n" + value(binding.primaryRemaining)
+                    : primaryLabel + " " + value(binding.primaryRemaining);
         } else if (shape == Shape.SQUARE) {
-            str = "5H " + compactValue(i) + "\nW " + compactValue(i2);
+            str = primaryLabel + " " + compactValue(binding.primaryRemaining) + "\n"
+                    + secondaryLabel + " " + compactValue(binding.secondaryRemaining);
         } else {
-            str = "5H " + value(i) + "  ·  W " + value(i2);
+            str = primaryLabel + " " + value(binding.primaryRemaining) + "  ·  "
+                    + secondaryLabel + " " + value(binding.secondaryRemaining);
         }
         if (lockWidgetOptions.showResetCredits || lockWidgetOptions.showResetAction) {
             return str + (shape == Shape.SQUARE ? "\nR" + Math.max(0, i3) : "  ·  R" + Math.max(0, i3));
@@ -472,23 +571,29 @@ final class SamsungLockWidgetSupport {
         return str;
     }
 
-    private static float numberTextSize(Shape shape, LockWidgetOptions lockWidgetOptions, boolean z) {
-        return shape == Shape.WIDE ? lockWidgetOptions.singleMetric() ? z ? 14.0f : 16.0f : z ? 12.0f : 14.0f : lockWidgetOptions.singleMetric() ? z ? 10.5f : 13.0f : z ? 9.2f : 11.0f;
+    private static float numberTextSize(Shape shape, boolean singleMetric, boolean z) {
+        return shape == Shape.WIDE ? singleMetric ? z ? 14.0f : 16.0f : z ? 12.0f : 14.0f
+                : singleMetric ? z ? 10.5f : 13.0f : z ? 9.2f : 11.0f;
     }
 
-    private static String contentDescription(boolean z, int i, int i2, Style style, LockWidgetOptions lockWidgetOptions, int i3) {
+    private static String contentDescription(boolean z, LockMeterBinding binding, Style style,
+            LockWidgetOptions lockWidgetOptions, int i3) {
         if (!z) {
             return "Codex Meter, sign in required";
         }
         StringBuilder sbAppend = new StringBuilder("Codex ").append(styleLabel(style).toLowerCase()).append(", ");
-        if (lockWidgetOptions.showsFiveHour()) {
-            sbAppend.append("five hour ").append(value(i)).append(" remaining");
+        if (binding.showPrimary) {
+            String label = binding.primary == null ? "primary" : binding.primary.label;
+            sbAppend.append(label).append(' ').append(value(binding.primaryRemaining))
+                    .append(" remaining");
         }
-        if (lockWidgetOptions.showsFiveHour() && lockWidgetOptions.showsWeekly()) {
+        if (binding.showPrimary && binding.showSecondary) {
             sbAppend.append(", ");
         }
-        if (lockWidgetOptions.showsWeekly()) {
-            sbAppend.append("weekly ").append(value(i2)).append(" remaining");
+        if (binding.showSecondary) {
+            String label = binding.secondary == null ? "secondary" : binding.secondary.label;
+            sbAppend.append(label).append(' ').append(value(binding.secondaryRemaining))
+                    .append(" remaining");
         }
         if (lockWidgetOptions.showCountdown) {
             sbAppend.append(", live reset countdown");

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java
@@ -122,6 +122,7 @@ public final class SettingsTransfer {
         json.put("reset_mode", safe.resetMode);
         json.put("display_mode", safe.displayMode);
         json.put("metric_mode", safe.metricMode);
+        json.put("visible_meters", safe.visibleMeters);
         json.put("show_title", safe.showTitle);
         json.put("show_plan", safe.showPlan);
         json.put("show_updated", safe.showUpdated);
@@ -163,7 +164,8 @@ public final class SettingsTransfer {
                 booleanOr(json, "show_reset_credits", fallback.showResetCredits),
                 booleanOr(json, "show_reset_action", fallback.showResetAction));
         return options.withPercentSymbol(
-                booleanOr(json, "show_percent_symbol", fallback.showPercentSymbol));
+                booleanOr(json, "show_percent_symbol", fallback.showPercentSymbol))
+                .withVisibleMeters(stringOr(json, "visible_meters", fallback.visibleMeters));
     }
 
     public static JSONArray leadTimesToJson(List<Long> leadTimes) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
@@ -25,6 +25,9 @@ import dev.oneuiproject.oneui.widget.CardItemView;
 import dev.oneuiproject.oneui.widget.RadioItemView;
 import dev.oneuiproject.oneui.widget.RadioItemViewGroup;
 import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 public final class WidgetConfigActivity extends AppCompatActivity {
     private Spinner accentSpinner;
@@ -33,8 +36,8 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     private boolean dark;
     private Spinner displaySpinner;
     private CardItemView displayRow;
-    private Spinner metricSpinner;
-    private CardItemView metricRow;
+    private Spinner styleSpinner;
+    private CardItemView styleRow;
     private SeslSeekBar opacitySlider;
     private SwitchCompat backgroundSwitch;
     private SwitchCompat percentSymbolSwitch;
@@ -44,6 +47,8 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     private Bundle widgetSize = new Bundle();
     private Spinner themeSpinner;
     private CardItemView themeRow;
+    private TextView metersHint;
+    private final LinkedHashSet<String> selectedMeters = new LinkedHashSet<>();
     private String tapAction = WidgetOptions.TAP_OPEN_APP;
     private final int tapOpenId = View.generateViewId();
     private final int tapRefreshId = View.generateViewId();
@@ -86,6 +91,8 @@ public final class WidgetConfigActivity extends AppCompatActivity {
 
         WidgetOptions saved = AppPreferences.loadWidgetOptions(this, this.appWidgetId);
         this.tapAction = AppPreferences.getWidgetTapAction(this, this.appWidgetId);
+        this.selectedMeters.clear();
+        this.selectedMeters.addAll(WidgetMeters.parse(saved.effectiveVisibleMeters()));
 
         content.addView(Ui.separator(this, "Appearance"));
         RoundedLinearLayout appearanceCard = Ui.seslRowCard(this, this.dark);
@@ -114,28 +121,60 @@ public final class WidgetConfigActivity extends AppCompatActivity {
 
         this.themeSpinner = Ui.spinner(this, WidgetOptionCatalog.THEME_LABELS, this.dark);
         this.accentSpinner = Ui.spinner(this, WidgetOptionCatalog.ACCENT_LABELS, this.dark);
+        this.styleSpinner = Ui.spinner(this, WidgetOptionCatalog.STYLE_LABELS, this.dark);
         WidgetOptionCatalog.selectString(this.themeSpinner, WidgetOptionCatalog.THEME_VALUES,
                 saved.theme);
         WidgetOptionCatalog.selectString(this.accentSpinner, WidgetOptionCatalog.ACCENT_VALUES,
                 saved.accent);
+        WidgetOptionCatalog.selectString(this.styleSpinner, WidgetOptionCatalog.STYLE_VALUES,
+                saved.layoutPreference());
+        this.styleRow = addOptionRow(appearanceCard, "Layout", this.styleSpinner,
+                WidgetOptionCatalog.STYLE_LABELS, true);
         this.themeRow = addOptionRow(appearanceCard, "Theme", this.themeSpinner,
                 WidgetOptionCatalog.THEME_LABELS, true);
         this.accentRow = addOptionRow(appearanceCard, "Accent", this.accentSpinner,
                 WidgetOptionCatalog.ACCENT_LABELS, true);
         content.addView(appearanceCard);
 
+        content.addView(Ui.separator(this, "Meters"));
+        RoundedLinearLayout metersCard = Ui.seslRowCard(this, this.dark);
+        this.metersHint = Ui.text(this, "", 13, Ui.secondaryText(this.dark));
+        this.metersHint.setPadding(Ui.dp(this, 20), Ui.dp(this, 12), Ui.dp(this, 20),
+                Ui.dp(this, 4));
+        metersCard.addView(this.metersHint);
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
+        List<String> available = WidgetMeters.availableKeys(snapshot);
+        boolean firstMeter = true;
+        for (String key : available) {
+            SwitchCompat toggle = new SwitchCompat(this);
+            toggle.setChecked(this.selectedMeters.contains(key));
+            String label = WidgetMeters.configLabel(key, snapshot);
+            metersCard.addView(buildSwitchRow(label, toggle, !firstMeter));
+            firstMeter = false;
+            toggle.setOnCheckedChangeListener((button, checked) -> {
+                if (checked) {
+                    this.selectedMeters.add(key);
+                } else {
+                    this.selectedMeters.remove(key);
+                    if (this.selectedMeters.isEmpty()) {
+                        this.selectedMeters.add(key);
+                        button.setChecked(true);
+                        return;
+                    }
+                }
+                updateMetersHint();
+                renderPreview();
+            });
+        }
+        content.addView(metersCard);
+
         content.addView(Ui.separator(this, "Content"));
         RoundedLinearLayout contentCard = Ui.seslRowCard(this, this.dark);
-        this.metricSpinner = Ui.spinner(this, WidgetOptionCatalog.METRIC_LABELS, this.dark);
-        WidgetOptionCatalog.selectString(this.metricSpinner, WidgetOptionCatalog.METRIC_VALUES,
-                saved.metricMode);
-        this.metricRow = addOptionRow(contentCard, "Allowance", this.metricSpinner,
-                WidgetOptionCatalog.METRIC_LABELS, false);
         this.displaySpinner = Ui.spinner(this, WidgetOptionCatalog.DISPLAY_LABELS, this.dark);
         WidgetOptionCatalog.selectString(this.displaySpinner, WidgetOptionCatalog.DISPLAY_VALUES,
                 saved.displayMode);
         this.displayRow = addOptionRow(contentCard, "Percentage", this.displaySpinner,
-                WidgetOptionCatalog.DISPLAY_LABELS, true);
+                WidgetOptionCatalog.DISPLAY_LABELS, false);
         View symbolDivider = new View(this);
         symbolDivider.setBackgroundColor(Ui.divider(this.dark));
         LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(-1, Ui.dp(this, 1));
@@ -153,6 +192,7 @@ public final class WidgetConfigActivity extends AppCompatActivity {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 updateRowSummaries();
+                updateMetersHint();
                 renderPreview();
             }
 
@@ -160,10 +200,10 @@ public final class WidgetConfigActivity extends AppCompatActivity {
             public void onNothingSelected(AdapterView<?> parent) {
             }
         };
+        this.styleSpinner.setOnItemSelectedListener(selectionListener);
         this.themeSpinner.setOnItemSelectedListener(selectionListener);
         this.accentSpinner.setOnItemSelectedListener(selectionListener);
         this.displaySpinner.setOnItemSelectedListener(selectionListener);
-        this.metricSpinner.setOnItemSelectedListener(selectionListener);
         this.percentSymbolSwitch.setOnCheckedChangeListener((button, checked) -> renderPreview());
         this.backgroundSwitch.setOnCheckedChangeListener((button, checked) -> {
             applyBackgroundEnabled(checked);
@@ -189,6 +229,7 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         page.save.setOnClickListener(view -> save());
         updateSliderVisuals();
         updateRowSummaries();
+        updateMetersHint();
         renderPreview();
     }
 
@@ -285,6 +326,7 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     private void applyPreviewSelection(Spinner spinner, int position) {
         spinner.setSelection(position);
         updateRowSummaries();
+        updateMetersHint();
         renderPreview();
     }
 
@@ -295,7 +337,9 @@ public final class WidgetConfigActivity extends AppCompatActivity {
                         WidgetOptionCatalog.OPACITY_VALUES.length - 1,
                         this.opacitySlider.getProgress()))]
                 : 0;
-        return new WidgetOptions(WidgetOptions.STYLE_RINGS,
+        String layout = WidgetOptionCatalog.STYLE_VALUES[
+                Math.max(0, this.styleSpinner.getSelectedItemPosition())];
+        return new WidgetOptions(layout,
                 WidgetOptions.DENSITY_AUTO,
                 WidgetOptions.SURFACE_ONE_UI, WidgetOptions.GRAPHIC_AUTO,
                 WidgetOptionCatalog.THEME_VALUES[this.themeSpinner.getSelectedItemPosition()],
@@ -303,15 +347,20 @@ public final class WidgetConfigActivity extends AppCompatActivity {
                 opacity,
                 WidgetOptions.RESET_HIDDEN,
                 WidgetOptionCatalog.DISPLAY_VALUES[this.displaySpinner.getSelectedItemPosition()],
-                WidgetOptionCatalog.METRIC_VALUES[this.metricSpinner.getSelectedItemPosition()],
+                WidgetOptions.METRIC_BOTH,
                 false, false, false, false, false, false)
                 .withPercentSymbol(this.percentSymbolSwitch == null
-                        || this.percentSymbolSwitch.isChecked());
+                        || this.percentSymbolSwitch.isChecked())
+                .withVisibleMeters(WidgetMeters.serialize(new ArrayList<>(this.selectedMeters)));
     }
 
     private void updateRowSummaries() {
         if (this.themeRow == null) {
             return;
+        }
+        if (this.styleRow != null) {
+            this.styleRow.setSummary(WidgetOptionCatalog.STYLE_LABELS[
+                    this.styleSpinner.getSelectedItemPosition()]);
         }
         this.themeRow.setSummary(WidgetOptionCatalog.THEME_LABELS[
                 this.themeSpinner.getSelectedItemPosition()]);
@@ -319,8 +368,29 @@ public final class WidgetConfigActivity extends AppCompatActivity {
                 this.accentSpinner.getSelectedItemPosition()]);
         this.displayRow.setSummary(WidgetOptionCatalog.DISPLAY_LABELS[
                 this.displaySpinner.getSelectedItemPosition()]);
-        this.metricRow.setSummary(WidgetOptionCatalog.METRIC_LABELS[
-                this.metricSpinner.getSelectedItemPosition()]);
+    }
+
+    private void updateMetersHint() {
+        if (this.metersHint == null) {
+            return;
+        }
+        WidgetOptions options = currentOptions();
+        int height = positiveOption("appWidgetMinHeight", "appWidgetMaxHeight", 70);
+        int width = positiveOption("appWidgetMinWidth", "appWidgetMaxWidth", 110);
+        int rows = this.widgetSize.getInt("semAppWidgetRowSpan", 0);
+        int columns = this.widgetSize.getInt("semAppWidgetColumnSpan", 0);
+        String visual = WidgetMeters.resolveHomeVisualStyle(options.layoutPreference(),
+                options.singleMetric(), rows, columns, height, width);
+        int capacity = WidgetMeters.slotCapacity(visual, height);
+        int selected = this.selectedMeters.size();
+        String message = "This size shows up to " + capacity + " meter"
+                + (capacity == 1 ? "" : "s") + ".";
+        if (selected > capacity) {
+            message += " " + (selected - capacity) + " extra selection"
+                    + (selected - capacity == 1 ? " is" : "s are")
+                    + " saved and appear when the widget is larger.";
+        }
+        this.metersHint.setText(message);
     }
 
     private void renderPreview() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetGraphics.java
@@ -86,6 +86,12 @@ public final class WidgetGraphics {
     }
 
     public static Bitmap dial(int i, int i2, int i3, int i4, String str, float f) {
+        return dial(i, i2, i3, i4, i < 0 ? "—" : clamp(i) + "%", str, f);
+    }
+
+    /** Gauge dial with an explicit center value (countdowns, credit counts, plain percents). */
+    public static Bitmap dial(int i, int i2, int i3, int i4, String centerText, String str,
+            float f) {
         float fClampScale = clampScale(f);
         int iRound = Math.round(260.0f * fClampScale);
         Bitmap bitmapCreateBitmap = Bitmap.createBitmap(iRound, Math.round(190.0f * fClampScale), Bitmap.Config.ARGB_8888);
@@ -115,8 +121,12 @@ public final class WidgetGraphics {
         paint.setTextAlign(Paint.Align.CENTER);
         paint.setTypeface(Typeface.create("sans-serif", 1));
         paint.setColor(i4);
-        paint.setTextSize(48.0f * fClampScale);
-        canvas.drawText(i < 0 ? "—" : clamp(i) + "%", iRound / 2.0f, 130.0f * fClampScale, paint);
+        String center = centerText == null || centerText.isEmpty() ? "—" : centerText;
+        // Percent values fit at full size; longer countdown strings scale down to stay inside.
+        float centerSize = center.length() <= 4
+                ? 48.0f : Math.max(24.0f, 48.0f * (4.5f / center.length()));
+        paint.setTextSize(centerSize * fClampScale);
+        canvas.drawText(center, iRound / 2.0f, 130.0f * fClampScale, paint);
         paint.setTypeface(Typeface.create("sans-serif-medium", 0));
         paint.setTextSize(19.0f * fClampScale);
         paint.setColor(withAlpha(i4, 0.68f));

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java
@@ -8,8 +8,9 @@ final class WidgetOptionCatalog {
     static final String[] THEME_VALUES = {WidgetOptions.THEME_SYSTEM, WidgetOptions.THEME_DARK, WidgetOptions.THEME_LIGHT};
     static final String[] SURFACE_LABELS = {"One UI"};
     static final String[] SURFACE_VALUES = {WidgetOptions.SURFACE_ONE_UI};
-    static final String[] STYLE_LABELS = {"Two usage dials"};
-    static final String[] STYLE_VALUES = {WidgetOptions.STYLE_RINGS};
+    static final String[] STYLE_LABELS = {"Adaptive by size", "Dials", "Progress bars"};
+    static final String[] STYLE_VALUES = {WidgetOptions.STYLE_AUTO, WidgetOptions.STYLE_DIALS,
+            WidgetOptions.STYLE_BARS};
     static final String[] DENSITY_LABELS = {"Auto", "Compact", "Comfortable"};
     static final String[] DENSITY_VALUES = {"auto", "compact", WidgetOptions.DENSITY_COMFORTABLE};
     static final String[] GRAPHIC_LABELS = {"Fit automatically", "Large", "Maximum"};

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java
@@ -62,6 +62,8 @@ public final class WidgetOptions {
     public final boolean showPercentSymbol;
     public final String surfaceStyle;
     public final String theme;
+    /** Ordered CSV of {@link WidgetMeters} keys; empty means migrate from {@link #metricMode}. */
+    public final String visibleMeters;
 
     public WidgetOptions(String str, String str2, String str3, int i, String str4, String str5) {
         this(str, "auto", SURFACE_MATERIAL, "auto", str2, str3, i, str4, str5, "both", false, true, true, true, false, false);
@@ -81,12 +83,20 @@ public final class WidgetOptions {
 
     public WidgetOptions(String str, String str2, String str3, String str4, String str5, String str6, int i, String str7, String str8, String str9, boolean z, boolean z2, boolean z3, boolean z4, boolean z5, boolean z6) {
         this(str, str2, str3, str4, str5, str6, i, str7, str8, str9, z, z2, z3,
-                z4, z5, z6, true);
+                z4, z5, z6, true, "");
     }
 
     private WidgetOptions(String str, String str2, String str3, String str4, String str5,
             String str6, int i, String str7, String str8, String str9, boolean z, boolean z2,
             boolean z3, boolean z4, boolean z5, boolean z6, boolean showPercentSymbol) {
+        this(str, str2, str3, str4, str5, str6, i, str7, str8, str9, z, z2, z3, z4, z5, z6,
+                showPercentSymbol, "");
+    }
+
+    private WidgetOptions(String str, String str2, String str3, String str4, String str5,
+            String str6, int i, String str7, String str8, String str9, boolean z, boolean z2,
+            boolean z3, boolean z4, boolean z5, boolean z6, boolean showPercentSymbol,
+            String visibleMeters) {
         this.layout = normalizeStyle(str);
         this.density = oneOf(str2, "auto", "compact", DENSITY_COMFORTABLE) ? str2 : "auto";
         this.surfaceStyle = oneOf(str3, SURFACE_MATERIAL, SURFACE_ONE_UI) ? str3 : SURFACE_MATERIAL;
@@ -112,6 +122,7 @@ public final class WidgetOptions {
         this.showResetCredits = z5;
         this.showResetAction = z6;
         this.showPercentSymbol = showPercentSymbol;
+        this.visibleMeters = visibleMeters == null ? "" : visibleMeters.trim();
     }
 
     public WidgetOptions withPercentSymbol(boolean show) {
@@ -119,11 +130,23 @@ public final class WidgetOptions {
                 this.graphicScale, this.theme, this.accent, this.opacity, this.resetMode,
                 this.displayMode, this.metricMode, this.showTitle, this.showPlan,
                 this.showUpdated, this.showRefresh, this.showResetCredits,
-                this.showResetAction, show);
+                this.showResetAction, show, this.visibleMeters);
+    }
+
+    public WidgetOptions withVisibleMeters(String metersCsv) {
+        return new WidgetOptions(this.layout, this.density, this.surfaceStyle,
+                this.graphicScale, this.theme, this.accent, this.opacity, this.resetMode,
+                this.displayMode, this.metricMode, this.showTitle, this.showPlan,
+                this.showUpdated, this.showRefresh, this.showResetCredits,
+                this.showResetAction, this.showPercentSymbol,
+                metersCsv == null ? "" : metersCsv);
     }
 
     public static WidgetOptions defaults() {
-        return new WidgetOptions(STYLE_RINGS, "auto", SURFACE_ONE_UI, "auto", THEME_SYSTEM, ACCENT_BLUE, DEFAULT_OPACITY, RESET_HIDDEN, DISPLAY_REMAINING, "both", false, false, false, false, false, false);
+        return new WidgetOptions(STYLE_AUTO, "auto", SURFACE_ONE_UI, "auto", THEME_SYSTEM,
+                ACCENT_BLUE, DEFAULT_OPACITY, RESET_HIDDEN, DISPLAY_REMAINING, "both",
+                false, false, false, false, false, false)
+                .withVisibleMeters(WidgetMeters.serialize(WidgetMeters.defaultVisible()));
     }
 
     /** Nearest allowed opacity when background is on; {@code 0} stays fully off. */
@@ -155,16 +178,28 @@ public final class WidgetOptions {
         return 1;
     }
 
+    /** Effective auto / dials / bars preference used by the renderer. */
+    public String layoutPreference() {
+        return WidgetMeters.layoutPreference(this.layout);
+    }
+
+    /** Resolved visible-meters CSV, migrating from metric_mode when unset. */
+    public String effectiveVisibleMeters() {
+        return WidgetMeters.effectiveVisibleCsv(this.visibleMeters, this.metricMode);
+    }
+
     public boolean showsFiveHour() {
-        return !"weekly".equals(this.metricMode);
+        return WidgetMeters.contains(
+                WidgetMeters.parse(effectiveVisibleMeters()), WidgetMeters.FIVE_HOUR);
     }
 
     public boolean showsWeekly() {
-        return !"five_hour".equals(this.metricMode);
+        return WidgetMeters.contains(
+                WidgetMeters.parse(effectiveVisibleMeters()), WidgetMeters.WEEKLY);
     }
 
     public boolean singleMetric() {
-        return !"both".equals(this.metricMode);
+        return WidgetMeters.singleUsageMetric(WidgetMeters.parse(effectiveVisibleMeters()));
     }
 
     public static String normalizeStyle(String str) {
@@ -174,7 +209,10 @@ public final class WidgetOptions {
         if ("compact".equals(str)) {
             return STYLE_MINIMAL;
         }
-        return !oneOf(str, "auto", STYLE_BARS, STYLE_RINGS, STYLE_DIALS, STYLE_MINIMAL) ? "auto" : str;
+        // Keep rings/minimal as stored values for transfer round-trips; layoutPreference()
+        // maps them to adaptive auto at render time.
+        return !oneOf(str, "auto", STYLE_BARS, STYLE_RINGS, STYLE_DIALS, STYLE_MINIMAL)
+                ? "auto" : str;
     }
 
     public static String normalizeTapAction(String value) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -176,7 +176,8 @@ public final class WidgetRenderer {
         boolean zChooseDark = chooseDark(context, widgetOptionsDefaults);
         WidgetState widgetStateError = WidgetState.error("Open Codex Meter to recover");
         applyRootAndHeader(context, remoteViews, i, widgetOptionsDefaults, zChooseDark, widgetStateError);
-        renderMinimal(context, remoteViews, widgetOptionsDefaults, zChooseDark, widgetStateError);
+        renderMinimal(context, remoteViews, widgetOptionsDefaults, zChooseDark, widgetStateError,
+                java.util.Collections.emptyList());
         return remoteViews;
     }
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -477,9 +477,13 @@ public final class WidgetRenderer {
             remoteViews.setInt(R.id.secondary_samsung_icon, "setColorFilter", iMainTextColor);
         } else {
             remoteViews.setImageViewBitmap(R.id.primary_graphic,
-                    WidgetGraphics.dial(primaryProgress, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
+                    WidgetGraphics.dial(primaryProgress, iAccentColor, iTrackColor, iMainTextColor,
+                            primary == null ? "—" : primary.valueText,
+                            primary == null || primary.usage ? str : primary.label, fMin));
             remoteViews.setImageViewBitmap(R.id.secondary_graphic,
-                    WidgetGraphics.dial(secondaryProgress, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
+                    WidgetGraphics.dial(secondaryProgress, iAccentColor, iTrackColor, iMainTextColor,
+                            secondary == null ? "—" : secondary.valueText,
+                            secondary == null || secondary.usage ? str : secondary.label, fMin));
         }
         remoteViews.setTextColor(R.id.primary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.secondary_label, iSecondaryColor);
@@ -630,7 +634,8 @@ public final class WidgetRenderer {
         int capacity = WidgetMeters.slotCapacity(visualStyle, height);
         List<String> available = WidgetMeters.availableKeys(snapshot);
         List<String> visible = WidgetMeters.cap(
-                WidgetMeters.resolveVisible(options.effectiveVisibleMeters(), available),
+                WidgetMeters.resolveVisibleOrDefault(options.effectiveVisibleMeters(),
+                        available, options.metricMode),
                 capacity);
         ResetCreditsSnapshot credits = AppPreferences.loadResetCredits(context);
         int resetCount = credits == null ? 0 : credits.availableCount;
@@ -659,13 +664,13 @@ public final class WidgetRenderer {
         }
         if (WidgetMeters.NEXT_RESET.equals(key)) {
             return new MeterSlot(key, "Reset", R.drawable.ic_oui_alarm, state.nextResetProgress,
-                    state.nextResetText, state.nextResetText, 100);
+                    state.nextResetText, state.nextResetText, 100, false);
         }
         if (WidgetMeters.RESET_CREDITS.equals(key)) {
             int progress = Math.min(100, Math.round((Math.min(4, resetCount) / 4.0f) * 100));
             String text = String.valueOf(resetCount);
             return new MeterSlot(key, "Credits", R.drawable.ic_oui_refresh, progress, text, text,
-                    Math.max(4, resetCount));
+                    Math.max(4, resetCount), false);
         }
         UsageLimit limit = WidgetMeters.findLimit(key, snapshot);
         if (limit != null) {
@@ -682,7 +687,7 @@ public final class WidgetRenderer {
 
     private static MeterSlot usageSlot(String key, String label, int icon, int progress,
             String valueText, String shortText) {
-        return new MeterSlot(key, label, icon, progress, valueText, shortText, 100);
+        return new MeterSlot(key, label, icon, progress, valueText, shortText, 100, true);
     }
 
     private static final class MeterSlot {
@@ -693,9 +698,11 @@ public final class WidgetRenderer {
         final String valueText;
         final String shortText;
         final int progressMax;
+        /** True for percent-based usage windows; false for countdown/credit helpers. */
+        final boolean usage;
 
         MeterSlot(String key, String label, int iconRes, int progress, String valueText,
-                String shortText, int progressMax) {
+                String shortText, int progressMax, boolean usage) {
             this.key = key;
             this.label = label;
             this.iconRes = iconRes;
@@ -703,6 +710,7 @@ public final class WidgetRenderer {
             this.valueText = valueText;
             this.shortText = shortText;
             this.progressMax = progressMax;
+            this.usage = usage;
         }
     }
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -15,7 +15,9 @@ import android.util.Log;
 import android.util.SizeF;
 import android.view.View;
 import android.widget.RemoteViews;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /* JADX INFO: loaded from: classes.dex */
@@ -23,8 +25,8 @@ public final class WidgetRenderer {
     private static final int GRAPHIC_LARGE = 1;
     private static final int GRAPHIC_MAX = 2;
     private static final int GRAPHIC_STANDARD = 0;
-    private static final String STYLE_BATTERY_LIST = "battery_list";
-    private static final String STYLE_FOUR_DIALS = "four_dials";
+    private static final String STYLE_BATTERY_LIST = WidgetMeters.VISUAL_BATTERY_LIST;
+    private static final String STYLE_FOUR_DIALS = WidgetMeters.VISUAL_FOUR_DIALS;
     private static final String STYLE_MICRO = "micro";
 
     private WidgetRenderer() {
@@ -76,15 +78,17 @@ public final class WidgetRenderer {
     @SuppressLint({"NewApi", "UseRequiresApi"})
     private static RemoteViews buildResponsiveWidget(Context context, int i, WidgetOptions widgetOptions) {
         LinkedHashMap<SizeF, RemoteViews> linkedHashMap = new LinkedHashMap<>();
-        String compactStyle = WidgetOptions.STYLE_RINGS;
-        String tallStyle = widgetOptions.singleMetric()
-                ? WidgetOptions.STYLE_DIALS : STYLE_BATTERY_LIST;
+        boolean single = widgetOptions.singleMetric();
+        String compactStyle = preferVisualStyle(widgetOptions, WidgetMeters.VISUAL_RINGS);
+        String wideShortStyle = preferVisualStyle(widgetOptions,
+                single ? WidgetMeters.VISUAL_RINGS : WidgetMeters.VISUAL_FOUR_DIALS);
+        String tallStyle = preferVisualStyle(widgetOptions,
+                single ? WidgetMeters.VISUAL_DIALS : WidgetMeters.VISUAL_BATTERY_LIST);
         linkedHashMap.put(new SizeF(110.0f, 60.0f),
                 buildViews(context, i, widgetOptions, compactStyle,
                         sizeBundle(110, 70), GRAPHIC_STANDARD));
         linkedHashMap.put(new SizeF(250.0f, 60.0f),
-                buildViews(context, i, widgetOptions,
-                        widgetOptions.singleMetric() ? compactStyle : STYLE_FOUR_DIALS,
+                buildViews(context, i, widgetOptions, wideShortStyle,
                         sizeBundle(250, 70), GRAPHIC_STANDARD));
         linkedHashMap.put(new SizeF(110.0f, 130.0f),
                 buildViews(context, i, widgetOptions, tallStyle,
@@ -92,7 +96,7 @@ public final class WidgetRenderer {
         linkedHashMap.put(new SizeF(250.0f, 130.0f),
                 buildViews(context, i, widgetOptions, tallStyle,
                         sizeBundle(250, 156),
-                        widgetOptions.singleMetric() ? GRAPHIC_LARGE : GRAPHIC_STANDARD));
+                        single ? GRAPHIC_LARGE : GRAPHIC_STANDARD));
         return new RemoteViews(linkedHashMap);
     }
 
@@ -107,23 +111,26 @@ public final class WidgetRenderer {
     private static String styleForSize(Context context, Bundle bundle, WidgetOptions options) {
         int rows = option(bundle, "semAppWidgetRowSpan");
         int columns = option(bundle, "semAppWidgetColumnSpan");
-        if (options != null && options.singleMetric()) {
-            if (rows >= 2 || currentHeight(context, bundle) >= 130) {
-                return WidgetOptions.STYLE_DIALS;
-            }
-            return WidgetOptions.STYLE_RINGS;
+        boolean single = options != null && options.singleMetric();
+        return WidgetMeters.resolveHomeVisualStyle(
+                options == null ? WidgetMeters.PREF_AUTO : options.layoutPreference(),
+                single, rows, columns, currentHeight(context, bundle),
+                currentWidth(context, bundle));
+    }
+
+    /** Applies Auto / Dials / Bars preference on top of a size-derived auto bucket style. */
+    private static String preferVisualStyle(WidgetOptions options, String autoBucketStyle) {
+        String preference = options == null
+                ? WidgetMeters.PREF_AUTO : options.layoutPreference();
+        if (WidgetMeters.PREF_BARS.equals(preference)) {
+            return WidgetMeters.VISUAL_BATTERY_LIST;
         }
-        if (rows > 0) {
-            if (rows >= 2) {
-                return STYLE_BATTERY_LIST;
-            }
-            return columns >= 3 ? STYLE_FOUR_DIALS : WidgetOptions.STYLE_RINGS;
+        if (WidgetMeters.PREF_DIALS.equals(preference)
+                && WidgetMeters.VISUAL_BATTERY_LIST.equals(autoBucketStyle)) {
+            return options.singleMetric()
+                    ? WidgetMeters.VISUAL_DIALS : WidgetMeters.VISUAL_FOUR_DIALS;
         }
-        if (currentHeight(context, bundle) >= 130) {
-            return STYLE_BATTERY_LIST;
-        }
-        return currentWidth(context, bundle) >= 240
-                ? STYLE_FOUR_DIALS : WidgetOptions.STYLE_RINGS;
+        return autoBucketStyle;
     }
 
     private static Bundle sizeBundle(int i, int i2) {
@@ -141,23 +148,24 @@ public final class WidgetRenderer {
         RemoteViews remoteViews = new RemoteViews(context.getPackageName(), layoutForStyle(str, i2));
         boolean zChooseDark = chooseDark(context, widgetOptions);
         WidgetState widgetStateFrom = WidgetState.from(context, widgetOptions);
+        List<MeterSlot> slots = resolveSlots(context, widgetOptions, widgetStateFrom, str, bundle);
         applyRootAndHeader(context, remoteViews, i, widgetOptions, zChooseDark, widgetStateFrom);
         if (STYLE_MICRO.equals(str)) {
-            renderMicro(remoteViews, widgetOptions, zChooseDark, widgetStateFrom);
+            renderMicro(remoteViews, widgetOptions, zChooseDark, widgetStateFrom, slots);
         } else if (WidgetOptions.STYLE_RINGS.equals(str)) {
-            renderGraphic(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom, true, i2);
+            renderGraphic(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom, true, i2, slots);
         } else if (STYLE_FOUR_DIALS.equals(str)) {
-            renderFourDials(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom);
+            renderFourDials(context, remoteViews, widgetOptions, zChooseDark, slots);
         } else if (STYLE_BATTERY_LIST.equals(str)) {
-            renderBatteryList(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom);
+            renderBatteryList(context, remoteViews, widgetOptions, zChooseDark, slots);
         } else if (WidgetOptions.STYLE_DIALS.equals(str)) {
-            renderGraphic(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom, false, i2);
+            renderGraphic(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom, false, i2, slots);
         } else if (WidgetOptions.STYLE_MINIMAL.equals(str)) {
-            renderMinimal(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom);
+            renderMinimal(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom, slots);
         } else {
-            renderBars(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom, bundle);
+            renderBars(context, remoteViews, widgetOptions, zChooseDark, widgetStateFrom, bundle, slots);
         }
-        applyMetricVisibility(remoteViews, widgetOptions);
+        applySlotVisibility(remoteViews, str, slots);
         applyResetCreditRow(context, remoteViews, i, widgetOptions, zChooseDark, str);
         return remoteViews;
     }
@@ -307,7 +315,7 @@ public final class WidgetRenderer {
                 + appWidgetId + "/" + action);
     }
 
-    private static void renderBars(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState, Bundle bundle) {
+    private static void renderBars(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState, Bundle bundle, List<MeterSlot> slots) {
         boolean z2 = false;
         int iMainTextColor = WidgetGraphics.mainTextColor(z);
         int iSecondaryColor = secondaryColor(z);
@@ -327,12 +335,16 @@ public final class WidgetRenderer {
         remoteViews.setImageViewResource(R.id.secondary_progress, iProgressResource);
         applyAppAccentFilter(context, remoteViews, widgetOptions.accent,
                 R.id.primary_progress, R.id.secondary_progress);
-        remoteViews.setInt(R.id.primary_progress, "setImageLevel", Math.max(GRAPHIC_STANDARD, widgetState.primaryValue) * 100);
-        remoteViews.setInt(R.id.secondary_progress, "setImageLevel", Math.max(GRAPHIC_STANDARD, widgetState.secondaryValue) * 100);
-        remoteViews.setTextViewText(R.id.primary_label, "5-hour");
-        remoteViews.setTextViewText(R.id.secondary_label, "Weekly");
-        remoteViews.setTextViewText(R.id.primary_percent, widgetState.primaryText);
-        remoteViews.setTextViewText(R.id.secondary_percent, widgetState.secondaryText);
+        MeterSlot primary = slotAt(slots, 0);
+        MeterSlot secondary = slotAt(slots, 1);
+        remoteViews.setInt(R.id.primary_progress, "setImageLevel",
+                Math.max(GRAPHIC_STANDARD, primary == null ? 0 : primary.progress) * 100);
+        remoteViews.setInt(R.id.secondary_progress, "setImageLevel",
+                Math.max(GRAPHIC_STANDARD, secondary == null ? 0 : secondary.progress) * 100);
+        remoteViews.setTextViewText(R.id.primary_label, primary == null ? "" : primary.label);
+        remoteViews.setTextViewText(R.id.secondary_label, secondary == null ? "" : secondary.label);
+        remoteViews.setTextViewText(R.id.primary_percent, primary == null ? "—" : primary.valueText);
+        remoteViews.setTextViewText(R.id.secondary_percent, secondary == null ? "—" : secondary.valueText);
         remoteViews.setTextViewText(R.id.primary_reset, widgetState.primaryReset);
         remoteViews.setTextViewText(R.id.secondary_reset, widgetState.secondaryReset);
         remoteViews.setViewVisibility(R.id.primary_reset, widgetState.primaryReset.isEmpty() ? 8 : GRAPHIC_STANDARD);
@@ -355,29 +367,34 @@ public final class WidgetRenderer {
         }
     }
 
-    private static void renderMicro(RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState) {
+    private static void renderMicro(RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z,
+            WidgetState widgetState, List<MeterSlot> slots) {
         int iMainTextColor = WidgetGraphics.mainTextColor(z);
         int iSecondaryColor = secondaryColor(z);
+        MeterSlot primary = slotAt(slots, 0);
+        MeterSlot secondary = slotAt(slots, 1);
         remoteViews.setTextColor(R.id.primary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.secondary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.primary_percent, iMainTextColor);
         remoteViews.setTextColor(R.id.secondary_percent, iMainTextColor);
-        remoteViews.setTextViewText(R.id.primary_label, "5h");
-        remoteViews.setTextViewText(R.id.secondary_label, "Wk");
-        remoteViews.setTextViewText(R.id.primary_percent, widgetState.primaryShort);
-        remoteViews.setTextViewText(R.id.secondary_percent, widgetState.secondaryShort);
+        remoteViews.setTextViewText(R.id.primary_label, primary == null ? "" : primary.label);
+        remoteViews.setTextViewText(R.id.secondary_label, secondary == null ? "" : secondary.label);
+        remoteViews.setTextViewText(R.id.primary_percent, primary == null ? "—" : primary.shortText);
+        remoteViews.setTextViewText(R.id.secondary_percent, secondary == null ? "—" : secondary.shortText);
         remoteViews.setViewVisibility(R.id.primary_reset, 8);
         remoteViews.setViewVisibility(R.id.secondary_reset, 8);
         remoteViews.setViewVisibility(R.id.updated_label, 8);
     }
 
-    private static void renderMinimal(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState) {
+    private static void renderMinimal(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState, List<MeterSlot> slots) {
         String str;
         int i = R.drawable.progress_track_light;
         int iMainTextColor = WidgetGraphics.mainTextColor(z);
         int iSecondaryColor = secondaryColor(z);
         int iMutedColor = mutedColor(z);
         int iFaintColor = faintColor(z);
+        MeterSlot primary = slotAt(slots, 0);
+        MeterSlot secondary = slotAt(slots, 1);
         remoteViews.setTextColor(R.id.primary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.secondary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.primary_percent, iMainTextColor);
@@ -394,12 +411,14 @@ public final class WidgetRenderer {
         remoteViews.setImageViewResource(R.id.secondary_progress, iProgressResource);
         applyAppAccentFilter(context, remoteViews, widgetOptions.accent,
                 R.id.primary_progress, R.id.secondary_progress);
-        remoteViews.setInt(R.id.primary_progress, "setImageLevel", Math.max(GRAPHIC_STANDARD, widgetState.primaryValue) * 100);
-        remoteViews.setInt(R.id.secondary_progress, "setImageLevel", Math.max(GRAPHIC_STANDARD, widgetState.secondaryValue) * 100);
-        remoteViews.setTextViewText(R.id.primary_label, "5h");
-        remoteViews.setTextViewText(R.id.secondary_label, "Week");
-        remoteViews.setTextViewText(R.id.primary_percent, widgetState.primaryShort);
-        remoteViews.setTextViewText(R.id.secondary_percent, widgetState.secondaryShort);
+        remoteViews.setInt(R.id.primary_progress, "setImageLevel",
+                Math.max(GRAPHIC_STANDARD, primary == null ? 0 : primary.progress) * 100);
+        remoteViews.setInt(R.id.secondary_progress, "setImageLevel",
+                Math.max(GRAPHIC_STANDARD, secondary == null ? 0 : secondary.progress) * 100);
+        remoteViews.setTextViewText(R.id.primary_label, primary == null ? "" : primary.label);
+        remoteViews.setTextViewText(R.id.secondary_label, secondary == null ? "" : secondary.label);
+        remoteViews.setTextViewText(R.id.primary_percent, primary == null ? "—" : primary.shortText);
+        remoteViews.setTextViewText(R.id.secondary_percent, secondary == null ? "—" : secondary.shortText);
         if ("five_hour".equals(widgetOptions.metricMode)) {
             str = widgetState.primaryShortReset.isEmpty() ? "" : "5h " + widgetState.primaryShortReset;
         } else if ("weekly".equals(widgetOptions.metricMode)) {
@@ -413,7 +432,7 @@ public final class WidgetRenderer {
         applyUpdated(remoteViews, widgetOptions, widgetState, iFaintColor);
     }
 
-    private static void renderGraphic(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState, boolean z2, int i) {
+    private static void renderGraphic(Context context, RemoteViews remoteViews, WidgetOptions widgetOptions, boolean z, WidgetState widgetState, boolean z2, int i, List<MeterSlot> slots) {
         float f;
         int iMainTextColor = WidgetGraphics.mainTextColor(z);
         int iSecondaryColor = secondaryColor(z);
@@ -428,34 +447,46 @@ public final class WidgetRenderer {
             f = i == GRAPHIC_LARGE ? 1.24f : 1.0f;
         }
         float fMin = widgetOptions.singleMetric() ? Math.min(1.36f, f * 1.16f) : f;
+        MeterSlot primary = slotAt(slots, 0);
+        MeterSlot secondary = slotAt(slots, 1);
+        int primaryProgress = primary == null ? -1 : primary.progress;
+        int secondaryProgress = secondary == null ? -1 : secondary.progress;
         if (z2) {
             applyProgressColors(remoteViews, R.id.primary_samsung_progress,
                     iAccentColor, iTrackColor);
             applyProgressColors(remoteViews, R.id.secondary_samsung_progress,
                     iAccentColor, iTrackColor);
             remoteViews.setProgressBar(R.id.primary_samsung_progress, 100,
-                    Math.max(GRAPHIC_STANDARD, widgetState.primaryValue), false);
+                    Math.max(GRAPHIC_STANDARD, primaryProgress), false);
             remoteViews.setProgressBar(R.id.secondary_samsung_progress, 100,
-                    Math.max(GRAPHIC_STANDARD, widgetState.secondaryValue), false);
+                    Math.max(GRAPHIC_STANDARD, secondaryProgress), false);
             remoteViews.setTextViewText(R.id.primary_samsung_value,
-                    dialValue(widgetState.primaryValue, widgetOptions.showPercentSymbol));
+                    primary == null ? "—" : primary.valueText);
             remoteViews.setTextViewText(R.id.secondary_samsung_value,
-                    dialValue(widgetState.secondaryValue, widgetOptions.showPercentSymbol));
+                    secondary == null ? "—" : secondary.valueText);
             remoteViews.setTextColor(R.id.primary_samsung_value, iMainTextColor);
             remoteViews.setTextColor(R.id.secondary_samsung_value, iMainTextColor);
+            if (primary != null) {
+                remoteViews.setImageViewResource(R.id.primary_samsung_icon, primary.iconRes);
+            }
+            if (secondary != null) {
+                remoteViews.setImageViewResource(R.id.secondary_samsung_icon, secondary.iconRes);
+            }
             remoteViews.setInt(R.id.primary_samsung_icon, "setColorFilter", iMainTextColor);
             remoteViews.setInt(R.id.secondary_samsung_icon, "setColorFilter", iMainTextColor);
         } else {
-            remoteViews.setImageViewBitmap(R.id.primary_graphic, WidgetGraphics.dial(widgetState.primaryValue, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
-            remoteViews.setImageViewBitmap(R.id.secondary_graphic, WidgetGraphics.dial(widgetState.secondaryValue, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
+            remoteViews.setImageViewBitmap(R.id.primary_graphic,
+                    WidgetGraphics.dial(primaryProgress, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
+            remoteViews.setImageViewBitmap(R.id.secondary_graphic,
+                    WidgetGraphics.dial(secondaryProgress, iAccentColor, iTrackColor, iMainTextColor, str, fMin));
         }
         remoteViews.setTextColor(R.id.primary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.secondary_label, iSecondaryColor);
         remoteViews.setTextColor(R.id.primary_reset, iMutedColor);
         remoteViews.setTextColor(R.id.secondary_reset, iMutedColor);
         remoteViews.setTextColor(R.id.updated_label, iFaintColor);
-        remoteViews.setTextViewText(R.id.primary_label, "5-hour");
-        remoteViews.setTextViewText(R.id.secondary_label, "Weekly");
+        remoteViews.setTextViewText(R.id.primary_label, primary == null ? "" : primary.label);
+        remoteViews.setTextViewText(R.id.secondary_label, secondary == null ? "" : secondary.label);
         remoteViews.setViewVisibility(R.id.primary_label, 8);
         remoteViews.setViewVisibility(R.id.secondary_label, 8);
         remoteViews.setTextViewText(R.id.primary_reset, widgetState.primaryShortReset);
@@ -466,63 +497,82 @@ public final class WidgetRenderer {
     }
 
     private static void renderFourDials(Context context, RemoteViews remoteViews,
-            WidgetOptions options, boolean dark, WidgetState state) {
+            WidgetOptions options, boolean dark, List<MeterSlot> slots) {
         int accent = WidgetGraphics.accentColor(context, options.accent, dark);
         int track = WidgetGraphics.trackColor(dark);
         int text = WidgetGraphics.mainTextColor(dark);
-        remoteViews.setImageViewBitmap(R.id.primary_four_graphic,
-                WidgetGraphics.compactDial(context, state.primaryValue, R.drawable.ic_oui_time,
-                        accent, track, text,
-                        dialValue(state.primaryValue, options.showPercentSymbol), 1.0f));
-        remoteViews.setImageViewBitmap(R.id.secondary_four_graphic,
-                WidgetGraphics.compactDial(context, state.secondaryValue,
-                        R.drawable.ic_oui_calendar_week, accent, track, text,
-                        dialValue(state.secondaryValue, options.showPercentSymbol), 1.0f));
-        remoteViews.setImageViewBitmap(R.id.reset_time_four_graphic,
-                WidgetGraphics.compactDial(context, state.nextResetProgress,
-                        R.drawable.ic_oui_alarm, accent, track, text, state.nextResetText, 1.0f));
-        ResetCreditsSnapshot credits = AppPreferences.loadResetCredits(context);
-        int resetCount = credits == null ? 0 : credits.availableCount;
-        int resetProgress = Math.min(100, Math.round((Math.min(4, resetCount) / 4.0f) * 100));
-        remoteViews.setImageViewBitmap(R.id.reset_count_four_graphic,
-                WidgetGraphics.compactDial(context, resetProgress,
-                        R.drawable.ic_oui_refresh, accent, track, text,
-                        String.valueOf(resetCount), 1.0f));
+        int[] graphicIds = {
+                R.id.primary_four_graphic, R.id.secondary_four_graphic,
+                R.id.reset_time_four_graphic, R.id.reset_count_four_graphic
+        };
+        int[] sectionIds = {
+                R.id.primary_section, R.id.secondary_section, 0, 0
+        };
+        for (int index = 0; index < graphicIds.length; index++) {
+            MeterSlot slot = slotAt(slots, index);
+            if (slot == null) {
+                remoteViews.setViewVisibility(graphicIds[index], View.GONE);
+                if (sectionIds[index] != 0) {
+                    remoteViews.setViewVisibility(sectionIds[index], View.GONE);
+                }
+                continue;
+            }
+            remoteViews.setViewVisibility(graphicIds[index], View.VISIBLE);
+            if (sectionIds[index] != 0) {
+                remoteViews.setViewVisibility(sectionIds[index], View.VISIBLE);
+            }
+            remoteViews.setImageViewBitmap(graphicIds[index],
+                    WidgetGraphics.compactDial(context, slot.progress, slot.iconRes,
+                            accent, track, text, slot.valueText, 1.0f));
+        }
     }
 
     private static void renderBatteryList(Context context, RemoteViews remoteViews,
-            WidgetOptions options, boolean dark, WidgetState state) {
+            WidgetOptions options, boolean dark, List<MeterSlot> slots) {
         int textColor = WidgetGraphics.mainTextColor(dark);
         int accent = WidgetGraphics.accentColor(context, options.accent, dark);
         int track = WidgetGraphics.trackColor(dark);
-        applyProgressColors(remoteViews, R.id.primary_list_progress, accent, track);
-        applyProgressColors(remoteViews, R.id.secondary_list_progress, accent, track);
-        applyProgressColors(remoteViews, R.id.reset_time_list_progress, accent, track);
-        applyProgressColors(remoteViews, R.id.reset_count_list_progress, accent, track);
-        remoteViews.setProgressBar(R.id.primary_list_progress, 100,
-                Math.max(GRAPHIC_STANDARD, state.primaryValue), false);
-        remoteViews.setProgressBar(R.id.secondary_list_progress, 100,
-                Math.max(GRAPHIC_STANDARD, state.secondaryValue), false);
-        remoteViews.setTextViewText(R.id.primary_list_value,
-                state.primaryValue < 0 ? "—" : state.primaryValue + "%");
-        remoteViews.setTextViewText(R.id.secondary_list_value,
-                state.secondaryValue < 0 ? "—" : state.secondaryValue + "%");
-        remoteViews.setTextColor(R.id.primary_list_value, textColor);
-        remoteViews.setTextColor(R.id.secondary_list_value, textColor);
-        remoteViews.setProgressBar(R.id.reset_time_list_progress, 100,
-                state.nextResetProgress, false);
-        remoteViews.setTextViewText(R.id.reset_time_list_value, state.nextResetText);
-        remoteViews.setTextColor(R.id.reset_time_list_value, textColor);
-        ResetCreditsSnapshot credits = AppPreferences.loadResetCredits(context);
-        int resetCount = credits == null ? 0 : credits.availableCount;
-        remoteViews.setProgressBar(R.id.reset_count_list_progress, Math.max(4, resetCount),
-                resetCount, false);
-        remoteViews.setTextViewText(R.id.reset_count_list_value, String.valueOf(resetCount));
-        remoteViews.setTextColor(R.id.reset_count_list_value, textColor);
-        remoteViews.setInt(R.id.primary_list_icon, "setColorFilter", Color.WHITE);
-        remoteViews.setInt(R.id.secondary_list_icon, "setColorFilter", Color.WHITE);
-        remoteViews.setInt(R.id.reset_time_list_icon, "setColorFilter", Color.WHITE);
-        remoteViews.setInt(R.id.reset_count_list_icon, "setColorFilter", Color.WHITE);
+        int[] sectionIds = {
+                R.id.primary_section, R.id.secondary_section,
+                R.id.reset_time_section, R.id.reset_count_section
+        };
+        int[] spacerIds = {
+                R.id.list_spacer_1, R.id.list_spacer_2, R.id.list_spacer_3
+        };
+        int[] progressIds = {
+                R.id.primary_list_progress, R.id.secondary_list_progress,
+                R.id.reset_time_list_progress, R.id.reset_count_list_progress
+        };
+        int[] valueIds = {
+                R.id.primary_list_value, R.id.secondary_list_value,
+                R.id.reset_time_list_value, R.id.reset_count_list_value
+        };
+        int[] iconIds = {
+                R.id.primary_list_icon, R.id.secondary_list_icon,
+                R.id.reset_time_list_icon, R.id.reset_count_list_icon
+        };
+        for (int index = 0; index < sectionIds.length; index++) {
+            MeterSlot slot = slotAt(slots, index);
+            if (slot == null) {
+                remoteViews.setViewVisibility(sectionIds[index], View.GONE);
+                if (index > 0) {
+                    remoteViews.setViewVisibility(spacerIds[index - 1], View.GONE);
+                }
+                continue;
+            }
+            remoteViews.setViewVisibility(sectionIds[index], View.VISIBLE);
+            if (index > 0) {
+                remoteViews.setViewVisibility(spacerIds[index - 1], View.VISIBLE);
+            }
+            applyProgressColors(remoteViews, progressIds[index], accent, track);
+            int max = slot.progressMax > 0 ? slot.progressMax : 100;
+            remoteViews.setProgressBar(progressIds[index], max,
+                    Math.max(GRAPHIC_STANDARD, slot.progress), false);
+            remoteViews.setTextViewText(valueIds[index], slot.valueText);
+            remoteViews.setTextColor(valueIds[index], textColor);
+            remoteViews.setImageViewResource(iconIds[index], slot.iconRes);
+            remoteViews.setInt(iconIds[index], "setColorFilter", Color.WHITE);
+        }
         remoteViews.setViewVisibility(R.id.primary_label, View.GONE);
         remoteViews.setViewVisibility(R.id.secondary_label, View.GONE);
         remoteViews.setViewVisibility(R.id.primary_reset, View.GONE);
@@ -556,9 +606,103 @@ public final class WidgetRenderer {
         remoteViews.setViewVisibility(R.id.updated_label, (!widgetOptions.showUpdated || widgetState.updated.isEmpty()) ? 8 : GRAPHIC_STANDARD);
     }
 
-    private static void applyMetricVisibility(RemoteViews remoteViews, WidgetOptions widgetOptions) {
-        remoteViews.setViewVisibility(R.id.primary_section, widgetOptions.showsFiveHour() ? GRAPHIC_STANDARD : 8);
-        remoteViews.setViewVisibility(R.id.secondary_section, widgetOptions.showsWeekly() ? GRAPHIC_STANDARD : 8);
+    private static void applySlotVisibility(RemoteViews remoteViews, String style, List<MeterSlot> slots) {
+        if (STYLE_FOUR_DIALS.equals(style) || STYLE_BATTERY_LIST.equals(style)) {
+            return;
+        }
+        remoteViews.setViewVisibility(R.id.primary_section, slots.size() > 0 ? View.VISIBLE : View.GONE);
+        remoteViews.setViewVisibility(R.id.secondary_section, slots.size() > 1 ? View.VISIBLE : View.GONE);
+    }
+
+    private static MeterSlot slotAt(List<MeterSlot> slots, int index) {
+        if (slots == null || index < 0 || index >= slots.size()) {
+            return null;
+        }
+        return slots.get(index);
+    }
+
+    private static List<MeterSlot> resolveSlots(Context context, WidgetOptions options,
+            WidgetState state, String visualStyle, Bundle bundle) {
+        UsageSnapshot snapshot = SecureTokenStore.isSignedIn(context)
+                ? AppPreferences.loadSnapshot(context) : null;
+        int height = currentHeight(context, bundle);
+        int capacity = WidgetMeters.slotCapacity(visualStyle, height);
+        List<String> available = WidgetMeters.availableKeys(snapshot);
+        List<String> visible = WidgetMeters.cap(
+                WidgetMeters.resolveVisible(options.effectiveVisibleMeters(), available),
+                capacity);
+        ResetCreditsSnapshot credits = AppPreferences.loadResetCredits(context);
+        int resetCount = credits == null ? 0 : credits.availableCount;
+        ArrayList<MeterSlot> slots = new ArrayList<>();
+        for (String key : visible) {
+            MeterSlot slot = buildSlot(key, snapshot, state, options, resetCount);
+            if (slot != null) {
+                slots.add(slot);
+            }
+        }
+        return slots;
+    }
+
+    private static MeterSlot buildSlot(String key, UsageSnapshot snapshot, WidgetState state,
+            WidgetOptions options, int resetCount) {
+        boolean used = WidgetOptions.DISPLAY_USED.equals(options.displayMode);
+        if (WidgetMeters.FIVE_HOUR.equals(key)) {
+            return usageSlot(key, "5h", R.drawable.ic_oui_time, state.primaryValue,
+                    dialValue(state.primaryValue, options.showPercentSymbol),
+                    state.primaryShort);
+        }
+        if (WidgetMeters.WEEKLY.equals(key)) {
+            return usageSlot(key, "Wk", R.drawable.ic_oui_calendar_week, state.secondaryValue,
+                    dialValue(state.secondaryValue, options.showPercentSymbol),
+                    state.secondaryShort);
+        }
+        if (WidgetMeters.NEXT_RESET.equals(key)) {
+            return new MeterSlot(key, "Reset", R.drawable.ic_oui_alarm, state.nextResetProgress,
+                    state.nextResetText, state.nextResetText, 100);
+        }
+        if (WidgetMeters.RESET_CREDITS.equals(key)) {
+            int progress = Math.min(100, Math.round((Math.min(4, resetCount) / 4.0f) * 100));
+            String text = String.valueOf(resetCount);
+            return new MeterSlot(key, "Credits", R.drawable.ic_oui_refresh, progress, text, text,
+                    Math.max(4, resetCount));
+        }
+        UsageLimit limit = WidgetMeters.findLimit(key, snapshot);
+        if (limit != null) {
+            UsageWindow window = WidgetMeters.isLimitPrimary(key) ? limit.primary : limit.secondary;
+            int value = window == null ? -1 : (used ? window.usedPercent : window.remainingPercent());
+            String label = WidgetMeters.shortLabel(key, snapshot);
+            int icon = WidgetMeters.isLimitPrimary(key)
+                    ? R.drawable.ic_oui_time : R.drawable.ic_oui_calendar_week;
+            String text = dialValue(value, options.showPercentSymbol);
+            return usageSlot(key, label, icon, value, text, text);
+        }
+        return null;
+    }
+
+    private static MeterSlot usageSlot(String key, String label, int icon, int progress,
+            String valueText, String shortText) {
+        return new MeterSlot(key, label, icon, progress, valueText, shortText, 100);
+    }
+
+    private static final class MeterSlot {
+        final String key;
+        final String label;
+        final int iconRes;
+        final int progress;
+        final String valueText;
+        final String shortText;
+        final int progressMax;
+
+        MeterSlot(String key, String label, int iconRes, int progress, String valueText,
+                String shortText, int progressMax) {
+            this.key = key;
+            this.label = label;
+            this.iconRes = iconRes;
+            this.progress = progress;
+            this.valueText = valueText;
+            this.shortText = shortText;
+            this.progressMax = progressMax;
+        }
     }
 
     private static void applyResetCreditRow(Context context, RemoteViews remoteViews, int i, WidgetOptions widgetOptions, boolean z, String str) {

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,0 +1,1 @@
+sdk.dir=/home/ubuntu/android-sdk

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,1 +1,0 @@
-sdk.dir=/home/ubuntu/android-sdk

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -30,6 +30,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageLimit.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/DashboardSections.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSample.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageHistory.java" \

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -482,10 +482,25 @@ grep -q 'RadioItemViewGroup' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/OneUiChoiceDialog.java"
 grep -q 'OneUiChoiceDialog.show' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
-grep -q 'OneUiChoiceDialog.show' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java"
 grep -q '"Both windows", "5-hour only", "Weekly only"' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java"
+# Home widget layout picker exposes Auto / Dials / Progress bars.
+grep -q '"Adaptive by size", "Dials", "Progress bars"' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetOptionCatalog.java"
+grep -q 'styleSpinner' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
+# Home and lock config drive the shared meter catalog for per-meter visibility.
+grep -q 'WidgetMeters' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
+grep -q 'WidgetMeters' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java"
+grep -q 'selectedMeters' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java"
+# Renderer honors the layout preference and binds ordered meter slots.
+grep -q 'resolveHomeVisualStyle' \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java"
+grep -q 'resolveSlots' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java"
 ! grep -q 'ListPopupWindow' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
 grep -q 'android:max="2"' "$ROOT/app/src/main/res/layout/view_widget_opacity.xml"

--- a/android/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java
@@ -169,6 +169,20 @@ public final class WidgetMeters {
         return result;
     }
 
+    /**
+     * Like {@link #resolveVisible} but never returns an empty list: when every saved key has
+     * gone stale (for example a widget pinned only to a model limit the account no longer
+     * reports), falls back to the legacy metric-mode selection so the widget keeps rendering.
+     */
+    public static List<String> resolveVisibleOrDefault(String savedCsv, List<String> available,
+            String metricMode) {
+        List<String> resolved = resolveVisible(savedCsv, available);
+        if (!resolved.isEmpty()) {
+            return resolved;
+        }
+        return resolveVisible(serialize(fromMetricMode(metricMode)), available);
+    }
+
     /** Truncates an ordered visible list to the host's slot capacity. */
     public static List<String> cap(List<String> visible, int capacity) {
         List<String> source = visible == null ? new ArrayList<>() : visible;
@@ -269,8 +283,8 @@ public final class WidgetMeters {
         return 2;
     }
 
-    /** Lock widgets expose at most two meter groups. */
-    public static int lockSlotCapacity(boolean wide) {
+    /** Lock widgets expose at most two meter groups regardless of shape. */
+    public static int lockSlotCapacity() {
         return 2;
     }
 
@@ -353,10 +367,6 @@ public final class WidgetMeters {
 
     public static boolean isLimitPrimary(String key) {
         return key != null && key.endsWith(PRIMARY_SUFFIX);
-    }
-
-    public static boolean isLimitSecondary(String key) {
-        return key != null && key.endsWith(SECONDARY_SUFFIX);
     }
 
     private static String shortLimitName(String displayName) {

--- a/android/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java
@@ -1,0 +1,380 @@
+package dev.bennett.codexmeter;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Stable meter keys and resolution rules for home and lock widgets. Preference selects which
+ * meters fill the slots; host size and visual style select how many slots fit.
+ */
+public final class WidgetMeters {
+    public static final String FIVE_HOUR = "five_hour";
+    public static final String WEEKLY = "weekly";
+    public static final String NEXT_RESET = "next_reset";
+    public static final String RESET_CREDITS = "reset_credits";
+
+    /** Internal render styles used by the home widget renderer. */
+    public static final String VISUAL_RINGS = "rings";
+    public static final String VISUAL_DIALS = "dials";
+    public static final String VISUAL_FOUR_DIALS = "four_dials";
+    public static final String VISUAL_BATTERY_LIST = "battery_list";
+
+    public static final String PREF_AUTO = "auto";
+    public static final String PREF_DIALS = "dials";
+    public static final String PREF_BARS = "bars";
+
+    private static final String LIMIT_PREFIX = "limit:";
+    private static final String PRIMARY_SUFFIX = ":primary";
+    private static final String SECONDARY_SUFFIX = ":secondary";
+
+    private WidgetMeters() {
+    }
+
+    /** Default visible meters for the classic "both windows" home widget. */
+    public static List<String> defaultVisible() {
+        List<String> keys = new ArrayList<>();
+        keys.add(FIVE_HOUR);
+        keys.add(WEEKLY);
+        keys.add(NEXT_RESET);
+        keys.add(RESET_CREDITS);
+        return keys;
+    }
+
+    /** Migrates the legacy metric_mode spinner into an explicit visible-meters list. */
+    public static List<String> fromMetricMode(String metricMode) {
+        if ("five_hour".equals(metricMode)) {
+            List<String> keys = new ArrayList<>();
+            keys.add(FIVE_HOUR);
+            return keys;
+        }
+        if ("weekly".equals(metricMode)) {
+            List<String> keys = new ArrayList<>();
+            keys.add(WEEKLY);
+            return keys;
+        }
+        return defaultVisible();
+    }
+
+    /**
+     * Returns the effective visible-meters CSV. An empty/missing saved value falls back to the
+     * legacy metric_mode mapping so upgraded widgets keep their previous content.
+     */
+    public static String effectiveVisibleCsv(String savedCsv, String metricMode) {
+        if (savedCsv != null && !savedCsv.trim().isEmpty()) {
+            return serialize(parse(savedCsv));
+        }
+        return serialize(fromMetricMode(metricMode));
+    }
+
+    public static List<String> parse(String csv) {
+        List<String> keys = new ArrayList<>();
+        if (csv == null || csv.trim().isEmpty()) {
+            return keys;
+        }
+        for (String part : csv.split(",")) {
+            String key = part.trim();
+            if (!key.isEmpty() && !keys.contains(key)) {
+                keys.add(key);
+            }
+        }
+        return keys;
+    }
+
+    public static String serialize(List<String> keys) {
+        StringBuilder csv = new StringBuilder();
+        if (keys == null) {
+            return "";
+        }
+        for (String key : keys) {
+            if (key == null || key.trim().isEmpty()) {
+                continue;
+            }
+            if (csv.length() > 0) {
+                csv.append(',');
+            }
+            csv.append(key.trim());
+        }
+        return csv.toString();
+    }
+
+    public static boolean isLimitKey(String key) {
+        return key != null && key.startsWith(LIMIT_PREFIX)
+                && (key.endsWith(PRIMARY_SUFFIX) || key.endsWith(SECONDARY_SUFFIX));
+    }
+
+    public static String limitPrimaryKey(UsageLimit limit) {
+        return LIMIT_PREFIX + limitIdentity(limit) + PRIMARY_SUFFIX;
+    }
+
+    public static String limitSecondaryKey(UsageLimit limit) {
+        return LIMIT_PREFIX + limitIdentity(limit) + SECONDARY_SUFFIX;
+    }
+
+    public static String limitIdentity(UsageLimit limit) {
+        if (limit == null) {
+            return "additional";
+        }
+        String identity = limit.id;
+        if (identity == null || identity.isEmpty()) {
+            identity = limit.name;
+        }
+        if (identity == null || identity.isEmpty()) {
+            identity = limit.meteredFeature;
+        }
+        if (identity == null || identity.isEmpty()) {
+            identity = "additional";
+        }
+        return identity.toLowerCase(Locale.ROOT).replace(',', '_');
+    }
+
+    /** Catalog of meters that can be offered in config for the current snapshot. */
+    public static List<String> availableKeys(UsageSnapshot snapshot) {
+        LinkedHashSet<String> keys = new LinkedHashSet<>();
+        keys.add(FIVE_HOUR);
+        keys.add(WEEKLY);
+        if (snapshot != null && snapshot.additionalLimits != null) {
+            for (UsageLimit limit : snapshot.additionalLimits) {
+                if (limit == null) {
+                    continue;
+                }
+                if (limit.primary != null) {
+                    keys.add(limitPrimaryKey(limit));
+                }
+                if (limit.secondary != null) {
+                    keys.add(limitSecondaryKey(limit));
+                }
+            }
+        }
+        keys.add(NEXT_RESET);
+        keys.add(RESET_CREDITS);
+        return new ArrayList<>(keys);
+    }
+
+    /**
+     * Applies a saved ordered visible list to currently available keys. Unknown/stale keys are
+     * dropped; order of surviving keys is preserved.
+     */
+    public static List<String> resolveVisible(String savedCsv, List<String> available) {
+        List<String> availableKeys = available == null
+                ? new ArrayList<>()
+                : new ArrayList<>(new LinkedHashSet<>(available));
+        List<String> result = new ArrayList<>();
+        for (String key : parse(savedCsv)) {
+            if (availableKeys.contains(key) && !result.contains(key)) {
+                result.add(key);
+            }
+        }
+        return result;
+    }
+
+    /** Truncates an ordered visible list to the host's slot capacity. */
+    public static List<String> cap(List<String> visible, int capacity) {
+        List<String> source = visible == null ? new ArrayList<>() : visible;
+        int limit = Math.max(0, capacity);
+        if (source.size() <= limit) {
+            return new ArrayList<>(source);
+        }
+        return new ArrayList<>(source.subList(0, limit));
+    }
+
+    public static boolean contains(List<String> keys, String key) {
+        return keys != null && key != null && keys.contains(key);
+    }
+
+    /** Number of usage-window meters (Codex + additional limits), excluding reset helpers. */
+    public static int usageMeterCount(List<String> keys) {
+        if (keys == null) {
+            return 0;
+        }
+        int count = 0;
+        for (String key : keys) {
+            if (FIVE_HOUR.equals(key) || WEEKLY.equals(key) || isLimitKey(key)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public static boolean singleUsageMetric(List<String> keys) {
+        return usageMeterCount(keys) <= 1;
+    }
+
+    /**
+     * Normalizes a stored layout preference to auto / dials / bars. Legacy forced {@code rings}
+     * and {@code minimal} values map to adaptive auto.
+     */
+    public static String layoutPreference(String layout) {
+        if (PREF_DIALS.equals(layout)) {
+            return PREF_DIALS;
+        }
+        if (PREF_BARS.equals(layout) || "detailed".equals(layout)) {
+            return PREF_BARS;
+        }
+        return PREF_AUTO;
+    }
+
+    /**
+     * Resolves the concrete home-widget visual style from preference + host size.
+     * {@code auto} preserves the pre-customization size map exactly.
+     */
+    public static String resolveHomeVisualStyle(String layoutPreference, boolean singleUsageMetric,
+            int rows, int columns, int heightDp, int widthDp) {
+        String preference = layoutPreference(layoutPreference);
+        if (PREF_BARS.equals(preference)) {
+            return VISUAL_BATTERY_LIST;
+        }
+        String autoStyle = autoStyleForSize(singleUsageMetric, rows, columns, heightDp, widthDp);
+        if (PREF_DIALS.equals(preference) && VISUAL_BATTERY_LIST.equals(autoStyle)) {
+            return singleUsageMetric ? VISUAL_DIALS : VISUAL_FOUR_DIALS;
+        }
+        return autoStyle;
+    }
+
+    /** Pixel-identical to the former {@code WidgetRenderer.styleForSize} auto path. */
+    public static String autoStyleForSize(boolean singleUsageMetric, int rows, int columns,
+            int heightDp, int widthDp) {
+        if (singleUsageMetric) {
+            if (rows >= 2 || heightDp >= 130) {
+                return VISUAL_DIALS;
+            }
+            return VISUAL_RINGS;
+        }
+        if (rows > 0) {
+            if (rows >= 2) {
+                return VISUAL_BATTERY_LIST;
+            }
+            return columns >= 3 ? VISUAL_FOUR_DIALS : VISUAL_RINGS;
+        }
+        if (heightDp >= 130) {
+            return VISUAL_BATTERY_LIST;
+        }
+        return widthDp >= 240 ? VISUAL_FOUR_DIALS : VISUAL_RINGS;
+    }
+
+    /**
+     * Slot capacity for a resolved visual style. Forced bars on short hosts only fit two rows.
+     */
+    public static int slotCapacity(String visualStyle, int heightDp) {
+        if (VISUAL_FOUR_DIALS.equals(visualStyle)) {
+            return 4;
+        }
+        if (VISUAL_BATTERY_LIST.equals(visualStyle)) {
+            return heightDp >= 130 ? 4 : 2;
+        }
+        if (VISUAL_RINGS.equals(visualStyle) || VISUAL_DIALS.equals(visualStyle)) {
+            return 2;
+        }
+        return 2;
+    }
+
+    /** Lock widgets expose at most two meter groups. */
+    public static int lockSlotCapacity(boolean wide) {
+        return 2;
+    }
+
+    /** Short label for dial/bar faces; config can use the fuller display name. */
+    public static String shortLabel(String key, UsageSnapshot snapshot) {
+        if (FIVE_HOUR.equals(key)) {
+            return "5h";
+        }
+        if (WEEKLY.equals(key)) {
+            return "Wk";
+        }
+        if (NEXT_RESET.equals(key)) {
+            return "Reset";
+        }
+        if (RESET_CREDITS.equals(key)) {
+            return "Credits";
+        }
+        UsageLimit limit = findLimit(key, snapshot);
+        if (limit != null) {
+            String base = shortLimitName(limit.displayName());
+            if (key.endsWith(PRIMARY_SUFFIX)) {
+                return base + " 5h";
+            }
+            if (key.endsWith(SECONDARY_SUFFIX)) {
+                return base + " W";
+            }
+        }
+        return "Meter";
+    }
+
+    /** Config-row title for a meter key. */
+    public static String configLabel(String key, UsageSnapshot snapshot) {
+        if (FIVE_HOUR.equals(key)) {
+            return "Codex · 5 hours";
+        }
+        if (WEEKLY.equals(key)) {
+            return "Codex · Weekly";
+        }
+        if (NEXT_RESET.equals(key)) {
+            return "Next reset";
+        }
+        if (RESET_CREDITS.equals(key)) {
+            return "Reset credits";
+        }
+        UsageLimit limit = findLimit(key, snapshot);
+        if (limit != null) {
+            String name = limit.displayName();
+            if (key.endsWith(PRIMARY_SUFFIX)) {
+                return name + " · 5 hours";
+            }
+            if (key.endsWith(SECONDARY_SUFFIX)) {
+                return name + " · Weekly";
+            }
+            return name;
+        }
+        return key;
+    }
+
+    public static UsageLimit findLimit(String key, UsageSnapshot snapshot) {
+        if (!isLimitKey(key) || snapshot == null || snapshot.additionalLimits == null) {
+            return null;
+        }
+        String identity;
+        if (key.endsWith(PRIMARY_SUFFIX)) {
+            identity = key.substring(LIMIT_PREFIX.length(),
+                    key.length() - PRIMARY_SUFFIX.length());
+        } else if (key.endsWith(SECONDARY_SUFFIX)) {
+            identity = key.substring(LIMIT_PREFIX.length(),
+                    key.length() - SECONDARY_SUFFIX.length());
+        } else {
+            return null;
+        }
+        for (UsageLimit limit : snapshot.additionalLimits) {
+            if (limit != null && identity.equals(limitIdentity(limit))) {
+                return limit;
+            }
+        }
+        return null;
+    }
+
+    public static boolean isLimitPrimary(String key) {
+        return key != null && key.endsWith(PRIMARY_SUFFIX);
+    }
+
+    public static boolean isLimitSecondary(String key) {
+        return key != null && key.endsWith(SECONDARY_SUFFIX);
+    }
+
+    private static String shortLimitName(String displayName) {
+        if (displayName == null || displayName.isEmpty()) {
+            return "Limit";
+        }
+        String trimmed = displayName.trim();
+        if (trimmed.toLowerCase(Locale.ROOT).contains("spark")) {
+            return "Spark";
+        }
+        if (trimmed.length() <= 10) {
+            return trimmed;
+        }
+        String[] parts = trimmed.split("[\\s\\-_/]+");
+        if (parts.length > 0 && !parts[parts.length - 1].isEmpty()) {
+            String last = parts[parts.length - 1];
+            return last.length() > 10 ? last.substring(0, 10) : last;
+        }
+        return trimmed.substring(0, 10);
+    }
+}

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -1288,6 +1288,20 @@ public final class ParserSelfTest {
         check(WidgetMeters.cap(resolved, 2).equals(java.util.Arrays.asList(
                         WidgetMeters.FIVE_HOUR, WidgetMeters.limitPrimaryKey(spark))),
                 "capacity truncates to first N meters");
+        check(WidgetMeters.resolveVisibleOrDefault(
+                        "limit:gone-model:primary", available, "both")
+                        .equals(WidgetMeters.defaultVisible()),
+                "all-stale selection falls back to default meters");
+        check(WidgetMeters.resolveVisibleOrDefault(
+                        "limit:gone-model:primary", available, "weekly")
+                        .equals(java.util.Arrays.asList(WidgetMeters.WEEKLY)),
+                "stale selection falls back to legacy metric mode");
+        check(WidgetMeters.resolveVisibleOrDefault(
+                        "weekly,five_hour", available, "both")
+                        .equals(java.util.Arrays.asList(WidgetMeters.WEEKLY,
+                                WidgetMeters.FIVE_HOUR)),
+                "valid selection is not replaced by fallback");
+        check(WidgetMeters.lockSlotCapacity() == 2, "lock widgets cap at two meters");
         check(WidgetMeters.shortLabel(WidgetMeters.limitPrimaryKey(spark), snapshot)
                         .equals("Spark 5h"),
                 "spark primary short label");

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -43,6 +43,7 @@ public final class ParserSelfTest {
         testJwtMerge();
         testPkce();
         testWidgetOptions();
+        testWidgetMeters();
         testOnboardingFlow();
         testOAuthBrowserPage();
         testReleaseVersions();
@@ -984,12 +985,13 @@ public final class ParserSelfTest {
 
 
     private static void testSettingsTransfer() throws Exception {
-        WidgetOptions widget = new WidgetOptions(WidgetOptions.STYLE_RINGS,
+        WidgetOptions widget = new WidgetOptions(WidgetOptions.STYLE_DIALS,
                 WidgetOptions.DENSITY_COMFORTABLE, WidgetOptions.SURFACE_ONE_UI,
                 WidgetOptions.GRAPHIC_MAX, WidgetOptions.THEME_DARK, WidgetOptions.ACCENT_BLUE,
                 94, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING,
                 WidgetOptions.METRIC_BOTH, false, true, false, true, true, false)
-                .withPercentSymbol(false);
+                .withPercentSymbol(false)
+                .withVisibleMeters("five_hour,limit:codex-spark:primary,weekly");
         org.json.JSONObject appSettings = new org.json.JSONObject()
                 .put("app_theme", WidgetOptions.THEME_DARK)
                 .put("material_you", true)
@@ -1041,6 +1043,9 @@ public final class ParserSelfTest {
                 parsed.appSettings.getJSONObject("default_widget"));
         check(WidgetOptions.THEME_DARK.equals(restored.theme), "widget theme restored");
         check(WidgetOptions.ACCENT_BLUE.equals(restored.accent), "widget accent restored");
+        check(WidgetOptions.STYLE_DIALS.equals(restored.layout), "widget layout preference restored");
+        check("five_hour,limit:codex-spark:primary,weekly".equals(restored.visibleMeters),
+                "widget visible meters restored");
         check(parsed.appSettings.getBoolean("material_you"), "material you preference restored");
         check(UsagePace.RELAXED.equals(
                         parsed.appSettings.getString("usage_pace_sensitivity")),
@@ -1213,6 +1218,110 @@ public final class ParserSelfTest {
         check(weeklyOnly.singleMetric() && !weeklyOnly.showsFiveHour()
                         && weeklyOnly.showsWeekly(),
                 "weekly-only widget exposes one dial");
+        check(WidgetMeters.PREF_AUTO.equals(WidgetOptions.defaults().layoutPreference()),
+                "default layout preference is adaptive");
+        WidgetOptions dialsPref = new WidgetOptions(WidgetOptions.STYLE_DIALS,
+                WidgetOptions.DENSITY_AUTO, WidgetOptions.SURFACE_ONE_UI,
+                WidgetOptions.GRAPHIC_AUTO, WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_BLUE,
+                88, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING,
+                "both", false, false, false, false, false, false);
+        check(WidgetMeters.PREF_DIALS.equals(dialsPref.layoutPreference()),
+                "dials layout preference preserved");
+        WidgetOptions barsPref = new WidgetOptions(WidgetOptions.STYLE_BARS,
+                WidgetOptions.DENSITY_AUTO, WidgetOptions.SURFACE_ONE_UI,
+                WidgetOptions.GRAPHIC_AUTO, WidgetOptions.THEME_SYSTEM, WidgetOptions.ACCENT_BLUE,
+                88, WidgetOptions.RESET_HIDDEN, WidgetOptions.DISPLAY_REMAINING,
+                "both", false, false, false, false, false, false);
+        check(WidgetMeters.PREF_BARS.equals(barsPref.layoutPreference()),
+                "bars layout preference preserved");
+        check(WidgetMeters.PREF_AUTO.equals(
+                        new WidgetOptions(WidgetOptions.STYLE_RINGS,
+                                WidgetOptions.DENSITY_AUTO, WidgetOptions.SURFACE_ONE_UI,
+                                WidgetOptions.GRAPHIC_AUTO, WidgetOptions.THEME_SYSTEM,
+                                WidgetOptions.ACCENT_BLUE, 88, WidgetOptions.RESET_HIDDEN,
+                                WidgetOptions.DISPLAY_REMAINING, "both", false, false, false,
+                                false, false, false).layoutPreference()),
+                "legacy rings maps to adaptive preference");
+    }
+
+    private static void testWidgetMeters() {
+        check(WidgetMeters.serialize(WidgetMeters.defaultVisible())
+                        .equals("five_hour,weekly,next_reset,reset_credits"),
+                "default visible meters csv");
+        check(WidgetMeters.serialize(WidgetMeters.fromMetricMode("five_hour"))
+                        .equals("five_hour"),
+                "metric mode five-hour migrates");
+        check(WidgetMeters.serialize(WidgetMeters.fromMetricMode("weekly"))
+                        .equals("weekly"),
+                "metric mode weekly migrates");
+        check(WidgetMeters.effectiveVisibleCsv("", "both")
+                        .equals("five_hour,weekly,next_reset,reset_credits"),
+                "empty visible meters falls back to metric mode");
+        check(WidgetMeters.effectiveVisibleCsv("weekly,five_hour", "both")
+                        .equals("weekly,five_hour"),
+                "saved visible meters keep order");
+
+        UsageLimit spark = new UsageLimit("codex-spark", "GPT-5.3-Codex-Spark",
+                "codex_bengalfox", true, false,
+                new UsageWindow(40, 18000L, 600L, 0L),
+                new UsageWindow(70, 604800L, 600L, 0L));
+        UsageSnapshot snapshot = new UsageSnapshot("plus", true, false,
+                new UsageWindow(20, 18000L, 600L, 0L),
+                new UsageWindow(50, 604800L, 600L, 0L),
+                java.util.Arrays.asList(spark), null, 0, System.currentTimeMillis());
+        List<String> available = WidgetMeters.availableKeys(snapshot);
+        check(available.contains(WidgetMeters.FIVE_HOUR)
+                        && available.contains(WidgetMeters.WEEKLY)
+                        && available.contains(WidgetMeters.limitPrimaryKey(spark))
+                        && available.contains(WidgetMeters.limitSecondaryKey(spark))
+                        && available.contains(WidgetMeters.NEXT_RESET)
+                        && available.contains(WidgetMeters.RESET_CREDITS),
+                "available meters include spark windows");
+        List<String> resolved = WidgetMeters.resolveVisible(
+                "five_hour,limit:codex-spark:primary,limit:missing:primary,weekly",
+                available);
+        check(resolved.equals(java.util.Arrays.asList(
+                        WidgetMeters.FIVE_HOUR,
+                        WidgetMeters.limitPrimaryKey(spark),
+                        WidgetMeters.WEEKLY)),
+                "resolveVisible drops stale keys and keeps order");
+        check(WidgetMeters.cap(resolved, 2).equals(java.util.Arrays.asList(
+                        WidgetMeters.FIVE_HOUR, WidgetMeters.limitPrimaryKey(spark))),
+                "capacity truncates to first N meters");
+        check(WidgetMeters.shortLabel(WidgetMeters.limitPrimaryKey(spark), snapshot)
+                        .equals("Spark 5h"),
+                "spark primary short label");
+        check(WidgetMeters.shortLabel(WidgetMeters.limitSecondaryKey(spark), snapshot)
+                        .equals("Spark W"),
+                "spark secondary short label");
+
+        check(WidgetMeters.VISUAL_RINGS.equals(WidgetMeters.resolveHomeVisualStyle(
+                        WidgetMeters.PREF_AUTO, false, 1, 2, 70, 110)),
+                "auto short both uses rings");
+        check(WidgetMeters.VISUAL_FOUR_DIALS.equals(WidgetMeters.resolveHomeVisualStyle(
+                        WidgetMeters.PREF_AUTO, false, 1, 4, 70, 250)),
+                "auto wide short both uses four dials");
+        check(WidgetMeters.VISUAL_BATTERY_LIST.equals(WidgetMeters.resolveHomeVisualStyle(
+                        WidgetMeters.PREF_AUTO, false, 2, 2, 156, 110)),
+                "auto tall both uses battery list");
+        check(WidgetMeters.VISUAL_DIALS.equals(WidgetMeters.resolveHomeVisualStyle(
+                        WidgetMeters.PREF_AUTO, true, 2, 2, 156, 110)),
+                "auto tall single uses dials");
+        check(WidgetMeters.VISUAL_FOUR_DIALS.equals(WidgetMeters.resolveHomeVisualStyle(
+                        WidgetMeters.PREF_DIALS, false, 2, 2, 156, 110)),
+                "forced dials never returns battery list");
+        check(WidgetMeters.VISUAL_BATTERY_LIST.equals(WidgetMeters.resolveHomeVisualStyle(
+                        WidgetMeters.PREF_BARS, true, 1, 2, 70, 110)),
+                "forced bars always returns battery list");
+        check(WidgetMeters.slotCapacity(WidgetMeters.VISUAL_BATTERY_LIST, 70) == 2,
+                "short bars capacity is 2");
+        check(WidgetMeters.slotCapacity(WidgetMeters.VISUAL_BATTERY_LIST, 156) == 4,
+                "tall bars capacity is 4");
+        check(WidgetMeters.slotCapacity(WidgetMeters.VISUAL_FOUR_DIALS, 70) == 4,
+                "four dials capacity is 4");
+        check(WidgetMeters.slotCapacity(WidgetMeters.VISUAL_RINGS, 70) == 2,
+                "rings capacity is 2");
+        System.out.println("Widget meter catalog, capacity, and layout preference checks passed.");
     }
 
     private static void testOnboardingFlow() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Home widgets no longer force dials vs progress bars purely from size. Users can pick **Adaptive by size** (default, same behavior as today), **Dials**, or **Progress bars**.

Both home and Samsung lock widgets get an ordered **Meters** checklist so Codex 5-hour/weekly, Spark (and other additional limits), next-reset, and reset-credits can be chosen within the host's slot capacity.

## Changes

- New shared `WidgetMeters` catalog: keys, metric-mode migration, capacity rules, Auto/Dials/Bars visual resolution, stale-selection fallback
- `WidgetOptions` / prefs / settings transfer persist `layout` preference and `visible_meters`
- `WidgetRenderer` binds generic meter slots into rings, four-dials, large-dials, and battery-list layouts (including `additionalLimits`)
- Home `WidgetConfigActivity`: Layout picker + meter toggles with capacity hint
- Lock widgets: meter checklist + slot binding in `SamsungLockWidgetSupport` (style remains provider-chosen); arc bitmaps take per-slot icons
- `run-tests.sh` structural checks updated for the new layout picker + meter UI

## Self-review fixes (second pass)

- Stale-only meter selections (e.g. a widget pinned solely to a model limit the account no longer reports) fall back to the legacy metric-mode meters instead of rendering a blank widget
- Large gauge dials render each slot's own value text with adaptive sizing — countdown/credit meters show "1h 59m" / "3" instead of a bogus percent, and the "Show % symbol" toggle now applies
- Lock arc bitmaps no longer hardcode clock/calendar icons by position
- Lock config preview leaves the second dial empty for single-meter selections
- Removed unused `isLimitSecondary` and the ignored `lockSlotCapacity` parameter

## Testing

- `./run-tests.sh` passes (WidgetMeters catalog, capacity, layout preference, and stale-fallback coverage)
- `./build.sh` (phone + Wear release) and `./lint.sh` pass; CI `build` job green
- Verified on a software-rendered Android emulator (no KVM: `-accel off -gpu swiftshader_indirect`). Layout switching re-renders the placed widget live; demo values were seeded locally (emulator cannot sign in) and the seed is not part of this branch.

[widget-dials-switch-demo-small.mp4](https://cursor.com/agents/bc-019fafac-a784-71bb-8993-1da694fd9cc9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwidget-dials-switch-demo-small.mp4)

Progress bars layout:

[Progress bars widget](https://cursor.com/agents/bc-019fafac-a784-71bb-8993-1da694fd9cc9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo-home-before.png)

Dials layout (same widget, live values):

[Dials widget on home](https://cursor.com/agents/bc-019fafac-a784-71bb-8993-1da694fd9cc9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdials-05-home.png)

Large dials with a countdown meter (post-review fix — countdown text instead of a bogus percent):

[Large dials with countdown](https://cursor.com/agents/bc-019fafac-a784-71bb-8993-1da694fd9cc9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freview-big-dials-countdown.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fafac-a784-71bb-8993-1da694fd9cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fafac-a784-71bb-8993-1da694fd9cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

