### PR TITLE
Fix 2.6.9 dashboard/auto-hide and Adaptive dials regressions (2.6.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.6.10 — 2026-07-31
+
+### Fixed
+
+- Restored dashboard auto-hide for empty usage-credit, reset-credit, and missing-window cards. The 2.6.9 blank-placeholder behavior was intended for widgets only, not the home-screen dashboard (#85).
+- Adaptive widget layouts no longer flip to two oversized dials after Spark/additional-limit meters are stripped from saved configs; multi-usage selections migrate to Codex 5-hour + weekly so tall Adaptive sizing keeps progress bars (#85).
+
+### Development
+
+- Shared `resolveVisibleForWidget` / `resolvedSingleUsageMetric` migration helpers cover layout, slot selection, config load, and lock widgets (#85).
+
+**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.9...v2.6.10 <!-- pragma: allowlist secret -->
+
 ## 2.6.9 — 2026-07-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
 
-## Android — Version 2.6.9
+## Android — Version 2.6.10
 
-Version 2.6.9 drops Spark and other model-specific limits from home and lock widgets, keeps toggled-on dashboard sections as blank dash placeholders instead of auto-hiding them, and adds drag-to-reorder for widget meter selection.
+Version 2.6.10 keeps Spark off widgets and restores dashboard auto-hide for empty cards, while fixing Adaptive tall layouts that incorrectly showed oversized dials after Spark meters were removed from saved widget configs.
 
 On compatible Galaxy Watches, those five standard AndroidX Tiles also advertise Samsung's private modular-card hints: the overview requests a 2×2 footprint and the focused usage, reset, and monitor Tiles request 2×1 footprints. Their diagonal One UI gradient cards use the same rounded 228-degree usage-dial geometry and One UI Sans typography as the phone's battery-style widgets. Other Wear OS tile hosts ignore the sizing hints and keep the normal full-screen carousel presentation. Samsung does not document third-party eligibility for modular placement, so final grid behavior remains firmware-dependent.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 27
-        versionName = "2.6.9"
+        versionCode = 28
+        versionName = "2.6.10"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 27;
-    public static final String VERSION_NAME = "2.6.9";
+    public static final int VERSION_CODE = 28;
+    public static final String VERSION_NAME = "2.6.10";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.6.9 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.6.10 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java
@@ -78,9 +78,10 @@ public final class DashboardReorderActivity extends AppCompatActivity {
         content.addView(listCard);
 
         TextView note = Ui.text(this,
-                "Changes are saved instantly. Toggled-on sections always keep their place on the "
-                        + "dashboard — when OpenAI has not reported data yet, the card shows a "
-                        + "blank dash placeholder instead of disappearing.",
+                "Changes are saved instantly. Usage-credit balance and reset credits stay hidden "
+                        + "when they have nothing to show (zero or below), and 5-hour, weekly, "
+                        + "and usage-history cards appear only while OpenAI reports data for them "
+                        + "— no matter where each card is placed or whether its switch is on.",
                 12.0f, Ui.secondaryText(dark));
         LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(-1, -2);
         noteParams.setMargins(Ui.dp(this, 6), Ui.dp(this, 14), Ui.dp(this, 6), 0);
@@ -106,13 +107,13 @@ public final class DashboardReorderActivity extends AppCompatActivity {
                 items.add(new SectionItem(key, "Weekly limit", "Rolling 7-day Codex window"));
             } else if (DashboardSections.USAGE_CREDITS.equals(key)) {
                 items.add(new SectionItem(key, "Usage-credit balance",
-                        "Shows a blank dash when no balance is available"));
+                        "Hidden automatically at a zero or negative balance"));
             } else if (DashboardSections.USAGE_HISTORY.equals(key)) {
                 items.add(new SectionItem(key, "Usage history",
-                        "Shows a placeholder until burn charts have data"));
+                        "Shown only when a 5-hour or weekly window is available"));
             } else if (DashboardSections.RESET_CREDITS.equals(key)) {
                 items.add(new SectionItem(key, "Reset credits",
-                        "Shows a blank state when no resets are available"));
+                        "Hidden automatically when no resets are available"));
             } else {
                 UsageLimit match = null;
                 for (UsageLimit limit : limits) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetConfigActivity.java
@@ -216,7 +216,8 @@ public final class LockWidgetConfigActivity extends AppCompatActivity {
         UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
         List<String> available = WidgetMeters.availableKeys(snapshot);
         List<String> visible = WidgetMeters.cap(
-                WidgetMeters.resolveVisible(options.effectiveVisibleMeters(), available),
+                WidgetMeters.resolveVisibleForWidget(options.effectiveVisibleMeters(), available,
+                        options.metricMode),
                 WidgetMeters.lockSlotCapacity());
         int primary = 73;
         int secondary = -1;

--- a/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetOptions.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/LockWidgetOptions.java
@@ -49,6 +49,7 @@ public final class LockWidgetOptions {
     }
 
     public boolean singleMetric() {
-        return WidgetMeters.singleUsageMetric(WidgetMeters.parse(effectiveVisibleMeters()));
+        return WidgetMeters.resolvedSingleUsageMetric(effectiveVisibleMeters(),
+                WidgetMeters.availableKeys(null), metricMode);
     }
 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -349,29 +349,33 @@ public final class MainActivity extends AppCompatActivity {
                 }
                 group.add(limit);
             }
-        }
-        // Visibility switches win: toggled-on sections keep a blank/dash placeholder when
-        // OpenAI has not reported data yet, instead of disappearing inconsistently.
-        if (AppPreferences.showDashboardFiveHour(this)) {
-            available.add(DashboardSections.FIVE_HOUR);
-        }
-        if (AppPreferences.showDashboardWeekly(this)) {
-            available.add(DashboardSections.WEEKLY);
-        }
-        if (AppPreferences.showDashboardAdditionalLimits(this)) {
-            for (String key : limitsByKey.keySet()) {
-                if (!AppPreferences.isDashboardSectionHidden(this, key)) {
-                    available.add(key);
+            if (AppPreferences.showDashboardFiveHour(this) && snapshot.fiveHour != null) {
+                available.add(DashboardSections.FIVE_HOUR);
+            }
+            if (AppPreferences.showDashboardWeekly(this) && snapshot.weekly != null) {
+                available.add(DashboardSections.WEEKLY);
+            }
+            if (AppPreferences.showDashboardAdditionalLimits(this)) {
+                for (String key : limitsByKey.keySet()) {
+                    if (!AppPreferences.isDashboardSectionHidden(this, key)) {
+                        available.add(key);
+                    }
                 }
             }
+            // Zero, near-zero, and negative balances are always hidden regardless of settings.
+            if (AppPreferences.showDashboardUsageCredits(this) && snapshot.usageCredits != null
+                    && snapshot.usageCredits.shouldDisplay()) {
+                available.add(DashboardSections.USAGE_CREDITS);
+            }
+            // Usage history only appears once at least one window can feed a burn chart.
+            if (AppPreferences.showDashboardUsageHistory(this)
+                    && snapshot.fetchedAtMillis > 0L
+                    && (snapshot.fiveHour != null || snapshot.weekly != null)) {
+                available.add(DashboardSections.USAGE_HISTORY);
+            }
         }
-        if (AppPreferences.showDashboardUsageCredits(this)) {
-            available.add(DashboardSections.USAGE_CREDITS);
-        }
-        if (AppPreferences.showDashboardUsageHistory(this)) {
-            available.add(DashboardSections.USAGE_HISTORY);
-        }
-        if (AppPreferences.showDashboardResetCredits(this)) {
+        // Zero available resets always hide the card, even when the Edit dashboard switch is on.
+        if (AppPreferences.showDashboardResetCredits(this) && shouldShowResetCreditsCard(snapshot)) {
             available.add(DashboardSections.RESET_CREDITS);
         }
         boolean inverted = false;
@@ -379,17 +383,14 @@ public final class MainActivity extends AppCompatActivity {
                 AppPreferences.getDashboardOrder(this), available)) {
             if (DashboardSections.FIVE_HOUR.equals(key)) {
                 addDashboardCard(column, buildMetricCard(
-                        "5-hour", snapshot, snapshot == null ? null : snapshot.fiveHour,
-                        inverted));
+                        "5-hour", snapshot, snapshot.fiveHour, inverted));
                 inverted = !inverted;
             } else if (DashboardSections.WEEKLY.equals(key)) {
                 addDashboardCard(column, buildMetricCard(
-                        "Weekly", snapshot, snapshot == null ? null : snapshot.weekly,
-                        inverted));
+                        "Weekly", snapshot, snapshot.weekly, inverted));
                 inverted = !inverted;
             } else if (DashboardSections.USAGE_CREDITS.equals(key)) {
-                addDashboardCard(column, buildUsageCreditsCard(
-                        snapshot == null ? null : snapshot.usageCredits));
+                addDashboardCard(column, buildUsageCreditsCard(snapshot.usageCredits));
             } else if (DashboardSections.USAGE_HISTORY.equals(key)) {
                 addDashboardCard(column, buildUsageHistoryCard());
             } else if (DashboardSections.RESET_CREDITS.equals(key)) {
@@ -431,24 +432,15 @@ public final class MainActivity extends AppCompatActivity {
         card.setPadding(0, 0, 0, 0);
         card.setMinimumHeight(Ui.dp(this, 103.0f));
         long now = System.currentTimeMillis();
+        String reset = UsageFormat.reset(this, window, WidgetOptions.RESET_RELATIVE,
+                snapshot.fetchedAtMillis, now);
+        UsagePace.Assessment pace = UsagePacePreferences.assess(this, snapshot, window, now);
         UsageWaveView wave = new UsageWaveView(this);
-        int icon = R.drawable.ic_oui_time;
-        if (window != null && window.windowSeconds >= 86_400L) {
-            icon = R.drawable.ic_oui_calendar_week;
-        } else if (label != null && label.toLowerCase(java.util.Locale.ROOT).contains("week")) {
-            icon = R.drawable.ic_oui_calendar_week;
-        }
-        if (window == null) {
-            wave.setUsage(label, "Waiting for OpenAI to report this window", "", -1, icon,
-                    invertedWave, false);
-        } else {
-            long fetchedAt = snapshot == null ? 0L : snapshot.fetchedAtMillis;
-            String reset = UsageFormat.reset(this, window, WidgetOptions.RESET_RELATIVE,
-                    fetchedAt, now);
-            UsagePace.Assessment pace = UsagePacePreferences.assess(this, snapshot, window, now);
-            wave.setUsage(label, reset, UsageFormat.estimatedRemaining(pace),
-                    window.remainingPercent(), icon, invertedWave, pace.accelerated);
-        }
+        wave.setUsage(label, reset, UsageFormat.estimatedRemaining(pace),
+                window.remainingPercent(),
+                window.windowSeconds >= 86_400L
+                        ? R.drawable.ic_oui_calendar_week : R.drawable.ic_oui_time,
+                invertedWave, pace.accelerated);
         card.addView(wave, new LinearLayout.LayoutParams(-1, Ui.dp(this, 103.0f)));
         return card;
     }
@@ -518,13 +510,8 @@ public final class MainActivity extends AppCompatActivity {
         TextView title = Ui.text(this, "Usage credits", 18, Ui.mainText(this.dark));
         title.setTypeface(Ui.mediumTypeface(this));
         card.addView(title);
-        if (credits == null || !credits.shouldDisplay()) {
-            card.addView(buildIconDetailRow(R.drawable.ic_oui_credit_card_outline,
-                    "—", "No usage-credit balance to show yet"));
-        } else {
-            card.addView(buildIconDetailRow(R.drawable.ic_oui_credit_card_outline,
-                    usageCreditBalance(credits), usageCreditsSummary(credits)));
-        }
+        card.addView(buildIconDetailRow(R.drawable.ic_oui_credit_card_outline,
+                usageCreditBalance(credits), usageCreditsSummary(credits)));
         return card;
     }
 
@@ -742,7 +729,7 @@ public final class MainActivity extends AppCompatActivity {
             return "Reset credits";
         }
         if (available <= 0) {
-            return "—";
+            return "No resets available";
         }
         if (available == 1) {
             return "1 reset available";
@@ -762,11 +749,24 @@ public final class MainActivity extends AppCompatActivity {
         if (available > 0) {
             return "Expiration details unavailable";
         }
-        return "No resets available yet";
+        return "Earn credits from ChatGPT Codex";
     }
 
     private void openResetCredits() {
         Ui.startSecondaryActivity(this, ResetCreditActivity.class);
+    }
+
+    /**
+     * Prefer the detailed reset-credits cache; fall back to the usage-endpoint summary count.
+     * Unknown inventory never surfaces an empty card.
+     */
+    private boolean shouldShowResetCreditsCard(UsageSnapshot snapshot) {
+        ResetCreditsSnapshot credits = AppPreferences.loadResetCredits(this);
+        if (credits != null) {
+            return credits.shouldDisplay();
+        }
+        return snapshot != null
+                && ResetCreditsSnapshot.shouldDisplayCount(snapshot.resetCreditsAvailable);
     }
 
     private LinearLayout buildWidgetCard() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java
@@ -31,8 +31,9 @@ public final class ResetCreditsSnapshot {
     }
 
     /**
-     * Whether inventory has at least one available reset. Dashboard cards that the user
-     * explicitly enabled still render a blank state when this returns false.
+     * Whether inventory is worth surfacing on the dashboard. Zero available resets always
+     * hide the card, even when the Edit dashboard switch is on — matching usage-credit
+     * auto-hide and data-gated 5-hour / weekly cards.
      */
     public boolean shouldDisplay() {
         return availableCount > 0;
@@ -40,7 +41,7 @@ public final class ResetCreditsSnapshot {
 
     /**
      * Same rule for a summary count from the usage endpoint when the detailed credits
-     * snapshot is not cached yet.
+     * snapshot is not cached yet. Negative / unknown counts never display.
      */
     public static boolean shouldDisplayCount(int availableCount) {
         return availableCount > 0;

--- a/android/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SamsungLockWidgetSupport.java
@@ -230,8 +230,9 @@ final class SamsungLockWidgetSupport {
 
     private static LockMeterBinding bindLockMeters(UsageSnapshot snapshot, LockWidgetOptions options) {
         List<String> available = WidgetMeters.availableKeys(snapshot);
-        List<String> resolved = WidgetMeters.resolveVisible(
-                options == null ? "" : options.effectiveVisibleMeters(), available);
+        String metricMode = options == null ? WidgetOptions.METRIC_BOTH : options.metricMode;
+        List<String> resolved = WidgetMeters.resolveVisibleForWidget(
+                options == null ? "" : options.effectiveVisibleMeters(), available, metricMode);
         ArrayList<String> usageKeys = new ArrayList<>();
         for (String key : resolved) {
             if (WidgetMeters.FIVE_HOUR.equals(key) || WidgetMeters.WEEKLY.equals(key)

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java
@@ -30,7 +30,6 @@ public final class UsageWaveView extends View {
     private String resetBottom = "";
     private String pace = "";
     private int percent;
-    private boolean unavailable;
     private boolean warning;
     private float phase;
     private float phaseOffset;
@@ -52,18 +51,14 @@ public final class UsageWaveView extends View {
     public void setUsage(String label, String reset, String paceEstimate, int remainingPercent,
             int iconRes, boolean invertedWave, boolean acceleratedWarning) {
         title = label;
-        unavailable = remainingPercent < 0;
-        percent = unavailable ? 0 : Math.max(0, Math.min(100, remainingPercent));
+        percent = Math.max(0, Math.min(100, remainingPercent));
         pace = paceEstimate == null ? "" : paceEstimate;
-        warning = !unavailable && acceleratedWarning;
+        warning = acceleratedWarning;
         if (animator != null) {
             animator.setDuration(warning ? WARNING_WAVE_DURATION_MS : NORMAL_WAVE_DURATION_MS);
         }
         phaseOffset = invertedWave ? (float) Math.PI : 0f;
-        if (unavailable) {
-            resetTop = reset == null || reset.isEmpty() ? "Unavailable" : reset;
-            resetBottom = "";
-        } else if (reset != null && reset.startsWith("Resets in ")) {
+        if (reset != null && reset.startsWith("Resets in ")) {
             resetTop = "Resets in";
             resetBottom = reset.substring("Resets in ".length());
         } else {
@@ -71,15 +66,9 @@ public final class UsageWaveView extends View {
             resetBottom = "";
         }
         icon = AppCompatResources.getDrawable(getContext(), iconRes);
-        String description = unavailable
-                ? label + ", unavailable. " + resetTop
-                : label + ", " + percent + " percent. " + reset;
-        if (!unavailable && !pace.isEmpty()) {
-            description += ". " + pace.replace("Est.", "Estimated");
-        }
-        if (warning) {
-            description += ". Accelerated usage warning";
-        }
+        String description = label + ", " + percent + " percent. " + reset;
+        if (!pace.isEmpty()) description += ". " + pace.replace("Est.", "Estimated");
+        if (warning) description += ". Accelerated usage warning";
         setContentDescription(description);
         invalidate();
     }
@@ -170,7 +159,6 @@ public final class UsageWaveView extends View {
         }
         percentPaint.setColor(foreground);
         percentPaint.setTextSize(22f * density);
-        canvas.drawText(unavailable ? "—" : percent + "%", rightCenter, 85f * density,
-                percentPaint);
+        canvas.drawText(percent + "%", rightCenter, 85f * density, percentPaint);
     }
 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java
@@ -357,10 +357,11 @@ public final class WidgetConfigActivity extends AppCompatActivity {
 
     private void loadMeterSelection(WidgetOptions saved, UsageSnapshot snapshot) {
         List<String> available = WidgetMeters.availableKeys(snapshot);
-        List<String> savedVisible = WidgetMeters.parse(saved.effectiveVisibleMeters());
+        List<String> selected = WidgetMeters.resolveVisibleForWidget(
+                saved.effectiveVisibleMeters(), available, saved.metricMode);
         this.meterOrder.clear();
         this.selectedMeters.clear();
-        for (String key : savedVisible) {
+        for (String key : selected) {
             if (available.contains(key) && !this.meterOrder.contains(key)) {
                 this.meterOrder.add(key);
                 this.selectedMeters.add(key);

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetOptions.java
@@ -199,7 +199,8 @@ public final class WidgetOptions {
     }
 
     public boolean singleMetric() {
-        return WidgetMeters.singleUsageMetric(WidgetMeters.parse(effectiveVisibleMeters()));
+        return WidgetMeters.resolvedSingleUsageMetric(effectiveVisibleMeters(),
+                WidgetMeters.availableKeys(null), metricMode);
     }
 
     public static String normalizeStyle(String str) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -634,7 +634,7 @@ public final class WidgetRenderer {
         int capacity = WidgetMeters.slotCapacity(visualStyle, height);
         List<String> available = WidgetMeters.availableKeys(snapshot);
         List<String> visible = WidgetMeters.cap(
-                WidgetMeters.resolveVisibleOrDefault(options.effectiveVisibleMeters(),
+                WidgetMeters.resolveVisibleForWidget(options.effectiveVisibleMeters(),
                         available, options.metricMode),
                 capacity);
         ResetCreditsSnapshot credits = AppPreferences.loadResetCredits(context);

--- a/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
+++ b/android/app/src/main/res/xml/preferences_settings_refresh_usage.xml
@@ -28,12 +28,12 @@
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_five_hour"
-            android:summary="Keeps a blank placeholder when this window is missing"
+            android:summary="Shown only when OpenAI returns this window"
             android:title="5-hour limit" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_weekly"
-            android:summary="Keeps a blank placeholder when this window is missing"
+            android:summary="Shown only when OpenAI returns this window"
             android:title="Weekly limit" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
@@ -43,17 +43,17 @@
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_usage_credits"
-            android:summary="Keeps a blank dash when the balance is empty"
+            android:summary="Hidden automatically at a zero or negative balance"
             android:title="Usage-credit balance" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_usage_history"
-            android:summary="Keeps a placeholder until burn charts have data"
+            android:summary="Shown only when a 5-hour or weekly window is available"
             android:title="Usage history" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="dashboard_reset_credits"
-            android:summary="Keeps a blank state when no resets are available"
+            android:summary="Hidden automatically when no resets are available"
             android:title="Reset credits" />
     </PreferenceCategory>
 

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.6.9"
+VERSION_NAME="2.6.10"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -71,14 +71,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.6.9"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 27' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.6.9"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 27' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.6.9"' "$ROOT/wear/build.gradle.kts"
-grep -q 'versionCode = 27' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.6.9' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.6.9"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.6.10"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 28' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.6.10"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 28' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.6.10"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionCode = 28' "$ROOT/wear/build.gradle.kts"
+grep -q 'codex-meter-android/2.6.10' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.6.10"' "$ROOT/build.sh"
 WORKFLOW="$ROOT/../.github/workflows/build-apk.yml"
 grep -Fq 'release-dist/CodexMeter-Wear-$VERSION_NAME.apk' "$WORKFLOW"
 grep -Fq '"platforms;android-37.0"' "$WORKFLOW"
@@ -91,6 +91,10 @@ grep -q 'testUsageCreditsAutoHide' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'testResetCreditsAutoHide' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'testDashboardSectionOrder' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'DashboardReorderActivity' "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'snapshot.usageCredits.shouldDisplay()' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'shouldShowResetCreditsCard' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'public boolean shouldDisplay()' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ResetCreditsSnapshot.java"
 grep -q 'DashboardSections.resolveOrder' \
@@ -120,33 +124,32 @@ grep -q 'dashboard_usage_history' \
 grep -q 'dashboard_hidden_sections' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
 grep -q 'hidden-section keys round-trip' "$ROOT/tests/ParserSelfTest.java"
-# Usage-history charts still gate on real windows; the section itself stays when toggled on.
+# Usage-history charts must be gated on real usage data instead of blank placeholders.
 grep -q 'fiveWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'weeklyWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 grep -q 'fiveWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
-grep -q 'blank dash placeholder' \
+# The usage-history section itself also hides until a window can feed a chart.
+grep -q 'snapshot.fiveHour != null || snapshot.weekly != null' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
+grep -q 'Hidden automatically when no resets are available' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/DashboardReorderActivity.java"
-grep -q 'Keeps a blank placeholder when this window is missing' \
-  "$ROOT/app/src/main/res/xml/preferences_settings_refresh_usage.xml"
-# Toggled-on dashboard sections keep placeholders instead of auto-hiding.
-grep -q 'showDashboardFiveHour(this))' \
+# Dashboard auto-hide wiring remains; blank placeholders are widget-only.
+grep -q 'snapshot.usageCredits.shouldDisplay()' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
-grep -q 'showDashboardUsageCredits(this))' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
-grep -q 'showDashboardResetCredits(this))' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
-! grep -q 'shouldShowResetCreditsCard' \
-  "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
-! grep -q 'snapshot.usageCredits.shouldDisplay()' \
+grep -q 'shouldShowResetCreditsCard' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"
 # Widget meter catalog excludes Spark / additional model limits; config supports drag reorder.
 grep -q 'Model-specific additional limits' \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java"
 grep -q 'available meters exclude model-specific Spark limits' \
   "$ROOT/tests/ParserSelfTest.java"
+grep -q 'resolveVisibleForWidget' \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java"
+grep -q 'resolvedSingleUsageMetric' \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java"
 grep -q 'ItemTouchHelper' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/WidgetConfigActivity.java"
 grep -q 'orderedSelectedMeters' \

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java
@@ -24,8 +24,10 @@ public final class UsageCredits {
     }
 
     /**
-     * Whether the balance has a meaningful non-empty amount. Dashboard cards that the user
-     * explicitly enabled still render a blank dash when this returns false.
+     * Whether the balance is worth surfacing anywhere in the UI. This is intentionally not
+     * configurable: zero, effectively-zero, and negative balances always hide the card, as does
+     * an account without purchased credits. Unlimited plans and unparseable non-empty balances
+     * remain visible.
      */
     public boolean shouldDisplay() {
         if (unlimited) {

--- a/android/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java
@@ -167,11 +167,55 @@ public final class WidgetMeters {
      */
     public static List<String> resolveVisibleOrDefault(String savedCsv, List<String> available,
             String metricMode) {
+        return resolveVisibleForWidget(savedCsv, available, metricMode);
+    }
+
+    /**
+     * Resolves saved widget meters against the current catalog and migrates away from
+     * removed model-specific limit keys without silently collapsing a multi-meter widget
+     * into a single-usage adaptive layout.
+     */
+    public static List<String> resolveVisibleForWidget(String savedCsv, List<String> available,
+            String metricMode) {
+        List<String> saved = parse(savedCsv);
         List<String> resolved = resolveVisible(savedCsv, available);
-        if (!resolved.isEmpty()) {
-            return resolved;
+        boolean savedHadLimit = false;
+        int savedUsage = 0;
+        for (String key : saved) {
+            if (isLimitKey(key)) {
+                savedHadLimit = true;
+                savedUsage++;
+            } else if (FIVE_HOUR.equals(key) || WEEKLY.equals(key)) {
+                savedUsage++;
+            }
         }
-        return resolveVisible(serialize(fromMetricMode(metricMode)), available);
+
+        if (resolved.isEmpty()) {
+            if (savedHadLimit) {
+                return resolveVisible(serialize(defaultVisible()), available);
+            }
+            return resolveVisible(serialize(fromMetricMode(metricMode)), available);
+        }
+
+        // Dropping Spark/other limit keys must not flip Adaptive tall layouts from bars to
+        // two oversized dials when the saved selection was multi-usage only because of them.
+        if (savedHadLimit && savedUsage > 1 && usageMeterCount(resolved) <= 1) {
+            List<String> repaired = new ArrayList<>(resolved);
+            if (!contains(repaired, FIVE_HOUR) && contains(available, FIVE_HOUR)) {
+                repaired.add(FIVE_HOUR);
+            }
+            if (!contains(repaired, WEEKLY) && contains(available, WEEKLY)) {
+                repaired.add(WEEKLY);
+            }
+            return repaired;
+        }
+        return resolved;
+    }
+
+    /** Single-usage layout decision after migrating away from removed limit meters. */
+    public static boolean resolvedSingleUsageMetric(String savedCsv, List<String> available,
+            String metricMode) {
+        return singleUsageMetric(resolveVisibleForWidget(savedCsv, available, metricMode));
     }
 
     /** Truncates an ordered visible list to the host's slot capacity. */

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -415,7 +415,7 @@ public final class ParserSelfTest {
         check(!clearRoundTrip.signedIn,
                 "Wear usage clear payload preserves signed-out state");
         WearSyncStatus status = new WearSyncStatus(true, true, 3000L,
-                "Network unavailable", "2.6.9", 4000L);
+                "Network unavailable", "2.6.10", 4000L);
         WearSyncStatus statusRoundTrip = WearSyncStatus.fromJson(status.toJson());
         check(statusRoundTrip != null && statusRoundTrip.signedIn,
                 "Wear status preserves phone sign-in state");
@@ -732,8 +732,8 @@ public final class ParserSelfTest {
                 java.util.Collections.emptyList(), new UsageCredits(true, false, "0"), -1, 9L);
         check(!zeroOnly.hasDisplayableData(),
                 "snapshot with only a zero balance has nothing to display");
-        System.out.println("Usage-credit shouldDisplay: zero, near-zero, and negative balances "
-                + "are treated as empty.");
+        System.out.println("Usage-credit auto-hide: zero, near-zero, and negative balances "
+                + "never render.");
     }
 
     private static void testResetCreditsAutoHide() {
@@ -1329,16 +1329,32 @@ public final class ParserSelfTest {
         check(WidgetMeters.resolveVisibleOrDefault(
                         "limit:gone-model:primary", available, "both")
                         .equals(WidgetMeters.defaultVisible()),
-                "all-stale selection falls back to default meters");
+                "all-stale Spark-only selection falls back to default meters");
         check(WidgetMeters.resolveVisibleOrDefault(
                         "limit:gone-model:primary", available, "weekly")
-                        .equals(java.util.Arrays.asList(WidgetMeters.WEEKLY)),
-                "stale selection falls back to legacy metric mode");
+                        .equals(WidgetMeters.defaultVisible()),
+                "stale Spark-only selection falls back to defaults, not single weekly");
         check(WidgetMeters.resolveVisibleOrDefault(
                         "weekly,five_hour", available, "both")
                         .equals(java.util.Arrays.asList(WidgetMeters.WEEKLY,
                                 WidgetMeters.FIVE_HOUR)),
                 "valid selection is not replaced by fallback");
+        check(WidgetMeters.resolveVisibleForWidget(
+                        "five_hour,limit:codex-spark:primary", available, "both")
+                        .equals(java.util.Arrays.asList(
+                                WidgetMeters.FIVE_HOUR, WidgetMeters.WEEKLY)),
+                "dropping Spark restores weekly so adaptive stays multi-meter");
+        check(!WidgetMeters.resolvedSingleUsageMetric(
+                        "five_hour,limit:codex-spark:primary", available, "both"),
+                "Spark-stripped multi selection is not single-metric");
+        check(WidgetMeters.VISUAL_BATTERY_LIST.equals(WidgetMeters.resolveHomeVisualStyle(
+                        WidgetMeters.PREF_AUTO,
+                        WidgetMeters.resolvedSingleUsageMetric(
+                                "five_hour,limit:codex-spark:primary", available, "both"),
+                        2, 2, 156, 110)),
+                "adaptive tall stays bars after Spark keys are stripped");
+        check(WidgetMeters.resolvedSingleUsageMetric("five_hour", available, "five_hour"),
+                "intentional five-hour-only selection stays single-metric");
         check(WidgetMeters.lockSlotCapacity() == 2, "lock widgets cap at two meters");
         check(WidgetMeters.shortLabel(WidgetMeters.limitPrimaryKey(spark), snapshot)
                         .equals("Spark 5h"),

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 27
-        versionName = "2.6.9"
+        versionCode = 28
+        versionName = "2.6.10"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Hotfix for the 2.6.9 regressions:

1. **Dashboard auto-hide restored** — Empty usage-credit / reset-credit / missing-window cards hide again on the home-screen dashboard. Blank dash placeholders were only meant for widgets.
2. **Adaptive layout fixed** — Stripping Spark/additional-limit keys from saved widget configs no longer collapses a multi-usage selection into a single-usage layout (two oversized dials instead of tall Adaptive bars). `resolveVisibleForWidget` migrates those configs to Codex 5h+weekly when needed.
3. **2.6.10 prep** — versionCode **28** / versionName **2.6.10** across phone + Wear, changelog, and README.

Widget Spark removal, widget meter drag-reorder, and widget blank slots for selected-but-empty meters remain.

## Verification
- [x] `./run-tests.sh`
- [x] Release Java compile (app + wear)
- [x] `./lint.sh`
- [ ] CI green
- [ ] Tag `v2.6.10` after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52d02f2d-d255-4a6a-9d0c-1a3274a49f7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52d02f2d-d255-4a6a-9d0c-1a3274a49f7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

