### PR TITLE
Prepare Codex Meter 2.6.9: widget Spark cleanup, blank placeholders, meter reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.6.9 — 2026-07-31
+
+### Changed
+
+- Home and lock widgets no longer offer GPT-5.3-Codex-Spark or other model-specific additional limits; those stay on the in-app dashboard while widgets stick to Codex 5-hour/weekly, next-reset, and reset-credit meters (#84).
+- Customize widget meters can be drag-reordered (handle or long-press) so slot priority matches the user’s order, matching Edit dashboard (#84).
+- Edit dashboard / Settings visibility switches keep toggled-on sections on screen with a blank dash placeholder when OpenAI has not reported data yet, instead of auto-hiding empty cards inconsistently (#84).
+
+### Fixed
+
+- Selected widget meters that fail to resolve no longer collapse away; they keep a reserved blank dash slot (#84).
+
+### Development
+
+- Regression coverage and static checks updated for the Spark-free widget catalog, dashboard placeholder visibility, and widget meter drag reorder (#84).
+
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.8...v2.6.9 <!-- pragma: allowlist secret -->
+
 ## 2.6.8 — 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
 
-## Android — Version 2.6.8
+## Android — Version 2.6.9
 
-Version 2.6.8 adds home and lock widget layout and meter customization (Adaptive / Dials / Progress bars plus per-meter slot selection), auto-hides empty reset-credit and usage-history dashboard cards, and stops low-usage alerts from re-firing when OpenAI's reset timestamp drifts within the same window.
+Version 2.6.9 drops Spark and other model-specific limits from home and lock widgets, keeps toggled-on dashboard sections as blank dash placeholders instead of auto-hiding them, and adds drag-to-reorder for widget meter selection.
 
 On compatible Galaxy Watches, those five standard AndroidX Tiles also advertise Samsung's private modular-card hints: the overview requests a 2×2 footprint and the focused usage, reset, and monitor Tiles request 2×1 footprints. Their diagonal One UI gradient cards use the same rounded 228-degree usage-dial geometry and One UI Sans typography as the phone's battery-style widgets. Other Wear OS tile hosts ignore the sizing hints and keep the normal full-screen carousel presentation. Samsung does not document third-party eligibility for modular placement, so final grid behavior remains firmware-dependent.
 
@@ -34,7 +34,7 @@ Users can choose silent, notification-sound, or alarm-sound alerts for the five-
 
 The app includes:
 
-- Responsive home-screen widgets with ring, four-dial, and battery-list layouts, plus Adaptive / Dials / Progress bars layout preference and configurable meter slots (Codex windows, additional model limits, next reset, reset credits).
+- Responsive home-screen widgets with ring, four-dial, and battery-list layouts, plus Adaptive / Dials / Progress bars layout preference and drag-reorderable meter slots (Codex 5-hour/weekly, next reset, reset credits).
 - Both-window, five-hour-only, and weekly-only configurations (legacy metric mode; meters checklist supersedes this when customized).
 - Optional reset-credit inventory, expiration, and redemption controls.
 - Transparent through opaque backgrounds, including a Background off toggle and three One UI-style opacity steps.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 26
-        versionName = "2.6.8"
+        versionCode = 27
+        versionName = "2.6.9"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 26;
-    public static final String VERSION_NAME = "2.6.8";
+    public static final int VERSION_CODE = 27;
+    public static final String VERSION_NAME = "2.6.9";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.6.8 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.6.9 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
@@ -78,10 +78,9 @@ public final class DashboardReorderActivity extends AppCompatActivity {
         content.addView(listCard);
 
         TextView note = Ui.text(this,
-                "Changes are saved instantly. Usage-credit balance and reset credits stay hidden "
-                        + "when they have nothing to show (zero or below), and 5-hour, weekly, "
-                        + "and usage-history cards appear only while OpenAI reports data for them "
-                        + "— no matter where each card is placed or whether its switch is on.",
+                "Changes are saved instantly. Toggled-on sections always keep their place on the "
+                        + "dashboard — when OpenAI has not reported data yet, the card shows a blank "
+                        + "dash placeholder instead of disappearing.",
                 12.0f, Ui.secondaryText(dark));
         LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(-1, -2);
         noteParams.setMargins(Ui.dp(this, 6), Ui.dp(this, 14), Ui.dp(this, 6), 0);
@@ -107,13 +106,13 @@ public final class DashboardReorderActivity extends AppCompatActivity {
                 items.add(new SectionItem(key, "Weekly limit", "Rolling 7-day Codex window"));
             } else if (DashboardSections.USAGE_CREDITS.equals(key)) {
                 items.add(new SectionItem(key, "Usage-credit balance",
-                        "Hidden automatically at a zero or negative balance"));
+                        "Shows a blank dash when no balance is available"));
             } else if (DashboardSections.USAGE_HISTORY.equals(key)) {
                 items.add(new SectionItem(key, "Usage history",
-                        "Shown only when a 5-hour or weekly window is available"));
+                        "Shows a placeholder until burn charts have data"));
             } else if (DashboardSections.RESET_CREDITS.equals(key)) {
                 items.add(new SectionItem(key, "Reset credits",
-                        "Hidden automatically when no resets are available"));
+                        "Shows a blank state when no resets are available"));
             } else {
                 UsageLimit match = null;
                 for (UsageLimit limit : limits) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
@@ -79,8 +79,8 @@ public final class DashboardReorderActivity extends AppCompatActivity {
 
         TextView note = Ui.text(this,
                 "Changes are saved instantly. Toggled-on sections always keep their place on the "
-                        + "dashboard — when OpenAI has not reported data yet, the card shows a blank "
-                        + "dash placeholder instead of disappearing.",
+                        + "dashboard — when OpenAI has not reported data yet, the card shows a "
+                        + "blank dash placeholder instead of disappearing.",
                 12.0f, Ui.secondaryText(dark));
         LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(-1, -2);
         noteParams.setMargins(Ui.dp(this, 6), Ui.dp(this, 14), Ui.dp(this, 6), 0);

--- a/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
@@ -63,8 +63,7 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
         LockWidgetOptions saved = AppPreferences.loadLockWidgetOptions(this, this.appWidgetId);
         this.selectedMeters.clear();
         for (String key : WidgetMeters.parse(saved.effectiveVisibleMeters())) {
-            if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)
-                    || WidgetMeters.isLimitKey(key)) {
+            if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)) {
                 this.selectedMeters.add(key);
             }
         }
@@ -82,13 +81,24 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
         UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
         List<String> available = new ArrayList<>();
         for (String key : WidgetMeters.availableKeys(snapshot)) {
-            if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)
-                    || WidgetMeters.isLimitKey(key)) {
+            if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)) {
                 available.add(key);
             }
         }
-        boolean first = true;
+        // Prefer saved selection order so the first enabled meter stays primary.
+        List<String> ordered = new ArrayList<>();
+        for (String key : this.selectedMeters) {
+            if (available.contains(key) && !ordered.contains(key)) {
+                ordered.add(key);
+            }
+        }
         for (String key : available) {
+            if (!ordered.contains(key)) {
+                ordered.add(key);
+            }
+        }
+        boolean first = true;
+        for (String key : ordered) {
             SwitchCompat toggle = new SwitchCompat(this);
             toggle.setChecked(this.selectedMeters.contains(key));
             metersCard.addView(buildSwitchRow(WidgetMeters.configLabel(key, snapshot), toggle,
@@ -179,7 +189,13 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
     }
 
     private LockWidgetOptions currentOptions() {
-        String visible = WidgetMeters.serialize(new ArrayList<>(this.selectedMeters));
+        List<String> ordered = new ArrayList<>();
+        for (String key : this.selectedMeters) {
+            if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)) {
+                ordered.add(key);
+            }
+        }
+        String visible = WidgetMeters.serialize(ordered);
         boolean five = this.selectedMeters.contains(WidgetMeters.FIVE_HOUR);
         boolean weekly = this.selectedMeters.contains(WidgetMeters.WEEKLY);
         String metricMode = WidgetOptions.METRIC_BOTH;

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -349,33 +349,29 @@ public final class MainActivity extends AppCompatActivity {
                 }
                 group.add(limit);
             }
-            if (AppPreferences.showDashboardFiveHour(this) && snapshot.fiveHour != null) {
-                available.add(DashboardSections.FIVE_HOUR);
-            }
-            if (AppPreferences.showDashboardWeekly(this) && snapshot.weekly != null) {
-                available.add(DashboardSections.WEEKLY);
-            }
-            if (AppPreferences.showDashboardAdditionalLimits(this)) {
-                for (String key : limitsByKey.keySet()) {
-                    if (!AppPreferences.isDashboardSectionHidden(this, key)) {
-                        available.add(key);
-                    }
+        }
+        // Visibility switches win: toggled-on sections keep a blank/dash placeholder when
+        // OpenAI has not reported data yet, instead of disappearing inconsistently.
+        if (AppPreferences.showDashboardFiveHour(this)) {
+            available.add(DashboardSections.FIVE_HOUR);
+        }
+        if (AppPreferences.showDashboardWeekly(this)) {
+            available.add(DashboardSections.WEEKLY);
+        }
+        if (AppPreferences.showDashboardAdditionalLimits(this)) {
+            for (String key : limitsByKey.keySet()) {
+                if (!AppPreferences.isDashboardSectionHidden(this, key)) {
+                    available.add(key);
                 }
             }
-            // Zero, near-zero, and negative balances are always hidden regardless of settings.
-            if (AppPreferences.showDashboardUsageCredits(this) && snapshot.usageCredits != null
-                    && snapshot.usageCredits.shouldDisplay()) {
-                available.add(DashboardSections.USAGE_CREDITS);
-            }
-            // Usage history only appears once at least one window can feed a burn chart.
-            if (AppPreferences.showDashboardUsageHistory(this)
-                    && snapshot.fetchedAtMillis > 0L
-                    && (snapshot.fiveHour != null || snapshot.weekly != null)) {
-                available.add(DashboardSections.USAGE_HISTORY);
-            }
         }
-        // Zero available resets always hide the card, even when the Edit dashboard switch is on.
-        if (AppPreferences.showDashboardResetCredits(this) && shouldShowResetCreditsCard(snapshot)) {
+        if (AppPreferences.showDashboardUsageCredits(this)) {
+            available.add(DashboardSections.USAGE_CREDITS);
+        }
+        if (AppPreferences.showDashboardUsageHistory(this)) {
+            available.add(DashboardSections.USAGE_HISTORY);
+        }
+        if (AppPreferences.showDashboardResetCredits(this)) {
             available.add(DashboardSections.RESET_CREDITS);
         }
         boolean inverted = false;
@@ -383,14 +379,17 @@ public final class MainActivity extends AppCompatActivity {
                 AppPreferences.getDashboardOrder(this), available)) {
             if (DashboardSections.FIVE_HOUR.equals(key)) {
                 addDashboardCard(column, buildMetricCard(
-                        "5-hour", snapshot, snapshot.fiveHour, inverted));
+                        "5-hour", snapshot, snapshot == null ? null : snapshot.fiveHour,
+                        inverted));
                 inverted = !inverted;
             } else if (DashboardSections.WEEKLY.equals(key)) {
                 addDashboardCard(column, buildMetricCard(
-                        "Weekly", snapshot, snapshot.weekly, inverted));
+                        "Weekly", snapshot, snapshot == null ? null : snapshot.weekly,
+                        inverted));
                 inverted = !inverted;
             } else if (DashboardSections.USAGE_CREDITS.equals(key)) {
-                addDashboardCard(column, buildUsageCreditsCard(snapshot.usageCredits));
+                addDashboardCard(column, buildUsageCreditsCard(
+                        snapshot == null ? null : snapshot.usageCredits));
             } else if (DashboardSections.USAGE_HISTORY.equals(key)) {
                 addDashboardCard(column, buildUsageHistoryCard());
             } else if (DashboardSections.RESET_CREDITS.equals(key)) {
@@ -432,15 +431,24 @@ public final class MainActivity extends AppCompatActivity {
         card.setPadding(0, 0, 0, 0);
         card.setMinimumHeight(Ui.dp(this, 103.0f));
         long now = System.currentTimeMillis();
-        String reset = UsageFormat.reset(this, window, WidgetOptions.RESET_RELATIVE,
-                snapshot.fetchedAtMillis, now);
-        UsagePace.Assessment pace = UsagePacePreferences.assess(this, snapshot, window, now);
         UsageWaveView wave = new UsageWaveView(this);
-        wave.setUsage(label, reset, UsageFormat.estimatedRemaining(pace),
-                window.remainingPercent(),
-                window.windowSeconds >= 86_400L
-                        ? R.drawable.ic_oui_calendar_week : R.drawable.ic_oui_time,
-                invertedWave, pace.accelerated);
+        int icon = R.drawable.ic_oui_time;
+        if (window != null && window.windowSeconds >= 86_400L) {
+            icon = R.drawable.ic_oui_calendar_week;
+        } else if (label != null && label.toLowerCase(java.util.Locale.ROOT).contains("week")) {
+            icon = R.drawable.ic_oui_calendar_week;
+        }
+        if (window == null) {
+            wave.setUsage(label, "Waiting for OpenAI to report this window", "", -1, icon,
+                    invertedWave, false);
+        } else {
+            long fetchedAt = snapshot == null ? 0L : snapshot.fetchedAtMillis;
+            String reset = UsageFormat.reset(this, window, WidgetOptions.RESET_RELATIVE,
+                    fetchedAt, now);
+            UsagePace.Assessment pace = UsagePacePreferences.assess(this, snapshot, window, now);
+            wave.setUsage(label, reset, UsageFormat.estimatedRemaining(pace),
+                    window.remainingPercent(), icon, invertedWave, pace.accelerated);
+        }
         card.addView(wave, new LinearLayout.LayoutParams(-1, Ui.dp(this, 103.0f)));
         return card;
     }
@@ -510,8 +518,13 @@ public final class MainActivity extends AppCompatActivity {
         TextView title = Ui.text(this, "Usage credits", 18, Ui.mainText(this.dark));
         title.setTypeface(Ui.mediumTypeface(this));
         card.addView(title);
-        card.addView(buildIconDetailRow(R.drawable.ic_oui_credit_card_outline,
-                usageCreditBalance(credits), usageCreditsSummary(credits)));
+        if (credits == null || !credits.shouldDisplay()) {
+            card.addView(buildIconDetailRow(R.drawable.ic_oui_credit_card_outline,
+                    "—", "No usage-credit balance to show yet"));
+        } else {
+            card.addView(buildIconDetailRow(R.drawable.ic_oui_credit_card_outline,
+                    usageCreditBalance(credits), usageCreditsSummary(credits)));
+        }
         return card;
     }
 
@@ -729,7 +742,7 @@ public final class MainActivity extends AppCompatActivity {
             return "Reset credits";
         }
         if (available <= 0) {
-            return "No resets available";
+            return "—";
         }
         if (available == 1) {
             return "1 reset available";
@@ -749,24 +762,11 @@ public final class MainActivity extends AppCompatActivity {
         if (available > 0) {
             return "Expiration details unavailable";
         }
-        return "Earn credits from ChatGPT Codex";
+        return "No resets available yet";
     }
 
     private void openResetCredits() {
         Ui.startSecondaryActivity(this, ResetCreditActivity.class);
-    }
-
-    /**
-     * Prefer the detailed reset-credits cache; fall back to the usage-endpoint summary count.
-     * Unknown inventory never surfaces an empty card.
-     */
-    private boolean shouldShowResetCreditsCard(UsageSnapshot snapshot) {
-        ResetCreditsSnapshot credits = AppPreferences.loadResetCredits(this);
-        if (credits != null) {
-            return credits.shouldDisplay();
-        }
-        return snapshot != null
-                && ResetCreditsSnapshot.shouldDisplayCount(snapshot.resetCreditsAvailable);
     }
 
     private LinearLayout buildWidgetCard() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java
@@ -31,9 +31,8 @@ public final class ResetCreditsSnapshot {
     }
 
     /**
-     * Whether inventory is worth surfacing on the dashboard. Zero available resets always
-     * hide the card, even when the Edit dashboard switch is on — matching usage-credit
-     * auto-hide and data-gated 5-hour / weekly cards.
+     * Whether inventory has at least one available reset. Dashboard cards that the user
+     * explicitly enabled still render a blank state when this returns false.
      */
     public boolean shouldDisplay() {
         return availableCount > 0;
@@ -41,7 +40,7 @@ public final class ResetCreditsSnapshot {
 
     /**
      * Same rule for a summary count from the usage endpoint when the detailed credits
-     * snapshot is not cached yet. Negative / unknown counts never display.
+     * snapshot is not cached yet.
      */
     public static boolean shouldDisplayCount(int availableCount) {
         return availableCount > 0;

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
@@ -30,6 +30,7 @@ public final class UsageWaveView extends View {
     private String resetBottom = "";
     private String pace = "";
     private int percent;
+    private boolean unavailable;
     private boolean warning;
     private float phase;
     private float phaseOffset;
@@ -51,14 +52,18 @@ public final class UsageWaveView extends View {
     public void setUsage(String label, String reset, String paceEstimate, int remainingPercent,
             int iconRes, boolean invertedWave, boolean acceleratedWarning) {
         title = label;
-        percent = Math.max(0, Math.min(100, remainingPercent));
+        unavailable = remainingPercent < 0;
+        percent = unavailable ? 0 : Math.max(0, Math.min(100, remainingPercent));
         pace = paceEstimate == null ? "" : paceEstimate;
-        warning = acceleratedWarning;
+        warning = !unavailable && acceleratedWarning;
         if (animator != null) {
             animator.setDuration(warning ? WARNING_WAVE_DURATION_MS : NORMAL_WAVE_DURATION_MS);
         }
         phaseOffset = invertedWave ? (float) Math.PI : 0f;
-        if (reset != null && reset.startsWith("Resets in ")) {
+        if (unavailable) {
+            resetTop = reset == null || reset.isEmpty() ? "Unavailable" : reset;
+            resetBottom = "";
+        } else if (reset != null && reset.startsWith("Resets in ")) {
             resetTop = "Resets in";
             resetBottom = reset.substring("Resets in ".length());
         } else {
@@ -66,9 +71,15 @@ public final class UsageWaveView extends View {
             resetBottom = "";
         }
         icon = AppCompatResources.getDrawable(getContext(), iconRes);
-        String description = label + ", " + percent + " percent. " + reset;
-        if (!pace.isEmpty()) description += ". " + pace.replace("Est.", "Estimated");
-        if (warning) description += ". Accelerated usage warning";
+        String description = unavailable
+                ? label + ", unavailable. " + resetTop
+                : label + ", " + percent + " percent. " + reset;
+        if (!unavailable && !pace.isEmpty()) {
+            description += ". " + pace.replace("Est.", "Estimated");
+        }
+        if (warning) {
+            description += ". Accelerated usage warning";
+        }
         setContentDescription(description);
         invalidate();
     }
@@ -159,6 +170,7 @@ public final class UsageWaveView extends View {
         }
         percentPaint.setColor(foreground);
         percentPaint.setTextSize(22f * density);
-        canvas.drawText(percent + "%", rightCenter, 85f * density, percentPaint);
+        canvas.drawText(unavailable ? "—" : percent + "%", rightCenter, 85f * density,
+                percentPaint);
     }
 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
@@ -3,13 +3,16 @@ package dev.bennett.codexmeter;
 import android.annotation.SuppressLint;
 import android.appwidget.AppWidgetManager;
 import android.content.Intent;
+import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
@@ -21,11 +24,15 @@ import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.SeslSeekBar;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import dev.oneuiproject.oneui.widget.CardItemView;
 import dev.oneuiproject.oneui.widget.RadioItemView;
 import dev.oneuiproject.oneui.widget.RadioItemViewGroup;
 import dev.oneuiproject.oneui.widget.RoundedLinearLayout;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -48,6 +55,9 @@ public final class WidgetConfigActivity extends AppCompatActivity {
     private Spinner themeSpinner;
     private CardItemView themeRow;
     private TextView metersHint;
+    private RecyclerView metersList;
+    private MeterAdapter meterAdapter;
+    private final List<String> meterOrder = new ArrayList<>();
     private final LinkedHashSet<String> selectedMeters = new LinkedHashSet<>();
     private String tapAction = WidgetOptions.TAP_OPEN_APP;
     private final int tapOpenId = View.generateViewId();
@@ -91,8 +101,8 @@ public final class WidgetConfigActivity extends AppCompatActivity {
 
         WidgetOptions saved = AppPreferences.loadWidgetOptions(this, this.appWidgetId);
         this.tapAction = AppPreferences.getWidgetTapAction(this, this.appWidgetId);
-        this.selectedMeters.clear();
-        this.selectedMeters.addAll(WidgetMeters.parse(saved.effectiveVisibleMeters()));
+        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
+        loadMeterSelection(saved, snapshot);
 
         content.addView(Ui.separator(this, "Appearance"));
         RoundedLinearLayout appearanceCard = Ui.seslRowCard(this, this.dark);
@@ -142,30 +152,21 @@ public final class WidgetConfigActivity extends AppCompatActivity {
         this.metersHint.setPadding(Ui.dp(this, 20), Ui.dp(this, 12), Ui.dp(this, 20),
                 Ui.dp(this, 4));
         metersCard.addView(this.metersHint);
-        UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
-        List<String> available = WidgetMeters.availableKeys(snapshot);
-        boolean firstMeter = true;
-        for (String key : available) {
-            SwitchCompat toggle = new SwitchCompat(this);
-            toggle.setChecked(this.selectedMeters.contains(key));
-            String label = WidgetMeters.configLabel(key, snapshot);
-            metersCard.addView(buildSwitchRow(label, toggle, !firstMeter));
-            firstMeter = false;
-            toggle.setOnCheckedChangeListener((button, checked) -> {
-                if (checked) {
-                    this.selectedMeters.add(key);
-                } else {
-                    this.selectedMeters.remove(key);
-                    if (this.selectedMeters.isEmpty()) {
-                        this.selectedMeters.add(key);
-                        button.setChecked(true);
-                        return;
-                    }
-                }
-                updateMetersHint();
-                renderPreview();
-            });
-        }
+        TextView reorderHint = Ui.text(this,
+                "Drag handles to choose which meters fill slots first. Empty selected meters "
+                        + "keep a blank dash on the widget.",
+                12, Ui.secondaryText(this.dark));
+        reorderHint.setPadding(Ui.dp(this, 20), 0, Ui.dp(this, 20), Ui.dp(this, 8));
+        metersCard.addView(reorderHint);
+        this.metersList = new RecyclerView(this);
+        this.metersList.setLayoutManager(new LinearLayoutManager(this));
+        this.metersList.setNestedScrollingEnabled(false);
+        this.meterAdapter = new MeterAdapter(snapshot);
+        this.metersList.setAdapter(this.meterAdapter);
+        ItemTouchHelper touchHelper = new ItemTouchHelper(new MeterReorderCallback());
+        touchHelper.attachToRecyclerView(this.metersList);
+        this.meterAdapter.touchHelper = touchHelper;
+        metersCard.addView(this.metersList, new LinearLayout.LayoutParams(-1, -2));
         content.addView(metersCard);
 
         content.addView(Ui.separator(this, "Content"));
@@ -351,7 +352,213 @@ public final class WidgetConfigActivity extends AppCompatActivity {
                 false, false, false, false, false, false)
                 .withPercentSymbol(this.percentSymbolSwitch == null
                         || this.percentSymbolSwitch.isChecked())
-                .withVisibleMeters(WidgetMeters.serialize(new ArrayList<>(this.selectedMeters)));
+                .withVisibleMeters(WidgetMeters.serialize(orderedSelectedMeters()));
+    }
+
+    private void loadMeterSelection(WidgetOptions saved, UsageSnapshot snapshot) {
+        List<String> available = WidgetMeters.availableKeys(snapshot);
+        List<String> savedVisible = WidgetMeters.parse(saved.effectiveVisibleMeters());
+        this.meterOrder.clear();
+        this.selectedMeters.clear();
+        for (String key : savedVisible) {
+            if (available.contains(key) && !this.meterOrder.contains(key)) {
+                this.meterOrder.add(key);
+                this.selectedMeters.add(key);
+            }
+        }
+        for (String key : available) {
+            if (!this.meterOrder.contains(key)) {
+                this.meterOrder.add(key);
+            }
+        }
+        if (this.selectedMeters.isEmpty() && !this.meterOrder.isEmpty()) {
+            this.selectedMeters.add(this.meterOrder.get(0));
+        }
+    }
+
+    private List<String> orderedSelectedMeters() {
+        List<String> ordered = new ArrayList<>();
+        for (String key : this.meterOrder) {
+            if (this.selectedMeters.contains(key)) {
+                ordered.add(key);
+            }
+        }
+        return ordered;
+    }
+
+    private void lockMeterListScrolling() {
+        if (this.metersList != null && this.metersList.getParent() != null) {
+            this.metersList.getParent().requestDisallowInterceptTouchEvent(true);
+        }
+    }
+
+    private final class MeterAdapter extends RecyclerView.Adapter<MeterHolder> {
+        ItemTouchHelper touchHelper;
+        private final UsageSnapshot snapshot;
+
+        MeterAdapter(UsageSnapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public MeterHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            LinearLayout row = Ui.horizontal(WidgetConfigActivity.this, Gravity.CENTER_VERTICAL);
+            row.setMinimumHeight(Ui.dp(WidgetConfigActivity.this, 64));
+            row.setPadding(Ui.dp(WidgetConfigActivity.this, 20),
+                    Ui.dp(WidgetConfigActivity.this, 8),
+                    Ui.dp(WidgetConfigActivity.this, 12),
+                    Ui.dp(WidgetConfigActivity.this, 8));
+            row.setLayoutParams(new RecyclerView.LayoutParams(-1, -2));
+
+            TextView title = Ui.text(WidgetConfigActivity.this, "", 17.0f,
+                    Ui.mainText(WidgetConfigActivity.this.dark));
+            row.addView(title, new LinearLayout.LayoutParams(0, -2, 1.0f));
+
+            SwitchCompat toggle = new SwitchCompat(WidgetConfigActivity.this);
+            toggle.setContentDescription("Show on widget");
+            LinearLayout.LayoutParams toggleParams = new LinearLayout.LayoutParams(-2, -2);
+            toggleParams.setMargins(Ui.dp(WidgetConfigActivity.this, 8), 0,
+                    Ui.dp(WidgetConfigActivity.this, 4), 0);
+            row.addView(toggle, toggleParams);
+
+            ImageView handle = new ImageView(WidgetConfigActivity.this);
+            handle.setImageResource(R.drawable.ic_oui_reorder);
+            handle.setImageTintList(ColorStateList.valueOf(
+                    Ui.secondaryText(WidgetConfigActivity.this.dark)));
+            handle.setContentDescription("Reorder");
+            int pad = Ui.dp(WidgetConfigActivity.this, 12);
+            handle.setPadding(pad, pad, pad, pad);
+            row.addView(handle, new LinearLayout.LayoutParams(
+                    Ui.dp(WidgetConfigActivity.this, 48),
+                    Ui.dp(WidgetConfigActivity.this, 48)));
+
+            MeterHolder holder = new MeterHolder(row, title, toggle, handle);
+            bindDragHandle(holder);
+            return holder;
+        }
+
+        @SuppressLint("ClickableViewAccessibility")
+        private void bindDragHandle(MeterHolder holder) {
+            holder.handle.setOnTouchListener((view, event) -> {
+                if (event.getActionMasked() == MotionEvent.ACTION_DOWN && touchHelper != null) {
+                    lockMeterListScrolling();
+                    touchHelper.startDrag(holder);
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        @Override
+        public void onBindViewHolder(MeterHolder holder, int position) {
+            String key = meterOrder.get(position);
+            holder.title.setText(WidgetMeters.configLabel(key, snapshot));
+            holder.toggle.setOnCheckedChangeListener(null);
+            boolean visible = selectedMeters.contains(key);
+            holder.toggle.setChecked(visible);
+            applyRowVisibility(holder, visible);
+            holder.toggle.setOnCheckedChangeListener((button, checked) -> {
+                int pos = holder.getBindingAdapterPosition();
+                if (pos < 0 || pos >= meterOrder.size()) {
+                    return;
+                }
+                String rowKey = meterOrder.get(pos);
+                if (checked) {
+                    selectedMeters.add(rowKey);
+                } else {
+                    selectedMeters.remove(rowKey);
+                    if (selectedMeters.isEmpty()) {
+                        selectedMeters.add(rowKey);
+                        button.setChecked(true);
+                        return;
+                    }
+                }
+                applyRowVisibility(holder, button.isChecked());
+                updateMetersHint();
+                renderPreview();
+            });
+        }
+
+        private void applyRowVisibility(MeterHolder holder, boolean visible) {
+            float alpha = visible ? 1.0f : 0.45f;
+            holder.title.setAlpha(alpha);
+        }
+
+        @Override
+        public int getItemCount() {
+            return meterOrder.size();
+        }
+    }
+
+    private static final class MeterHolder extends RecyclerView.ViewHolder {
+        final TextView title;
+        final SwitchCompat toggle;
+        final ImageView handle;
+
+        MeterHolder(View row, TextView title, SwitchCompat toggle, ImageView handle) {
+            super(row);
+            this.title = title;
+            this.toggle = toggle;
+            this.handle = handle;
+        }
+    }
+
+    private final class MeterReorderCallback extends ItemTouchHelper.Callback {
+        @Override
+        public int getMovementFlags(RecyclerView recyclerView, RecyclerView.ViewHolder holder) {
+            return makeMovementFlags(ItemTouchHelper.UP | ItemTouchHelper.DOWN, 0);
+        }
+
+        @Override
+        public boolean isLongPressDragEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder from,
+                RecyclerView.ViewHolder to) {
+            int fromPosition = from.getBindingAdapterPosition();
+            int toPosition = to.getBindingAdapterPosition();
+            if (fromPosition < 0 || toPosition < 0) {
+                return false;
+            }
+            if (fromPosition < toPosition) {
+                for (int i = fromPosition; i < toPosition; i++) {
+                    Collections.swap(meterOrder, i, i + 1);
+                }
+            } else {
+                for (int i = fromPosition; i > toPosition; i--) {
+                    Collections.swap(meterOrder, i, i - 1);
+                }
+            }
+            recyclerView.getAdapter().notifyItemMoved(fromPosition, toPosition);
+            updateMetersHint();
+            renderPreview();
+            return true;
+        }
+
+        @Override
+        public void onSelectedChanged(RecyclerView.ViewHolder holder, int actionState) {
+            super.onSelectedChanged(holder, actionState);
+            if (actionState == ItemTouchHelper.ACTION_STATE_DRAG && holder != null) {
+                lockMeterListScrolling();
+                holder.itemView.setAlpha(0.85f);
+                holder.itemView.setElevation(Ui.dp(holder.itemView.getContext(), 4));
+            }
+        }
+
+        @Override
+        public void clearView(RecyclerView recyclerView, RecyclerView.ViewHolder holder) {
+            super.clearView(recyclerView, holder);
+            holder.itemView.setAlpha(1.0f);
+            holder.itemView.setElevation(0.0f);
+            updateMetersHint();
+            renderPreview();
+        }
+
+        @Override
+        public void onSwiped(RecyclerView.ViewHolder holder, int direction) {
+        }
     }
 
     private void updateRowSummaries() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -642,11 +642,27 @@ public final class WidgetRenderer {
         ArrayList<MeterSlot> slots = new ArrayList<>();
         for (String key : visible) {
             MeterSlot slot = buildSlot(key, snapshot, state, options, resetCount);
-            if (slot != null) {
-                slots.add(slot);
+            if (slot == null) {
+                // Keep the reserved slot so a toggled-on meter never collapses away.
+                slot = blankSlot(key, snapshot);
             }
+            slots.add(slot);
         }
         return slots;
+    }
+
+    private static MeterSlot blankSlot(String key, UsageSnapshot snapshot) {
+        String label = WidgetMeters.shortLabel(key, snapshot);
+        int icon = WidgetMeters.WEEKLY.equals(key)
+                || (WidgetMeters.isLimitKey(key) && !WidgetMeters.isLimitPrimary(key))
+                ? R.drawable.ic_oui_calendar_week
+                : R.drawable.ic_oui_time;
+        if (WidgetMeters.NEXT_RESET.equals(key)) {
+            icon = R.drawable.ic_oui_alarm;
+        } else if (WidgetMeters.RESET_CREDITS.equals(key)) {
+            icon = R.drawable.ic_oui_refresh;
+        }
+        return new MeterSlot(key, label, icon, -1, "—", "—", 100, true);
     }
 
     private static MeterSlot buildSlot(String key, UsageSnapshot snapshot, WidgetState state,

--- a/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
+++ b/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
@@ -28,12 +28,12 @@
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_five_hour"
-            android:summary="Shown only when OpenAI returns this window"
+            android:summary="Keeps a blank placeholder when this window is missing"
             android:title="5-hour limit" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_weekly"
-            android:summary="Shown only when OpenAI returns this window"
+            android:summary="Keeps a blank placeholder when this window is missing"
             android:title="Weekly limit" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
@@ -43,17 +43,17 @@
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_usage_credits"
-            android:summary="Hidden automatically at a zero or negative balance"
+            android:summary="Keeps a blank dash when the balance is empty"
             android:title="Usage-credit balance" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_usage_history"
-            android:summary="Shown only when a 5-hour or weekly window is available"
+            android:summary="Keeps a placeholder until burn charts have data"
             android:title="Usage history" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_reset_credits"
-            android:summary="Hidden automatically when no resets are available"
+            android:summary="Keeps a blank state when no resets are available"
             android:title="Reset credits" />
     </PreferenceCategory>
 

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.6.8"
+VERSION_NAME="2.6.9"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -71,14 +71,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.6.8"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 26' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.6.8"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 26' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.6.8"' "$ROOT/wear/build.gradle.kts"
-grep -q 'versionCode = 26' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.6.8' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.6.8"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.6.9"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 27' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.6.9"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 27' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.6.9"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionCode = 27' "$ROOT/wear/build.gradle.kts"
+grep -q 'codex-meter-android/2.6.9' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.6.9"' "$ROOT/build.sh"
 WORKFLOW="$ROOT/../.github/workflows/build-apk.yml"
 grep -Fq 'release-dist/CodexMeter-Wear-$VERSION_NAME.apk' "$WORKFLOW"
 grep -Fq '"platforms;android-37.0"' "$WORKFLOW"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -91,10 +91,6 @@ grep -q 'testUsageCreditsAutoHide' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'testResetCreditsAutoHide' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'testDashboardSectionOrder' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'DashboardReorderActivity' "$ROOT/app/src/main/AndroidManifest.xml"
-grep -q 'snapshot.usageCredits.shouldDisplay()' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
-grep -q 'shouldShowResetCreditsCard' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'public boolean shouldDisplay()' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java"
 grep -q 'DashboardSections.resolveOrder' \
@@ -124,18 +120,39 @@ grep -q 'dashboard_usage_history' \
 grep -q 'dashboard_hidden_sections' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
 grep -q 'hidden-section keys round-trip' "$ROOT/tests/ParserSelfTest.java"
-# Usage-history charts must be gated on real usage data instead of blank placeholders.
+# Usage-history charts still gate on real windows; the section itself stays when toggled on.
 grep -q 'fiveWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'weeklyWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'fiveWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
-# The usage-history section itself also hides until a window can feed a chart.
-grep -q 'snapshot.fiveHour != null || snapshot.weekly != null' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
-grep -q 'Hidden automatically when no resets are available' \
+grep -q 'blank dash placeholder' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java"
+grep -q 'Keeps a blank placeholder when this window is missing' \
+  "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
+# Toggled-on dashboard sections keep placeholders instead of auto-hiding.
+grep -q 'showDashboardFiveHour(this))' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'showDashboardUsageCredits(this))' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'showDashboardResetCredits(this))' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+! grep -q 'shouldShowResetCreditsCard' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+! grep -q 'snapshot.usageCredits.shouldDisplay()' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+# Widget meter catalog excludes Spark / additional model limits; config supports drag reorder.
+grep -q 'Model-specific additional limits' \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java"
+grep -q 'available meters exclude model-specific Spark limits' \
+  "$ROOT/tests/ParserSelfTest.java"
+grep -q 'ItemTouchHelper' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
+grep -q 'orderedSelectedMeters' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
+grep -q 'ic_oui_reorder' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
 
 # Reset/usage-credit dashboard cards use bold in-card titles with left-aligned icon rows,
 # matching the other dashboard cards, instead of external One UI separators or centered blocks.

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
@@ -24,10 +24,8 @@ public final class UsageCredits {
     }
 
     /**
-     * Whether the balance is worth surfacing anywhere in the UI. This is intentionally not
-     * configurable: zero, effectively-zero, and negative balances always hide the card, as does
-     * an account without purchased credits. Unlimited plans and unparseable non-empty balances
-     * remain visible.
+     * Whether the balance has a meaningful non-empty amount. Dashboard cards that the user
+     * explicitly enabled still render a blank dash when this returns false.
      */
     public boolean shouldDisplay() {
         if (unlimited) {

--- a/android/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java
@@ -129,24 +129,15 @@ public final class WidgetMeters {
         return identity.toLowerCase(Locale.ROOT).replace(',', '_');
     }
 
-    /** Catalog of meters that can be offered in config for the current snapshot. */
+    /**
+     * Catalog of meters that can be offered in widget config. Model-specific additional limits
+     * (for example GPT-5.3-Codex-Spark) stay on the in-app dashboard only — widgets stick to the
+     * Codex 5-hour/weekly windows plus next-reset and reset-credit helpers.
+     */
     public static List<String> availableKeys(UsageSnapshot snapshot) {
         LinkedHashSet<String> keys = new LinkedHashSet<>();
         keys.add(FIVE_HOUR);
         keys.add(WEEKLY);
-        if (snapshot != null && snapshot.additionalLimits != null) {
-            for (UsageLimit limit : snapshot.additionalLimits) {
-                if (limit == null) {
-                    continue;
-                }
-                if (limit.primary != null) {
-                    keys.add(limitPrimaryKey(limit));
-                }
-                if (limit.secondary != null) {
-                    keys.add(limitSecondaryKey(limit));
-                }
-            }
-        }
         keys.add(NEXT_RESET);
         keys.add(RESET_CREDITS);
         return new ArrayList<>(keys);
@@ -374,9 +365,6 @@ public final class WidgetMeters {
             return "Limit";
         }
         String trimmed = displayName.trim();
-        if (trimmed.toLowerCase(Locale.ROOT).contains("spark")) {
-            return "Spark";
-        }
         if (trimmed.length() <= 10) {
             return trimmed;
         }

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -415,7 +415,7 @@ public final class ParserSelfTest {
         check(!clearRoundTrip.signedIn,
                 "Wear usage clear payload preserves signed-out state");
         WearSyncStatus status = new WearSyncStatus(true, true, 3000L,
-                "Network unavailable", "2.6.8", 4000L);
+                "Network unavailable", "2.6.9", 4000L);
         WearSyncStatus statusRoundTrip = WearSyncStatus.fromJson(status.toJson());
         check(statusRoundTrip != null && statusRoundTrip.signedIn,
                 "Wear status preserves phone sign-in state");

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -732,8 +732,8 @@ public final class ParserSelfTest {
                 java.util.Collections.emptyList(), new UsageCredits(true, false, "0"), -1, 9L);
         check(!zeroOnly.hasDisplayableData(),
                 "snapshot with only a zero balance has nothing to display");
-        System.out.println("Usage-credit auto-hide: zero, near-zero, and negative balances "
-                + "never render.");
+        System.out.println("Usage-credit shouldDisplay: zero, near-zero, and negative balances "
+                + "are treated as empty.");
     }
 
     private static void testResetCreditsAutoHide() {
@@ -757,7 +757,7 @@ public final class ParserSelfTest {
                 java.util.Collections.emptyList(), null, 2, 11L);
         check(positiveResetsOnly.hasDisplayableData(),
                 "snapshot with available resets remains displayable");
-        System.out.println("Reset-credit auto-hide: zero inventory never renders on the dashboard.");
+        System.out.println("Reset-credit shouldDisplay: zero inventory is treated as empty.");
     }
 
     private static void testDashboardSectionOrder() {
@@ -1307,23 +1307,24 @@ public final class ParserSelfTest {
                 new UsageWindow(50, 604800L, 600L, 0L),
                 java.util.Arrays.asList(spark), null, 0, System.currentTimeMillis());
         List<String> available = WidgetMeters.availableKeys(snapshot);
-        check(available.contains(WidgetMeters.FIVE_HOUR)
-                        && available.contains(WidgetMeters.WEEKLY)
-                        && available.contains(WidgetMeters.limitPrimaryKey(spark))
-                        && available.contains(WidgetMeters.limitSecondaryKey(spark))
-                        && available.contains(WidgetMeters.NEXT_RESET)
-                        && available.contains(WidgetMeters.RESET_CREDITS),
-                "available meters include spark windows");
+        check(available.equals(java.util.Arrays.asList(
+                        WidgetMeters.FIVE_HOUR,
+                        WidgetMeters.WEEKLY,
+                        WidgetMeters.NEXT_RESET,
+                        WidgetMeters.RESET_CREDITS)),
+                "available meters exclude model-specific Spark limits");
+        check(!available.contains(WidgetMeters.limitPrimaryKey(spark))
+                        && !available.contains(WidgetMeters.limitSecondaryKey(spark)),
+                "Spark limit keys are not offered for widgets");
         List<String> resolved = WidgetMeters.resolveVisible(
                 "five_hour,limit:codex-spark:primary,limit:missing:primary,weekly",
                 available);
         check(resolved.equals(java.util.Arrays.asList(
                         WidgetMeters.FIVE_HOUR,
-                        WidgetMeters.limitPrimaryKey(spark),
                         WidgetMeters.WEEKLY)),
-                "resolveVisible drops stale keys and keeps order");
+                "resolveVisible drops Spark and stale keys and keeps order");
         check(WidgetMeters.cap(resolved, 2).equals(java.util.Arrays.asList(
-                        WidgetMeters.FIVE_HOUR, WidgetMeters.limitPrimaryKey(spark))),
+                        WidgetMeters.FIVE_HOUR, WidgetMeters.WEEKLY)),
                 "capacity truncates to first N meters");
         check(WidgetMeters.resolveVisibleOrDefault(
                         "limit:gone-model:primary", available, "both")
@@ -1341,10 +1342,14 @@ public final class ParserSelfTest {
         check(WidgetMeters.lockSlotCapacity() == 2, "lock widgets cap at two meters");
         check(WidgetMeters.shortLabel(WidgetMeters.limitPrimaryKey(spark), snapshot)
                         .equals("Spark 5h"),
-                "spark primary short label");
+                "limit primary short label still formats from display name");
         check(WidgetMeters.shortLabel(WidgetMeters.limitSecondaryKey(spark), snapshot)
                         .equals("Spark W"),
-                "spark secondary short label");
+                "limit secondary short label still formats from display name");
+        check(WidgetMeters.shortLabel(WidgetMeters.FIVE_HOUR, snapshot).equals("5h"),
+                "five-hour short label");
+        check(WidgetMeters.shortLabel(WidgetMeters.WEEKLY, snapshot).equals("Wk"),
+                "weekly short label");
 
         check(WidgetMeters.VISUAL_RINGS.equals(WidgetMeters.resolveHomeVisualStyle(
                         WidgetMeters.PREF_AUTO, false, 1, 2, 70, 110)),

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 26
-        versionName = "2.6.8"
+        versionCode = 27
+        versionName = "2.6.9"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Patch release prep for **2.6.9** (versionCode **27**) plus the widget/dashboard cleanup:

1. **Spark out of widgets** — Home and lock widgets no longer offer GPT-5.3-Codex-Spark or other model-specific additional limits. Those stay on the in-app dashboard only; widgets keep Codex 5-hour/weekly, next reset, and reset credits.
2. **Consistent blanks when toggled on** — Edit dashboard / Settings visibility switches now win. Enabled sections keep their place with a dash / blank placeholder when OpenAI has not reported data (or credits/resets are empty), instead of some cards vanishing while others showed placeholders.
3. **Drag-to-reorder widget meters** — Customize widget meters use the same handle + long-press `ItemTouchHelper` pattern as Edit dashboard, so slot priority matches the user’s order.
4. **Release metadata** — Bumped Gradle / `AppConstants` / `build.sh` / self-checks to **2.6.9** / code **27**, and refreshed `CHANGELOG.md` + README.

This PR prepares version metadata and the fix set — it does **not** create the `v2.6.9` tag or GitHub Release. After merge, tagging `v2.6.9` on the merge commit will trigger CI to publish the signed phone + Wear APKs.

## Verification
- [x] `./run-tests.sh` passed (including static greps / version guards for 2.6.9 / code 27)
- [x] `:app:compileReleaseJavaWithJavac` + `:wear:compileReleaseJavaWithJavac` passed
- [x] `./lint.sh` passed (`:app:lintRelease` + `:wear:lintRelease`)
- [x] `./build.sh` produced `CodexMeter-2.6.9.apk` + `CodexMeter-Wear-2.6.9.apk` (APK Signature Scheme v2)
- [ ] CI `build` job green on this branch
- [ ] Tag `v2.6.9` after merge (creates release once instructed)

## Manual smoke
- [ ] Pin a home widget → Customize → confirm Spark/additional-limit rows are gone; drag meters and save; resize and confirm slot order
- [ ] Edit dashboard → enable sections with no data → cards show `—` / placeholders instead of disappearing; disable → cards hide
- [ ] Lock widget customize → only 5-hour / weekly meters; no Spark rows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52d02f2d-d255-4a6a-9d0c-1a3274a49f7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52d02f2d-d255-4a6a-9d0c-1a3274a49f7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

