### PR TITLE
Prepare Codex Meter 2.6.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2.6.8 — 2026-07-30
+
+### Added
+
+- Home and Samsung lock widget layout and meter customization: choose Adaptive by size, Dials, or Progress bars, and pick which Codex 5-hour/weekly, Spark (and other additional limits), next-reset, and reset-credits meters fill the available slots (#81).
+
+### Changed
+
+- Reset-credit cards auto-hide when no resets are available (or inventory is unknown), even if the Edit dashboard / Settings toggle is on (#80).
+- Usage history stays off the Android dashboard until OpenAI reports a 5-hour or weekly window that can feed a burn chart (#80).
+- Usage-credit balances on iOS now hide when zero, near-zero, or negative, matching Android (#80).
+
+### Fixed
+
+- Low-usage alerts no longer re-fire every adaptive refresh when OpenAI's reset timestamp drifts slightly within the same usage window; dedupe uses the same reset-time tolerance as local usage history (#82).
+
+### Development
+
+- Expanded regression coverage for widget meter catalogs, capacity/layout preferences, stale meter fallbacks, reset-credit auto-hide, and low-usage alert dedupe (#80, #81, #82).
+
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.6.7...v2.6.8 <!-- pragma: allowlist secret -->
+
 ## 2.6.7 — 2026-07-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
 
-## Android — Version 2.6.5
+## Android — Version 2.6.8
 
-Version 2.6.5 adds local usage history with burn charts, responsive single-dial widgets, One UI Watch modular tiles and adaptive complications, drag-to-reorder dashboard sections, and automatic hiding of empty usage-credit balances.
+Version 2.6.8 adds home and lock widget layout and meter customization (Adaptive / Dials / Progress bars plus per-meter slot selection), auto-hides empty reset-credit and usage-history dashboard cards, and stops low-usage alerts from re-firing when OpenAI's reset timestamp drifts within the same window.
 
 On compatible Galaxy Watches, those five standard AndroidX Tiles also advertise Samsung's private modular-card hints: the overview requests a 2×2 footprint and the focused usage, reset, and monitor Tiles request 2×1 footprints. Their diagonal One UI gradient cards use the same rounded 228-degree usage-dial geometry and One UI Sans typography as the phone's battery-style widgets. Other Wear OS tile hosts ignore the sizing hints and keep the normal full-screen carousel presentation. Samsung does not document third-party eligibility for modular placement, so final grid behavior remains firmware-dependent.
 
@@ -34,8 +34,8 @@ Users can choose silent, notification-sound, or alarm-sound alerts for the five-
 
 The app includes:
 
-- Responsive home-screen widgets with ring, four-dial, and battery-list layouts selected for the available size.
-- Both-window, five-hour-only, and weekly-only configurations.
+- Responsive home-screen widgets with ring, four-dial, and battery-list layouts, plus Adaptive / Dials / Progress bars layout preference and configurable meter slots (Codex windows, additional model limits, next reset, reset credits).
+- Both-window, five-hour-only, and weekly-only configurations (legacy metric mode; meters checklist supersedes this when customized).
 - Optional reset-credit inventory, expiration, and redemption controls.
 - Transparent through opaque backgrounds, including a Background off toggle and three One UI-style opacity steps.
 - Samsung One UI presentation throughout the dashboard, settings, and widget configuration surfaces.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 25
-        versionName = "2.6.7"
+        versionCode = 26
+        versionName = "2.6.8"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 25;
-    public static final String VERSION_NAME = "2.6.7";
+    public static final int VERSION_CODE = 26;
+    public static final String VERSION_NAME = "2.6.8";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.6.7 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.6.8 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.6.7"
+VERSION_NAME="2.6.8"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -71,14 +71,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.6.7"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 25' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.6.7"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 25' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.6.7"' "$ROOT/wear/build.gradle.kts"
-grep -q 'versionCode = 25' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.6.7' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.6.7"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.6.8"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 26' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.6.8"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 26' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.6.8"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionCode = 26' "$ROOT/wear/build.gradle.kts"
+grep -q 'codex-meter-android/2.6.8' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.6.8"' "$ROOT/build.sh"
 WORKFLOW="$ROOT/../.github/workflows/build-apk.yml"
 grep -Fq 'release-dist/CodexMeter-Wear-$VERSION_NAME.apk' "$WORKFLOW"
 grep -Fq '"platforms;android-37.0"' "$WORKFLOW"

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -415,7 +415,7 @@ public final class ParserSelfTest {
         check(!clearRoundTrip.signedIn,
                 "Wear usage clear payload preserves signed-out state");
         WearSyncStatus status = new WearSyncStatus(true, true, 3000L,
-                "Network unavailable", "2.6.5", 4000L);
+                "Network unavailable", "2.6.8", 4000L);
         WearSyncStatus statusRoundTrip = WearSyncStatus.fromJson(status.toJson());
         check(statusRoundTrip != null && statusRoundTrip.signedIn,
                 "Wear status preserves phone sign-in state");

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 25
-        versionName = "2.6.7"
+        versionCode = 26
+        versionName = "2.6.8"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump Android phone + Wear to version code **26** / **2.6.8** across Gradle, `AppConstants`, `build.sh`, and release self-checks.
- Document post-`v2.6.7` changes from merged PRs **#80**, **#81**, and **#82** in `CHANGELOG.md` and refresh the README version blurb.

### Included since v2.6.7

- **#81** — Home and lock widget layout + meter customization (Adaptive / Dials / Progress bars; per-meter slot selection)
- **#80** — Auto-hide empty reset-credit and usage-history dashboard cards (Android + iOS usage-credit parity)
- **#82** — Fix low-usage alert spam from OpenAI reset-time drift

This PR only prepares version metadata and release notes — it does **not** create the `v2.6.8` tag or GitHub Release. After merge, tagging `v2.6.8` on the merge commit will trigger CI to publish the signed phone + Wear APKs.

## Testing

- `./run-tests.sh` passed (parser/updater/OAuth/onboarding/widget/Wear checks + version guards for 2.6.8 / code 26)
- `./build.sh` produced `android/dist/CodexMeter-2.6.8.apk` and `CodexMeter-Wear-2.6.8.apk` (APK Signature Scheme v2)
- `./lint.sh` passed (`:app:lintRelease` + `:wear:lintRelease`)
- [ ] Tag `v2.6.8` after merge (will push/create release once instructed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4eae7aa-5d87-4275-9489-93d602ec6d0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4eae7aa-5d87-4275-9489-93d602ec6d0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

