### PR TITLE
Restore public GitHub owner in changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Shared `resolveVisibleForWidget` / `resolvedSingleUsageMetric` migration helpers cover layout, slot selection, config load, and lock widgets (#85).
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.9...v2.6.10 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.6.9...v2.6.10 <!-- pragma: allowlist secret -->
 
 ## 2.6.9 — 2026-07-31
 
@@ -29,7 +29,7 @@
 
 - Regression coverage and static checks updated for the Spark-free widget catalog, dashboard placeholder visibility, and widget meter drag reorder (#84).
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.8...v2.6.9 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.6.8...v2.6.9 <!-- pragma: allowlist secret -->
 
 ## 2.6.8 — 2026-07-30
 
@@ -60,7 +60,7 @@
 - Reset credits is now a real dashboard section that reorders and hides with the rest of the cards, so the usage-history chart (or any other card) can be placed below it instead of the reset-credit card being pinned to the bottom of the page.
 - Reset-credit and usage-credit cards use bold in-card titles with left-aligned icon rows, matching the 5-hour, weekly, and usage-history cards, instead of external One UI section separators that looked inconsistent.
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.6...v2.6.7 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.6.6...v2.6.7 <!-- pragma: allowlist secret -->
 
 ## 2.6.6 — 2026-07-26
 
@@ -82,7 +82,7 @@
 
 - Expanded dashboard-section regression coverage for the usage-history key and hidden-section CSV round-trips.
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.5...v2.6.6 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.6.5...v2.6.6 <!-- pragma: allowlist secret -->
 
 ## 2.6.5 — 2026-07-26
 
@@ -102,7 +102,7 @@
 
 - Expanded regression coverage for usage-credit auto-hide, dashboard section order merging, Wear modular tile metadata, and widget configuration wiring (#67, #68, #75).
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.6.0...v2.6.5 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.6.0...v2.6.5 <!-- pragma: allowlist secret -->
 
 ## 2.6.0 — 2026-07-26
 
@@ -125,7 +125,7 @@
 
 - Expanded regression coverage for adaptive refresh policy and settings migration, plus adaptive usage parsing for partial, additional-only, and credit-only responses (#70, #71).
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.5.0...v2.6.0 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.5.0...v2.6.0 <!-- pragma: allowlist secret -->
 
 ## 2.5.0 — 2026-07-20
 
@@ -154,7 +154,7 @@
 - Added regression coverage for Wear sync clear/status payloads, pace settings, stale/account formatting, canonical icon parity, and public Wear release-asset publication.
 - Validated the signed app, all five Tiles, all four Complications, One UI controls, and promoted ongoing notification on a Wear OS 6.1 large-round emulator.
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.4.3...v2.5.0 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.4.3...v2.5.0 <!-- pragma: allowlist secret -->
 
 ## 2.4.3 — 2026-07-19
 
@@ -162,7 +162,7 @@
 
 - Android Appearance settings once again show the illustrated Light and Dark theme options side by side, while preserving System default behavior in the redesigned settings navigation.
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.4.2...v2.4.3 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.4.2...v2.4.3 <!-- pragma: allowlist secret -->
 
 ## 2.4.2 — 2026-07-19
 
@@ -179,7 +179,7 @@
 
 - Onboarding card spacing and Settings bottom padding no longer collapse against adjacent cards or the screen edge (#52).
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.4.1...v2.4.2 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.4.1...v2.4.2 <!-- pragma: allowlist secret -->
 
 ## 2.4.1 — 2026-07-18
 
@@ -188,7 +188,7 @@
 - Active Android Live Updates now rebuild immediately after promoted-notification access changes, allowing automatic Samsung fallback and explicit Android modes to adopt the newly available notification contract without waiting for another usage refresh.
 - Live Update construction now adapts to both early Android 16's required colorization and newer uncolorized promotion rules, while notification and Now Bar Codex icons use SystemUI-compatible vector syntax.
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.4.0...v2.4.1 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.4.0...v2.4.1 <!-- pragma: allowlist secret -->
 
 ## 2.4.0 — 2026-07-18
 
@@ -219,7 +219,7 @@
 - Fixed Cloud Agent setup to invoke `android/gradlew` after the monorepo move (#43).
 - Expanded regression coverage for settings transfer, update-check frequency, usage-pace estimates, widget fill controls, Material You preferences, and Wear sync contracts (#37, #38, #42, #44, #45, #47).
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.3.3...v2.4.0 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.3.3...v2.4.0 <!-- pragma: allowlist secret -->
 
 ## 2.3.3 — 2026-07-17
 
@@ -259,7 +259,7 @@
 
 - Added regression coverage for display-mode normalization and firmware-dependent mode resolution (#29).
 
-**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter/compare/v2.3.1...v2.3.2 <!-- pragma: allowlist secret -->
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.3.1...v2.3.2 <!-- pragma: allowlist secret -->
 
 ## 2.3.1 — 2026-07-14
 

--- a/android/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java
@@ -24,6 +24,7 @@ public final class ReleaseNotesMarkdown {
 
     public static String toHtml(String markdown) {
         String source = markdown == null ? "" : markdown.replace("\r\n", "\n").replace('\r', '\n');
+        source = repairRedactedRepositoryLinks(source);
         source = HTML_COMMENT.matcher(source).replaceAll("");
         source = source.trim();
         if (source.isEmpty()) {
@@ -96,6 +97,21 @@ public final class ReleaseNotesMarkdown {
             html.append("</p>");
         }
         return html.toString();
+    }
+
+    /**
+     * Older published release notes accidentally contain a literal
+     * {@code [REDACTED]} owner placeholder copied from agent tooling output.
+     * Rewrite those URLs to the canonical public repository before rendering.
+     */
+    static String repairRedactedRepositoryLinks(String source) {
+        if (source == null || source.isEmpty() || !source.contains("[REDACTED]")) {
+            return source == null ? "" : source;
+        }
+        String repository = GitHubReleaseSource.REPOSITORY_URL;
+        return source
+                .replace("https://github.com/[REDACTED]/Codex-Meter", repository)
+                .replace("http://github.com/[REDACTED]/Codex-Meter", repository);
     }
 
     private static String inline(String text) {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -1574,6 +1574,19 @@ public final class ParserSelfTest {
                 "unsafe markdown links stay plain text");
         check(!ReleaseNotesMarkdown.toHtml("[bad](javascript:alert(1))").contains("<a "),
                 "unsafe markdown links are not anchored");
+
+        String redactedNotes = "**Full Changelog**: https://github.com/[REDACTED]/Codex-Meter"
+                + "/compare/v2.6.9...v2.6.10";
+        String repaired = ReleaseNotesMarkdown.toHtml(redactedNotes);
+        String expectedHref = GitHubReleaseSource.REPOSITORY_URL
+                + "/compare/v2.6.9...v2.6.10";
+        check(repaired.contains("<a href=\"" + expectedHref + "\">"),
+                "redacted changelog owner rewritten to canonical repository");
+        check(!repaired.contains("[REDACTED]"),
+                "redacted changelog owner placeholder removed from rendered notes");
+        check(ReleaseNotesMarkdown.repairRedactedRepositoryLinks(redactedNotes)
+                        .startsWith("**Full Changelog**: " + GitHubReleaseSource.REPOSITORY_URL),
+                "redacted repository link repair is reusable");
     }
 
     private static void testReleaseUpdatePolicy() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prior Cursor agent sessions accidentally wrote the literal string `[REDACTED]` into `CHANGELOG.md` compare URLs (copying secret-redacted tool output). That placeholder is not a real secret — it was the public GitHub username/owner — and it showed up in the in-app App update “Full Changelog” link.

App source (`GitHubReleaseSource`, About screens, etc.) already used the real public owner. Only the changelog (and GitHub release bodies derived from it) were corrupted.

## Changes

- Replace all 12 literal `[REDACTED]` owner segments in `CHANGELOG.md` with the real public repository owner.
- When rendering release notes in the Android app, rewrite any remaining `github.com/[REDACTED]/Codex-Meter` URLs to `GitHubReleaseSource.REPOSITORY_URL` so already-published GitHub release notes display correctly without needing a mass release-body edit first.
- Add parser self-test coverage for that rewrite.

## Verification

- `./run-tests.sh` passed (parser/updater/OAuth/onboarding/widget self-tests).

## Notes

- Historical GitHub release note bodies on github.com may still contain the placeholder until edited or superseded by a newer release; the app will repair them on render after this change.
- Future releases that extract notes from `CHANGELOG.md` will publish clean URLs again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe7e53ba-1555-45d3-9017-5b18ec36e5c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe7e53ba-1555-45d3-9017-5b18ec36e5c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

