### PR TITLE
Fix repeated low-usage notification spam

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ResetNotificationManager.java
@@ -259,18 +259,22 @@ public final class ResetNotificationManager {
     private static void notifyLowWindow(Context context, UsageWindow window, long fetchedAt,
             String label, String stateKey, int notificationId) {
         if (window == null || window.remainingPercent() > ResetAlertPreferences.getThreshold(context)) return;
-        long windowId = window.resetAtMillis();
-        if (windowId <= 0L && window.resetAfterSeconds > 0L) {
-            windowId = fetchedAt + window.resetAfterSeconds * 1000L;
-        }
+        long windowId = window.effectiveResetAtMillis(fetchedAt);
         if (windowId <= 0L) return;
         SharedPreferences state = state(context);
-        if (state.getLong(stateKey, 0L) == windowId) return;
+        long previousWindowId = state.getLong(stateKey, 0L);
+        if (!UsageWindow.shouldAnnounceLowUsage(previousWindowId, windowId, window.windowSeconds)) {
+            // Keep the stored reset aligned with API drift so slow skew cannot re-arm the alert.
+            if (previousWindowId != windowId) {
+                state.edit().putLong(stateKey, windowId).apply();
+            }
+            return;
+        }
         int remaining = window.remainingPercent();
         if (post(context, notificationId, label + " Codex usage is low",
                 remaining + "% remaining in the current "
                         + label.toLowerCase(Locale.ROOT) + " window.",
-                notificationId)) {
+                notificationId, true)) {
             state.edit().putLong(stateKey, windowId).apply();
         }
     }
@@ -334,6 +338,11 @@ public final class ResetNotificationManager {
     }
 
     private static boolean post(Context context, int id, String title, String text, int requestCode) {
+        return post(context, id, title, text, requestCode, false);
+    }
+
+    private static boolean post(Context context, int id, String title, String text, int requestCode,
+            boolean onlyAlertOnce) {
         NotificationManager manager = manager(context);
         if (manager == null) return false;
         String channel = createChannel(manager, ResetAlertPreferences.getStyle(context));
@@ -349,6 +358,7 @@ public final class ResetNotificationManager {
                 .setStyle(new Notification.BigTextStyle().bigText(text))
                 .setContentIntent(contentIntent)
                 .setAutoCancel(true)
+                .setOnlyAlertOnce(onlyAlertOnce)
                 .setCategory(Notification.CATEGORY_REMINDER)
                 .setVisibility(Notification.VISIBILITY_PUBLIC)
                 .setShowWhen(true)

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageHistory.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageHistory.java
@@ -142,10 +142,9 @@ public final class UsageHistory {
     }
 
     static boolean sameWindow(UsageSample left, UsageSample right) {
-        if (left == null || right == null || left.windowSeconds != right.windowSeconds) return false;
-        long tolerance = Math.min(TimeUnit.MINUTES.toMillis(15),
-                Math.max(TimeUnit.MINUTES.toMillis(1), left.windowSeconds * 1000L / 20L));
-        return Math.abs(left.resetAtMillis - right.resetAtMillis) <= tolerance;
+        if (left == null || right == null) return false;
+        return UsageWindow.sameResetWindow(left.resetAtMillis, left.windowSeconds,
+                right.resetAtMillis, right.windowSeconds);
     }
 
     private static String normalizeKind(String kind) {

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java
@@ -1,5 +1,6 @@
 package dev.bennett.codexmeter;
 
+import java.util.concurrent.TimeUnit;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -44,6 +45,38 @@ public final class UsageWindow {
             return 0L;
         }
         return observedAtMillis + resetAfterSeconds * 1000L;
+    }
+
+    /**
+     * OpenAI reset timestamps drift slightly across refreshes. Treat nearby reset times for the
+     * same window length as one window so low-usage alerts stay one-shot until the real reset.
+     */
+    public static long resetWindowToleranceMillis(long windowSeconds) {
+        if (windowSeconds <= 0L) return TimeUnit.MINUTES.toMillis(1);
+        return Math.min(TimeUnit.MINUTES.toMillis(15),
+                Math.max(TimeUnit.MINUTES.toMillis(1), windowSeconds * 1000L / 20L));
+    }
+
+    public static boolean sameResetWindow(long leftResetAtMillis, long leftWindowSeconds,
+            long rightResetAtMillis, long rightWindowSeconds) {
+        if (leftResetAtMillis <= 0L || rightResetAtMillis <= 0L
+                || leftWindowSeconds != rightWindowSeconds) {
+            return false;
+        }
+        return Math.abs(leftResetAtMillis - rightResetAtMillis)
+                <= resetWindowToleranceMillis(leftWindowSeconds);
+    }
+
+    /**
+     * Whether a low-usage alert should fire for {@code currentResetAtMillis}. Returns false when
+     * {@code lastAnnouncedResetAtMillis} already covers the same usage window.
+     */
+    public static boolean shouldAnnounceLowUsage(long lastAnnouncedResetAtMillis,
+            long currentResetAtMillis, long windowSeconds) {
+        if (currentResetAtMillis <= 0L) return false;
+        if (lastAnnouncedResetAtMillis <= 0L) return true;
+        return !sameResetWindow(lastAnnouncedResetAtMillis, windowSeconds,
+                currentResetAtMillis, windowSeconds);
     }
 
     public JSONObject toJson() throws JSONException {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -29,6 +29,7 @@ public final class ParserSelfTest {
         testResetCreditExpiryReminders();
         testResetCreditExpiryOrdering();
         testFullWindowHidesResetCountdown();
+        testLowUsageAlertDedup();
         testUsageHistory();
         testUsagePace();
         testAdaptiveRefreshPolicy();
@@ -66,6 +67,42 @@ public final class ParserSelfTest {
         check(almostFull.showsResetCountdown(), "99% remaining still shows reset countdown");
         check(used.showsResetCountdown(), "partial usage shows reset countdown");
         System.out.println("Reset-countdown demo: hide at 100% remaining, show again at 99% or less.");
+    }
+
+    private static void testLowUsageAlertDedup() {
+        long windowSeconds = TimeUnit.HOURS.toSeconds(5);
+        long reset = 2_000_000_000_000L;
+        check(UsageWindow.shouldAnnounceLowUsage(0L, reset, windowSeconds),
+                "first low-usage sighting announces");
+        check(!UsageWindow.shouldAnnounceLowUsage(reset, reset, windowSeconds),
+                "exact same reset does not re-announce");
+        check(!UsageWindow.shouldAnnounceLowUsage(reset, reset + TimeUnit.SECONDS.toMillis(1),
+                        windowSeconds),
+                "one-second reset drift does not re-announce");
+        check(!UsageWindow.shouldAnnounceLowUsage(reset, reset + TimeUnit.MINUTES.toMillis(1),
+                        windowSeconds),
+                "one-minute reset drift does not re-announce");
+        check(!UsageWindow.shouldAnnounceLowUsage(reset, reset + TimeUnit.MINUTES.toMillis(14),
+                        windowSeconds),
+                "sub-tolerance drift does not re-announce");
+        check(UsageWindow.shouldAnnounceLowUsage(reset,
+                        reset + TimeUnit.HOURS.toMillis(5), windowSeconds),
+                "next five-hour window announces again");
+        check(UsageWindow.sameResetWindow(reset, windowSeconds,
+                        reset + TimeUnit.SECONDS.toMillis(45), windowSeconds),
+                "nearby resets are the same window");
+        check(!UsageWindow.sameResetWindow(reset, windowSeconds,
+                        reset + TimeUnit.HOURS.toMillis(5), windowSeconds),
+                "hours-apart resets are distinct windows");
+        long fetchedAt = reset - TimeUnit.HOURS.toMillis(2);
+        UsageWindow relative = new UsageWindow(75, windowSeconds,
+                TimeUnit.HOURS.toSeconds(2), 0L);
+        long computed = relative.effectiveResetAtMillis(fetchedAt);
+        check(computed == reset, "reset-after fallback yields absolute reset");
+        check(!UsageWindow.shouldAnnounceLowUsage(reset,
+                        relative.effectiveResetAtMillis(fetchedAt + 500L), windowSeconds),
+                "millisecond fetch skew with reset-after does not re-announce");
+        System.out.println("Low-usage alert dedupe: one shot per window despite reset drift.");
     }
 
     private static void testUsagePace() {

--- a/ios/CodexMeter/Infrastructure/NotificationCoordinator.swift
+++ b/ios/CodexMeter/Infrastructure/NotificationCoordinator.swift
@@ -22,15 +22,38 @@ nonisolated public enum NotificationDeduplication {
         Int(resetDate.timeIntervalSince1970)
     }
 
-    public static func shouldDeliverLowUsage(
-        lastDeliveredWindowToken: Int?,
-        resetDate: Date
-    ) -> Bool {
-        lastDeliveredWindowToken != windowToken(for: resetDate)
+    /// OpenAI reset timestamps drift across refreshes; match Android's window tolerance.
+    public static func resetWindowToleranceSeconds(windowSeconds: Int64) -> Int {
+        if windowSeconds <= 0 { return 60 }
+        let proportional = Int(windowSeconds / 20)
+        return min(15 * 60, max(60, proportional))
     }
 
-    public static func lowUsageIdentifier(metric: AlertMetric, resetDate: Date) -> String {
-        "\(identifierPrefix)low.\(metric.rawValue).\(windowToken(for: resetDate))"
+    public static func sameResetWindow(
+        leftToken: Int,
+        rightToken: Int,
+        windowSeconds: Int64
+    ) -> Bool {
+        abs(leftToken - rightToken) <= resetWindowToleranceSeconds(windowSeconds: windowSeconds)
+    }
+
+    public static func shouldDeliverLowUsage(
+        lastDeliveredWindowToken: Int?,
+        resetDate: Date,
+        windowSeconds: Int64
+    ) -> Bool {
+        let current = windowToken(for: resetDate)
+        guard let lastDeliveredWindowToken else { return true }
+        return !sameResetWindow(
+            leftToken: lastDeliveredWindowToken,
+            rightToken: current,
+            windowSeconds: windowSeconds
+        )
+    }
+
+    /// Stable per-metric id so refresh drift cannot create a second low-usage alert.
+    public static func lowUsageIdentifier(metric: AlertMetric) -> String {
+        "\(identifierPrefix)low.\(metric.rawValue)"
     }
 
     public static func resetIdentifier(metric: AlertMetric, resetDate: Date) -> String {
@@ -264,19 +287,21 @@ public actor NotificationCoordinator {
             )
         )
         guard window.hasRemainingAllowance(atOrBelow: threshold) else { return }
-        let identifier = NotificationDeduplication.lowUsageIdentifier(
-            metric: metric,
-            resetDate: resetDate
-        )
+        let identifier = NotificationDeduplication.lowUsageIdentifier(metric: metric)
         currentLowIdentifiers.insert(identifier)
         let stateKey = Self.lowUsageStatePrefix + metric.rawValue
         let previousWindowToken = defaults.object(forKey: stateKey) == nil
             ? nil
             : defaults.integer(forKey: stateKey)
+        let currentToken = NotificationDeduplication.windowToken(for: resetDate)
         guard NotificationDeduplication.shouldDeliverLowUsage(
             lastDeliveredWindowToken: previousWindowToken,
-            resetDate: resetDate
+            resetDate: resetDate,
+            windowSeconds: window.windowSeconds
         ) else {
+            if previousWindowToken != currentToken {
+                defaults.set(currentToken, forKey: stateKey)
+            }
             return
         }
         let lowContent = UNMutableNotificationContent()
@@ -287,7 +312,7 @@ public actor NotificationCoordinator {
             try await center.add(
                 UNNotificationRequest(identifier: identifier, content: lowContent, trigger: nil)
             )
-            defaults.set(NotificationDeduplication.windowToken(for: resetDate), forKey: stateKey)
+            defaults.set(currentToken, forKey: stateKey)
         } catch {
             // Leave the state unset so a later refresh can retry delivery.
         }

--- a/ios/CodexMeterTests/LiveCodexServiceTests.swift
+++ b/ios/CodexMeterTests/LiveCodexServiceTests.swift
@@ -354,28 +354,42 @@ final class LiveCodexServiceTests: XCTestCase {
 
     func testNotificationDedupeKeysAreStablePerMetricAndWindow() {
         let reset = Date(timeIntervalSince1970: 1_800_000_000)
-        let first = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour, resetDate: reset)
-        let duplicate = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour, resetDate: reset)
-        let otherMetric = NotificationDeduplication.lowUsageIdentifier(metric: .weekly, resetDate: reset)
-        let otherWindow = NotificationDeduplication.lowUsageIdentifier(
-            metric: .fiveHour,
-            resetDate: reset.addingTimeInterval(1)
-        )
+        let fiveHourSeconds: Int64 = 18_000
+        let first = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour)
+        let duplicate = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour)
+        let otherMetric = NotificationDeduplication.lowUsageIdentifier(metric: .weekly)
 
         XCTAssertEqual(first, duplicate)
         XCTAssertNotEqual(first, otherMetric)
-        XCTAssertNotEqual(first, otherWindow)
         let token = NotificationDeduplication.windowToken(for: reset)
         XCTAssertFalse(
             NotificationDeduplication.shouldDeliverLowUsage(
                 lastDeliveredWindowToken: token,
-                resetDate: reset
+                resetDate: reset,
+                windowSeconds: fiveHourSeconds
             )
         )
+        // Small API reset drift must not re-arm the one-shot low-usage alert.
+        XCTAssertFalse(
+            NotificationDeduplication.shouldDeliverLowUsage(
+                lastDeliveredWindowToken: token,
+                resetDate: reset.addingTimeInterval(1),
+                windowSeconds: fiveHourSeconds
+            )
+        )
+        XCTAssertFalse(
+            NotificationDeduplication.shouldDeliverLowUsage(
+                lastDeliveredWindowToken: token,
+                resetDate: reset.addingTimeInterval(60),
+                windowSeconds: fiveHourSeconds
+            )
+        )
+        // A real next window (hours later) should notify again.
         XCTAssertTrue(
             NotificationDeduplication.shouldDeliverLowUsage(
                 lastDeliveredWindowToken: token,
-                resetDate: reset.addingTimeInterval(1)
+                resetDate: reset.addingTimeInterval(TimeInterval(fiveHourSeconds)),
+                windowSeconds: fiveHourSeconds
             )
         )
         XCTAssertNotEqual(
@@ -386,14 +400,8 @@ final class LiveCodexServiceTests: XCTestCase {
 
     func testNotificationCleanupRemovesOnlyObsoleteWindowIdentifiers() {
         let reset = Date(timeIntervalSince1970: 1_800_000_000)
-        let keptLow = NotificationDeduplication.lowUsageIdentifier(
-            metric: .fiveHour,
-            resetDate: reset
-        )
-        let obsoleteLow = NotificationDeduplication.lowUsageIdentifier(
-            metric: .weekly,
-            resetDate: reset
-        )
+        let keptLow = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour)
+        let obsoleteLow = NotificationDeduplication.lowUsageIdentifier(metric: .weekly)
         let keptReset = NotificationDeduplication.resetIdentifier(
             metric: .fiveHour,
             resetDate: reset


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Low-usage alerts kept re-firing every adaptive refresh (~5–15 minutes while near the threshold) even though they are supposed to be one-shot per usage window.

Root cause: dedupe keyed off an **exact** reset timestamp. OpenAI’s `reset_at` / `reset_after_seconds` values drift slightly across refreshes, so each poll looked like a “new” window and posted another notification.

## Fix
- Match usage windows with the same reset-time tolerance already used by local usage history (1–15 minutes depending on window length).
- Update the stored announced reset when still within tolerance so slow drift cannot eventually re-arm the alert.
- Android: use `effectiveResetAtMillis`, set `onlyAlertOnce` on low-usage posts.
- iOS: same tolerance logic; stable per-metric low-usage notification identifiers.

## Testing
- `./run-tests.sh` (includes new `testLowUsageAlertDedup`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b075f02e-9477-4e93-983d-020a051456f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b075f02e-9477-4e93-983d-020a051456f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

