### PR TITLE
Add scrubbable usage-history analytics with plan value estimates

### DIFF
--- a/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
+++ b/android/app/src/debug/java/dev/bennett/codexmeter/UsagePaceDemoActivity.java
@@ -111,39 +111,57 @@ public final class UsagePaceDemoActivity extends Activity {
     }
 
     private void seedHistory(long now, long fiveHourReset, long weeklyReset) {
+        // Varied historical shapes exercise the per-window breakdown, typical-pace
+        // comparison, and scrubbable overlays: quiet, steady, heavy, and bursty windows.
         UsageHistory five = UsageHistory.empty(UsageHistory.FIVE_HOUR);
-        for (int window = 2; window >= 1; window--) {
+        int[][] fiveShapes = {
+                {3, 7, 12, 18, 22},
+                {6, 14, 25, 33, 41},
+                {12, 30, 52, 74, 96},
+                {10, 26, 38, 61, 83},
+        };
+        for (int window = fiveShapes.length; window >= 1; window--) {
             long reset = fiveHourReset - TimeUnit.HOURS.toMillis(5L * window);
-            for (int point = 1; point <= 5; point++) {
+            int[] shape = fiveShapes[fiveShapes.length - window];
+            for (int point = 0; point < shape.length; point++) {
                 long observed = reset - TimeUnit.HOURS.toMillis(5)
-                        + TimeUnit.MINUTES.toMillis(45L * point);
-                int used = Math.min(96, point * (window == 1 ? 18 : 15));
-                five = five.append(new UsageWindow(used, TimeUnit.HOURS.toSeconds(5), 0L,
-                        reset / 1000L), observed);
+                        + TimeUnit.MINUTES.toMillis(45L * (point + 1));
+                five = five.append(new UsageWindow(shape[point],
+                        TimeUnit.HOURS.toSeconds(5), 0L, reset / 1000L), observed);
             }
         }
-        int[] fiveUsed = {4, 9, 15};
+        // Current 5-hour window climbs to the snapshot's 37% over the elapsed hour.
+        int[] fiveUsed = {8, 15, 22, 30, 37};
         for (int point = 0; point < fiveUsed.length; point++) {
             five = five.append(new UsageWindow(fiveUsed[point],
                             TimeUnit.HOURS.toSeconds(5), 0L, fiveHourReset / 1000L),
-                    now - TimeUnit.MINUTES.toMillis(40L - 20L * point));
+                    now - TimeUnit.MINUTES.toMillis(48L - 12L * point));
         }
         AppPreferences.saveUsageHistory(this, five);
 
         UsageHistory weekly = UsageHistory.empty(UsageHistory.WEEKLY);
-        long previousWeeklyReset = weeklyReset - TimeUnit.DAYS.toMillis(7);
-        for (int point = 1; point <= 6; point++) {
-            long observed = previousWeeklyReset - TimeUnit.DAYS.toMillis(7)
-                    + TimeUnit.HOURS.toMillis(24L * point);
-            weekly = weekly.append(new UsageWindow(point * 9,
-                            TimeUnit.DAYS.toSeconds(7), 0L, previousWeeklyReset / 1000L),
-                    observed);
+        int[][] weeklyShapes = {
+                {5, 9, 14, 22, 30, 38},
+                {8, 19, 33, 47, 58, 71},
+                {15, 34, 52, 78, 95, 100},
+                {11, 24, 39, 52, 66, 84},
+        };
+        for (int window = weeklyShapes.length; window >= 1; window--) {
+            long reset = weeklyReset - TimeUnit.DAYS.toMillis(7L * window);
+            int[] shape = weeklyShapes[weeklyShapes.length - window];
+            for (int point = 0; point < shape.length; point++) {
+                long observed = reset - TimeUnit.DAYS.toMillis(7)
+                        + TimeUnit.HOURS.toMillis(24L * (point + 1));
+                weekly = weekly.append(new UsageWindow(shape[point],
+                        TimeUnit.DAYS.toSeconds(7), 0L, reset / 1000L), observed);
+            }
         }
-        int[] weeklyUsed = {4, 9, 15};
+        // Current weekly window climbs to the snapshot's 61% over the elapsed hour.
+        int[] weeklyUsed = {12, 28, 41, 53, 61};
         for (int point = 0; point < weeklyUsed.length; point++) {
             weekly = weekly.append(new UsageWindow(weeklyUsed[point],
                             TimeUnit.DAYS.toSeconds(7), 0L, weeklyReset / 1000L),
-                    now - TimeUnit.MINUTES.toMillis(40L - 20L * point));
+                    now - TimeUnit.MINUTES.toMillis(48L - 12L * point));
         }
         AppPreferences.saveUsageHistory(this, weekly);
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageBurnChartView.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageBurnChartView.java
@@ -6,16 +6,31 @@ import android.graphics.Color;
 import android.graphics.DashPathEffect;
 import android.graphics.Paint;
 import android.graphics.Path;
+import android.graphics.RectF;
 import android.graphics.Typeface;
+import android.text.format.DateFormat;
 import android.util.AttributeSet;
+import android.view.HapticFeedbackConstants;
+import android.view.MotionEvent;
 import android.view.View;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 /** Compact local-history chart showing actual, sustainable, and projected quota burn. */
 public final class UsageBurnChartView extends View {
+    /** Reports finger-scrub positions so hosts can surface point-in-time detail. */
+    public interface OnScrubListener {
+        void onScrub(long timeMillis, double usedPercent, boolean historicalWindow);
+
+        void onScrubEnd();
+    }
+
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Path path = new Path();
+    private final RectF bubbleRect = new RectF();
     private final DashPathEffect budgetDash;
     private final DashPathEffect projectionDash;
     private final Typeface regularTypeface = Typeface.create("sec", Typeface.NORMAL);
@@ -26,6 +41,13 @@ public final class UsageBurnChartView extends View {
     private List<List<UsageSample>> windows = Collections.emptyList();
     private UsagePace.Assessment pace;
     private long observedAtMillis;
+    private boolean scrubEnabled;
+    private OnScrubListener scrubListener;
+    private int selectedWindowIndex = -1;
+    private boolean scrubbing;
+    private long scrubTimeMillis;
+    private double scrubPercent = -1d;
+    private long lastHapticBucket = Long.MIN_VALUE;
 
     public UsageBurnChartView(Context context) {
         this(context, null);
@@ -47,6 +69,7 @@ public final class UsageBurnChartView extends View {
         this.windows = history == null ? Collections.emptyList() : history.recentWindows(5);
         this.observedAtMillis = observedAtMillis;
         this.pace = pace;
+        this.selectedWindowIndex = -1;
         String detail = samples.size() < 2 ? "Building local history"
                 : samples.size() + " local samples";
         if (pace != null && pace.available) {
@@ -54,7 +77,111 @@ public final class UsageBurnChartView extends View {
                     + UsageFormat.relative(pace.estimatedExhaustionAtMillis,
                             System.currentTimeMillis());
         }
+        if (scrubEnabled) {
+            detail += ". Touch and drag to inspect points in time";
+        }
         setContentDescription(this.label + " usage burn chart. " + detail + ".");
+        invalidate();
+    }
+
+    /** Enables finger scrubbing across the burn line for point-in-time inspection. */
+    public void setScrubEnabled(boolean enabled) {
+        this.scrubEnabled = enabled;
+    }
+
+    public void setOnScrubListener(OnScrubListener listener) {
+        this.scrubListener = listener;
+    }
+
+    /**
+     * Highlights one recorded window and points scrubbing at it. Accepts an index into
+     * {@code recentWindows(5)} ordering (oldest first); any other value selects the
+     * current window.
+     */
+    public void setSelectedWindow(int index) {
+        this.selectedWindowIndex = index >= 0 && index < windows.size() - 1 ? index : -1;
+        this.scrubbing = false;
+        invalidate();
+    }
+
+    public int windowCount() {
+        return windows.size();
+    }
+
+    private boolean historicalSelection() {
+        return selectedWindowIndex >= 0 && selectedWindowIndex < windows.size() - 1;
+    }
+
+    private List<UsageSample> activeSamples() {
+        return historicalSelection() ? windows.get(selectedWindowIndex) : samples;
+    }
+
+    /** Start and end of the time axis for the actively scrubbed window. */
+    private long[] activeAxis() {
+        if (historicalSelection()) {
+            List<UsageSample> selected = windows.get(selectedWindowIndex);
+            UsageSample reference = selected.get(selected.size() - 1);
+            long start = reference.resetAtMillis - reference.windowSeconds * 1000L;
+            return new long[]{start, reference.resetAtMillis};
+        }
+        if (window == null || observedAtMillis <= 0L) return null;
+        long resetAt = window.effectiveResetAtMillis(observedAtMillis);
+        long duration = window.windowSeconds * 1000L;
+        long startAt = resetAt - duration;
+        if (resetAt <= startAt) return null;
+        return new long[]{startAt, resetAt};
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (!scrubEnabled) return super.onTouchEvent(event);
+        List<UsageSample> active = activeSamples();
+        long[] axis = activeAxis();
+        if (active.isEmpty() || axis == null) return super.onTouchEvent(event);
+        switch (event.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+            case MotionEvent.ACTION_MOVE:
+                getParent().requestDisallowInterceptTouchEvent(true);
+                updateScrub(event.getX(), active, axis);
+                return true;
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                scrubbing = false;
+                lastHapticBucket = Long.MIN_VALUE;
+                if (scrubListener != null) scrubListener.onScrubEnd();
+                invalidate();
+                return true;
+            default:
+                return super.onTouchEvent(event);
+        }
+    }
+
+    private void updateScrub(float touchX, List<UsageSample> active, long[] axis) {
+        float density = getResources().getDisplayMetrics().density;
+        float left = 16f * density;
+        float right = getWidth() - 16f * density;
+        double ratio = Math.max(0d, Math.min(1d,
+                (touchX - left) / (double) Math.max(1f, right - left)));
+        long time = axis[0] + Math.round(ratio * (axis[1] - axis[0]));
+        long first = active.get(0).observedAtMillis;
+        long last = active.get(active.size() - 1).observedAtMillis;
+        long clamped = Math.max(first, Math.min(last, time));
+        double percent = UsageStats.usedPercentAt(active, clamped);
+        if (percent < 0d) percent = active.get(active.size() - 1).usedPercent;
+        boolean changed = !scrubbing || clamped != scrubTimeMillis;
+        scrubbing = true;
+        scrubTimeMillis = clamped;
+        scrubPercent = percent;
+        // One gentle tick per 24th of the axis keeps scrubbing tactile without buzzing.
+        long bucket = (axis[1] - axis[0]) <= 0L ? 0L
+                : (clamped - axis[0]) / Math.max(1L, (axis[1] - axis[0]) / 24L);
+        if (bucket != lastHapticBucket) {
+            lastHapticBucket = bucket;
+            performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK);
+        }
+        if (changed && scrubListener != null) {
+            scrubListener.onScrub(clamped, percent, historicalSelection());
+        }
         invalidate();
     }
 
@@ -67,6 +194,7 @@ public final class UsageBurnChartView extends View {
         float right = getWidth() - 16f * density;
         float top = 34f * density;
         float bottom = getHeight() - 24f * density;
+        paint.setStyle(Paint.Style.FILL);
         paint.setTypeface(boldTypeface);
         paint.setTextSize(14f * density);
         paint.setColor(Ui.mainText(dark));
@@ -103,24 +231,33 @@ public final class UsageBurnChartView extends View {
         canvas.drawLine(left, bottom, right, top, paint);
         paint.setPathEffect(null);
 
-        // Normalize completed windows to the same x-axis so historical burn shapes are comparable.
-        paint.setStrokeWidth(1.5f * density);
-        paint.setColor(Color.argb(dark ? 62 : 48, 128, 128, 128));
-        for (int index = 0; index < windows.size() - 1; index++) {
-            List<UsageSample> historical = windows.get(index);
-            if (historical.size() < 2) continue;
-            UsageSample reference = historical.get(historical.size() - 1);
-            long historicalStart = reference.resetAtMillis - reference.windowSeconds * 1000L;
-            path.reset();
-            for (int sampleIndex = 0; sampleIndex < historical.size(); sampleIndex++) {
-                UsageSample sample = historical.get(sampleIndex);
-                float historicalX = x(sample.observedAtMillis, historicalStart,
-                        reference.resetAtMillis, left, right);
-                float historicalY = y(sample.usedPercent, top, bottom);
-                if (sampleIndex == 0) path.moveTo(historicalX, historicalY);
-                else path.lineTo(historicalX, historicalY);
+        // Normalize completed windows to the same x-axis so historical burn shapes are
+        // comparable; the selected window is emphasized and drawn last.
+        for (int pass = 0; pass < 2; pass++) {
+            for (int index = 0; index < windows.size() - 1; index++) {
+                boolean selected = index == selectedWindowIndex;
+                if ((pass == 0) == selected) continue;
+                List<UsageSample> historical = windows.get(index);
+                if (historical.size() < 2) continue;
+                UsageSample reference = historical.get(historical.size() - 1);
+                long historicalStart = reference.resetAtMillis
+                        - reference.windowSeconds * 1000L;
+                path.reset();
+                for (int sampleIndex = 0; sampleIndex < historical.size(); sampleIndex++) {
+                    UsageSample sample = historical.get(sampleIndex);
+                    float historicalX = x(sample.observedAtMillis, historicalStart,
+                            reference.resetAtMillis, left, right);
+                    float historicalY = y(sample.usedPercent, top, bottom);
+                    if (sampleIndex == 0) path.moveTo(historicalX, historicalY);
+                    else path.lineTo(historicalX, historicalY);
+                }
+                paint.setStrokeWidth(selected ? 2.5f * density : 1.5f * density);
+                paint.setColor(selected ? Ui.desaturatedAccent(getContext(), dark)
+                        : Color.argb(dark ? 62 : 48, 128, 128, 128));
+                paint.setStrokeCap(Paint.Cap.ROUND);
+                paint.setStrokeJoin(Paint.Join.ROUND);
+                canvas.drawPath(path, paint);
             }
-            canvas.drawPath(path, paint);
         }
 
         if (!samples.isEmpty()) {
@@ -136,14 +273,17 @@ public final class UsageBurnChartView extends View {
                     path.lineTo(x, y);
                 }
             }
-            paint.setColor(Ui.accent(getContext(), dark));
+            boolean dimmed = historicalSelection();
+            int accent = Ui.accent(getContext(), dark);
+            paint.setColor(dimmed ? Color.argb(96, Color.red(accent), Color.green(accent),
+                    Color.blue(accent)) : accent);
             paint.setStrokeWidth(3f * density);
             paint.setStrokeCap(Paint.Cap.ROUND);
             paint.setStrokeJoin(Paint.Join.ROUND);
             canvas.drawPath(path, paint);
         }
 
-        if (pace != null && pace.available && !samples.isEmpty()) {
+        if (pace != null && pace.available && !samples.isEmpty() && !historicalSelection()) {
             UsageSample latest = samples.get(samples.size() - 1);
             float fromX = x(latest.observedAtMillis, startAt, resetAt, left, right);
             float fromY = y(latest.usedPercent, top, bottom);
@@ -159,6 +299,10 @@ public final class UsageBurnChartView extends View {
             paint.setPathEffect(null);
         }
 
+        if (scrubbing && scrubPercent >= 0d) {
+            drawScrub(canvas, left, right, top, bottom, density, dark);
+        }
+
         paint.setStyle(Paint.Style.FILL);
         paint.setTypeface(regularTypeface);
         paint.setTextSize(10f * density);
@@ -166,6 +310,54 @@ public final class UsageBurnChartView extends View {
         canvas.drawText("0%", left, getHeight() - 7f * density, paint);
         String reset = "reset";
         canvas.drawText(reset, right - paint.measureText(reset), getHeight() - 7f * density, paint);
+    }
+
+    private void drawScrub(Canvas canvas, float left, float right, float top, float bottom,
+            float density, boolean dark) {
+        long[] axis = activeAxis();
+        if (axis == null) return;
+        float scrubX = x(scrubTimeMillis, axis[0], axis[1], left, right);
+        float scrubY = y((int) Math.round(scrubPercent), top, bottom);
+        int accent = historicalSelection() ? Ui.desaturatedAccent(getContext(), dark)
+                : Ui.accent(getContext(), dark);
+
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setStrokeWidth(1.5f * density);
+        paint.setColor(Color.argb(dark ? 130 : 110, Color.red(accent), Color.green(accent),
+                Color.blue(accent)));
+        canvas.drawLine(scrubX, top, scrubX, bottom, paint);
+
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(Ui.cardColor(getContext(), dark));
+        canvas.drawCircle(scrubX, scrubY, 6f * density, paint);
+        paint.setColor(accent);
+        canvas.drawCircle(scrubX, scrubY, 4f * density, paint);
+
+        String bubble = scrubTimeLabel() + " · " + Math.round(scrubPercent) + "%";
+        paint.setTypeface(regularTypeface);
+        paint.setTextSize(11f * density);
+        float textWidth = paint.measureText(bubble);
+        float padding = 8f * density;
+        float bubbleLeft = Math.max(left,
+                Math.min(right - textWidth - padding * 2f, scrubX - textWidth / 2f - padding));
+        float bubbleTop = top - 30f * density;
+        bubbleRect.set(bubbleLeft, bubbleTop, bubbleLeft + textWidth + padding * 2f,
+                bubbleTop + 22f * density);
+        paint.setColor(Ui.controlSurface(getContext(), dark));
+        canvas.drawRoundRect(bubbleRect, 11f * density, 11f * density, paint);
+        paint.setColor(Ui.mainText(dark));
+        canvas.drawText(bubble, bubbleLeft + padding, bubbleTop + 15f * density, paint);
+    }
+
+    private String scrubTimeLabel() {
+        boolean weekly = window != null
+                && window.windowSeconds > 24L * 60L * 60L;
+        boolean is24Hour = DateFormat.is24HourFormat(getContext());
+        String pattern = weekly
+                ? (is24Hour ? "EEE HH:mm" : "EEE h:mm a")
+                : (is24Hour ? "HH:mm" : "h:mm a");
+        return new SimpleDateFormat(pattern, Locale.getDefault())
+                .format(new Date(scrubTimeMillis));
     }
 
     private void drawEmpty(Canvas canvas, float left, float top, boolean dark, float density,

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java
@@ -1,14 +1,24 @@
 package dev.bennett.codexmeter;
 
 import android.app.AlertDialog;
+import android.graphics.Typeface;
 import android.os.Bundle;
+import android.text.format.DateFormat;
+import android.view.Gravity;
+import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 
-/** Full local-history view with explicit privacy and deletion controls. */
+/** Full local-history view with scrubbable charts, insights, and value estimates. */
 public final class UsageHistoryActivity extends AppCompatActivity {
+    private static final int MAX_BREAKDOWN_WINDOWS = 5;
+
     private LinearLayout content;
     private boolean dark;
 
@@ -32,6 +42,7 @@ public final class UsageHistoryActivity extends AppCompatActivity {
         UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
         UsageHistory five = AppPreferences.loadUsageHistory(this, UsageHistory.FIVE_HOUR);
         UsageHistory weekly = AppPreferences.loadUsageHistory(this, UsageHistory.WEEKLY);
+        PlanPricing pricing = snapshot == null ? null : PlanPricing.forPlan(snapshot.planType);
 
         LinearLayout intro = Ui.card(this, dark);
         TextView title = Ui.text(this, "Burn trends", 20, Ui.mainText(dark));
@@ -41,7 +52,8 @@ public final class UsageHistoryActivity extends AppCompatActivity {
                 "Samples stay on this device and are recorded only after a successful refresh. "
                         + "The solid line is current usage, faint lines are previous windows, "
                         + "the dotted diagonal is a sustainable pace, and the dashed extension "
-                        + "is the estimate.",
+                        + "is the estimate. Touch and drag a chart to inspect any moment, and "
+                        + "tap a window below a chart to compare previous windows.",
                 13, Ui.secondaryText(dark));
         LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(-1, -2);
         detailParams.setMargins(0, Ui.dp(this, 8), 0, 0);
@@ -53,14 +65,12 @@ public final class UsageHistoryActivity extends AppCompatActivity {
         boolean hasCharts = false;
         UsageWindow fiveWindow = snapshot == null ? null : snapshot.fiveHour;
         if (fiveWindow != null && snapshot.fetchedAtMillis > 0L) {
-            content.addView(buildChartCard("5-hour", fiveWindow, snapshot, five));
-            Ui.addSpacer(content, 20);
+            addWindowSection("5-hour", fiveWindow, snapshot, five, pricing);
             hasCharts = true;
         }
         UsageWindow weeklyWindow = snapshot == null ? null : snapshot.weekly;
         if (weeklyWindow != null && snapshot.fetchedAtMillis > 0L) {
-            content.addView(buildChartCard("Weekly", weeklyWindow, snapshot, weekly));
-            Ui.addSpacer(content, 20);
+            addWindowSection("Weekly", weeklyWindow, snapshot, weekly, pricing);
             hasCharts = true;
         }
         if (!hasCharts) {
@@ -70,6 +80,12 @@ public final class UsageHistoryActivity extends AppCompatActivity {
                             + "Refresh usage from the dashboard to check again.",
                     13, Ui.secondaryText(dark)));
             content.addView(waiting);
+            Ui.addSpacer(content, 20);
+        }
+
+        if (snapshot != null && hasCharts) {
+            content.addView(Ui.separator(this, "Estimated value"));
+            content.addView(buildValueCard(snapshot, pricing));
             Ui.addSpacer(content, 20);
         }
 
@@ -88,8 +104,21 @@ public final class UsageHistoryActivity extends AppCompatActivity {
         content.addView(clear, new LinearLayout.LayoutParams(-1, Ui.dp(this, 58)));
     }
 
+    private void addWindowSection(String label, UsageWindow window, UsageSnapshot snapshot,
+            UsageHistory history, PlanPricing pricing) {
+        content.addView(Ui.separator(this, label + " window"));
+        content.addView(buildChartCard(label, window, snapshot, history, pricing));
+        Ui.addSpacer(content, 12);
+        LinearLayout insights = buildInsightsCard(window, snapshot, history, pricing);
+        if (insights != null) {
+            content.addView(insights);
+            Ui.addSpacer(content, 12);
+        }
+        Ui.addSpacer(content, 8);
+    }
+
     private LinearLayout buildChartCard(String label, UsageWindow window, UsageSnapshot snapshot,
-            UsageHistory history) {
+            UsageHistory history, PlanPricing pricing) {
         LinearLayout card = Ui.card(this, dark);
         card.setPadding(Ui.dp(this, 6), Ui.dp(this, 8), Ui.dp(this, 6), Ui.dp(this, 8));
         long now = System.currentTimeMillis();
@@ -97,16 +126,251 @@ public final class UsageHistoryActivity extends AppCompatActivity {
                 ? UsagePace.assess(null, 0L, now, UsagePace.BALANCED)
                 : UsagePacePreferences.assess(this, snapshot, window, now);
         UsageBurnChartView chart = new UsageBurnChartView(this);
+        chart.setScrubEnabled(true);
         chart.setData(label, window, history,
                 snapshot == null ? now : snapshot.fetchedAtMillis, pace);
-        card.addView(chart, new LinearLayout.LayoutParams(-1, Ui.dp(this, 190)));
+        card.addView(chart, new LinearLayout.LayoutParams(-1, Ui.dp(this, 200)));
+
+        String defaultDetail = "Touch and drag the chart to inspect any moment in time.";
+        TextView scrubDetail = Ui.text(this, defaultDetail, 12, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams scrubParams = new LinearLayout.LayoutParams(-1, -2);
+        scrubParams.setMargins(Ui.dp(this, 12), Ui.dp(this, 2), Ui.dp(this, 12), 0);
+        card.addView(scrubDetail, scrubParams);
+        chart.setOnScrubListener(new UsageBurnChartView.OnScrubListener() {
+            @Override
+            public void onScrub(long timeMillis, double usedPercent, boolean historicalWindow) {
+                String moment = UsageFormat.absolute(UsageHistoryActivity.this, timeMillis,
+                        System.currentTimeMillis());
+                String text = moment + " — " + Math.round(usedPercent) + "% used";
+                if (pricing != null) {
+                    text += " · ≈ " + PlanPricing.formatUsd(
+                            pricing.estimatedValueUsd(history.kind, usedPercent)) + " of usage";
+                }
+                scrubDetail.setTextColor(Ui.mainText(dark));
+                scrubDetail.setText(text);
+            }
+
+            @Override
+            public void onScrubEnd() {
+                scrubDetail.setTextColor(Ui.secondaryText(dark));
+                scrubDetail.setText(defaultDetail);
+            }
+        });
+
         String summary = history.samples.size() + " samples · "
                 + history.completedWindowCount() + " completed window"
                 + (history.completedWindowCount() == 1 ? "" : "s");
         TextView stats = Ui.text(this, summary, 12, Ui.secondaryText(dark));
         LinearLayout.LayoutParams statsParams = new LinearLayout.LayoutParams(-1, -2);
-        statsParams.setMargins(Ui.dp(this, 12), 0, Ui.dp(this, 12), Ui.dp(this, 6));
+        statsParams.setMargins(Ui.dp(this, 12), Ui.dp(this, 6), Ui.dp(this, 12), Ui.dp(this, 6));
         card.addView(stats, statsParams);
+
+        List<UsageStats.WindowStats> breakdown =
+                UsageStats.windowBreakdown(history, MAX_BREAKDOWN_WINDOWS);
+        if (breakdown.size() > 1) {
+            View divider = new View(this);
+            divider.setBackgroundColor(Ui.divider(dark));
+            LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(-1, 1);
+            dividerParams.setMargins(Ui.dp(this, 12), Ui.dp(this, 4), Ui.dp(this, 12),
+                    Ui.dp(this, 4));
+            card.addView(divider, dividerParams);
+            addWindowRows(card, chart, history, breakdown, pricing);
+        }
         return card;
+    }
+
+    /** Tappable per-window rows that select a window on the chart for scrubbing. */
+    private void addWindowRows(LinearLayout card, UsageBurnChartView chart, UsageHistory history,
+            List<UsageStats.WindowStats> breakdown, PlanPricing pricing) {
+        boolean weekly = UsageHistory.WEEKLY.equals(history.kind);
+        TextView[] titles = new TextView[breakdown.size()];
+        Runnable[] selections = new Runnable[breakdown.size()];
+        for (int index = breakdown.size() - 1; index >= 0; index--) {
+            UsageStats.WindowStats stats = breakdown.get(index);
+            boolean current = !stats.complete;
+            String rowTitle = current ? "Current window" : windowRangeLabel(stats, weekly);
+            StringBuilder subtitle = new StringBuilder();
+            subtitle.append(stats.finalPercent).append("% used");
+            if (stats.averageBurnPercentPerHour > 0d) {
+                subtitle.append(" · avg ").append(formatRate(stats.averageBurnPercentPerHour));
+            }
+            if (pricing != null) {
+                subtitle.append(" · ≈ ").append(PlanPricing.formatUsd(
+                        pricing.estimatedValueUsd(history.kind, stats.finalPercent)));
+            }
+            if (stats.exhausted) subtitle.append(" · hit limit");
+
+            LinearLayout row = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
+            row.setPadding(Ui.dp(this, 12), Ui.dp(this, 8), Ui.dp(this, 12), Ui.dp(this, 8));
+            LinearLayout texts = new LinearLayout(this);
+            texts.setOrientation(LinearLayout.VERTICAL);
+            TextView titleView = Ui.text(this, rowTitle, 14,
+                    current ? Ui.accent(this, dark) : Ui.mainText(dark));
+            titleView.setTypeface(Ui.mediumTypeface(this));
+            texts.addView(titleView);
+            texts.addView(Ui.text(this, subtitle.toString(), 12, Ui.secondaryText(dark)));
+            row.addView(texts, new LinearLayout.LayoutParams(0, -2, 1f));
+            card.addView(row, new LinearLayout.LayoutParams(-1, -2));
+
+            titles[index] = titleView;
+            int chartWindowIndex = chart.windowCount() - breakdown.size() + index;
+            boolean selectsCurrent = current;
+            int rowIndex = index;
+            selections[index] = () -> {
+                chart.setSelectedWindow(selectsCurrent ? -1 : chartWindowIndex);
+                for (int i = 0; i < titles.length; i++) {
+                    boolean selected = i == rowIndex;
+                    titles[i].setTextColor(selected ? Ui.accent(this, dark)
+                            : Ui.mainText(dark));
+                }
+            };
+            row.setOnClickListener(view -> selections[rowIndex].run());
+            row.setClickable(true);
+            row.setFocusable(true);
+            row.setContentDescription("Inspect " + rowTitle + ". " + subtitle);
+        }
+    }
+
+    private LinearLayout buildInsightsCard(UsageWindow window, UsageSnapshot snapshot,
+            UsageHistory history, PlanPricing pricing) {
+        long now = System.currentTimeMillis();
+        long observedAt = snapshot == null ? now : snapshot.fetchedAtMillis;
+        LinearLayout card = Ui.card(this, dark);
+        TextView title = Ui.text(this, "Insights", 16, Ui.mainText(dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        int rows = 0;
+
+        // Current position against the typical pace of completed windows.
+        long resetAt = window.effectiveResetAtMillis(observedAt);
+        long durationMillis = window.windowSeconds * 1000L;
+        if (resetAt > 0L && durationMillis > 0L) {
+            double elapsedFraction = 1d - Math.max(0d, Math.min(1d,
+                    (resetAt - now) / (double) durationMillis));
+            double typical = UsageStats.typicalUsedPercentAt(history, elapsedFraction);
+            if (typical >= 0d) {
+                long delta = Math.round(window.usedPercent - typical);
+                String value;
+                if (delta >= 2L) {
+                    value = delta + " pts ahead of typical";
+                } else if (delta <= -2L) {
+                    value = (-delta) + " pts behind typical";
+                } else {
+                    value = "On par with typical";
+                }
+                addStatRow(card, "Pace vs. previous windows", value);
+                rows++;
+            }
+        }
+
+        UsagePace.Assessment pace = snapshot == null ? null
+                : UsagePacePreferences.assess(this, snapshot, window, now);
+        if (pace != null && pace.available) {
+            addStatRow(card, "Projected exhaustion",
+                    UsageFormat.relative(pace.estimatedExhaustionAtMillis, now));
+            rows++;
+        }
+
+        double averageFinal = UsageStats.averageFinalPercent(history);
+        if (averageFinal >= 0d) {
+            addStatRow(card, "Avg. completed window", Math.round(averageFinal) + "% used");
+            rows++;
+        }
+
+        double peakBurn = UsageStats.peakBurnPercentPerHour(history);
+        if (peakBurn > 0d) {
+            String value = formatRate(peakBurn);
+            if (pricing != null) {
+                value += " · ≈ " + PlanPricing.formatUsd(
+                        pricing.windowValueUsd(history.kind) * peakBurn / 100d) + "/h";
+            }
+            addStatRow(card, "Peak burn observed", value);
+            rows++;
+        }
+
+        if (pricing != null) {
+            addStatRow(card, "Est. value used this window",
+                    "≈ " + PlanPricing.formatUsd(pricing.estimatedValueUsd(history.kind,
+                            window.usedPercent))
+                            + " of " + PlanPricing.formatUsd(
+                                    pricing.windowValueUsd(history.kind)));
+            rows++;
+        }
+        return rows == 0 ? null : card;
+    }
+
+    private LinearLayout buildValueCard(UsageSnapshot snapshot, PlanPricing pricing) {
+        LinearLayout card = Ui.card(this, dark);
+        if (pricing == null) {
+            String plan = UsageFormat.planLabel(snapshot.planType);
+            card.addView(Ui.text(this,
+                    (plan.isEmpty() ? "Your plan" : "The " + plan + " plan")
+                            + " has no researched usage-value estimates yet. Estimates cover "
+                            + "Plus, Pro 5x, and Pro 20x subscriptions.",
+                    13, Ui.secondaryText(dark)));
+            return card;
+        }
+        TextView title = Ui.text(this, pricing.planLabel + " · "
+                + PlanPricing.formatUsd(pricing.monthlyPriceUsd) + "/month", 16,
+                Ui.mainText(dark));
+        title.setTypeface(Ui.mediumTypeface(this));
+        card.addView(title);
+        addStatRow(card, "Est. included usage",
+                "≈ " + PlanPricing.formatUsd(pricing.monthlyValueUsd) + "/month");
+        addStatRow(card, "Weekly allowance",
+                "≈ " + PlanPricing.formatUsd(pricing.weeklyValueUsd()));
+        addStatRow(card, "5-hour allowance",
+                "≈ " + PlanPricing.formatUsd(pricing.fiveHourValueUsd()));
+        addStatRow(card, "Vs. subscription price",
+                "≈ " + Math.round(pricing.valueMultiplier()) + "x the monthly cost");
+        if (snapshot.weekly != null) {
+            addStatRow(card, "Weekly value remaining",
+                    "≈ " + PlanPricing.formatUsd(pricing.estimatedValueUsd(UsageHistory.WEEKLY,
+                            snapshot.weekly.remainingPercent())));
+        }
+        TextView disclaimer = Ui.text(this,
+                "Rough estimates from community research comparing subscription allowances "
+                        + "with equivalent API pricing. Actual limits vary by model and "
+                        + "workload; nothing here is a billing statement.",
+                12, Ui.secondaryText(dark));
+        LinearLayout.LayoutParams disclaimerParams = new LinearLayout.LayoutParams(-1, -2);
+        disclaimerParams.setMargins(0, Ui.dp(this, 10), 0, 0);
+        card.addView(disclaimer, disclaimerParams);
+        return card;
+    }
+
+    private void addStatRow(LinearLayout card, String label, String value) {
+        LinearLayout row = Ui.horizontal(this, Gravity.CENTER_VERTICAL);
+        LinearLayout.LayoutParams rowParams = new LinearLayout.LayoutParams(-1, -2);
+        rowParams.setMargins(0, Ui.dp(this, 8), 0, 0);
+        TextView labelView = Ui.text(this, label, 13, Ui.secondaryText(dark));
+        row.addView(labelView, new LinearLayout.LayoutParams(0, -2, 1f));
+        TextView valueView = Ui.text(this, value, 13, Ui.mainText(dark));
+        valueView.setTypeface(Typeface.create("sec", Typeface.NORMAL));
+        valueView.setGravity(Gravity.END);
+        row.addView(valueView, new LinearLayout.LayoutParams(-2, -2));
+        card.addView(row, rowParams);
+    }
+
+    private String windowRangeLabel(UsageStats.WindowStats stats, boolean weekly) {
+        boolean is24Hour = DateFormat.is24HourFormat(this);
+        if (weekly) {
+            SimpleDateFormat day = new SimpleDateFormat("MMM d", Locale.getDefault());
+            return day.format(new Date(stats.windowStartMillis)) + " – "
+                    + day.format(new Date(stats.resetAtMillis));
+        }
+        SimpleDateFormat day = new SimpleDateFormat("MMM d", Locale.getDefault());
+        SimpleDateFormat time = new SimpleDateFormat(is24Hour ? "HH:mm" : "h:mm a",
+                Locale.getDefault());
+        return day.format(new Date(stats.windowStartMillis)) + " · "
+                + time.format(new Date(stats.windowStartMillis)) + " – "
+                + time.format(new Date(stats.resetAtMillis));
+    }
+
+    private static String formatRate(double percentPerHour) {
+        if (percentPerHour >= 10d) {
+            return Math.round(percentPerHour) + "%/h";
+        }
+        return String.format(Locale.US, "%.1f%%/h", percentPerHour);
     }
 }

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -35,6 +35,8 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSample.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageHistory.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/PlanPricing.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageStats.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/AdaptiveRefreshPolicy.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarAutoStart.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/NowBarDisplayMode.java" \
@@ -124,6 +126,22 @@ grep -q 'dashboard_usage_history' \
 grep -q 'dashboard_hidden_sections' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
 grep -q 'hidden-section keys round-trip' "$ROOT/tests/ParserSelfTest.java"
+# Usage-history analytics: scrubbable charts, per-window insights, and value estimates.
+grep -q 'testPlanPricing' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'testUsageStats' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'setScrubEnabled' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageBurnChartView.java"
+grep -q 'requestDisallowInterceptTouchEvent' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageBurnChartView.java"
+grep -q 'setOnScrubListener' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
+grep -q 'PlanPricing.forPlan' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
+grep -q 'UsageStats.windowBreakdown' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
+test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/PlanPricing.java"
+test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageStats.java"
+
 # Usage-history charts must be gated on real usage data instead of blank placeholders.
 grep -q 'fiveWindow != null && snapshot.fetchedAtMillis > 0L' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/MainActivity.java"

--- a/android/shared/src/main/java/dev/bennett/codexmeter/PlanPricing.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/PlanPricing.java
@@ -1,0 +1,87 @@
+package dev.bennett.codexmeter;
+
+import java.util.Locale;
+
+/**
+ * Rough, community-researched value estimates for Codex subscription allowances.
+ *
+ * <p>Anchors: Pro 20x ($200/month) is commonly measured at roughly $14,000 of
+ * equivalent API usage per month and Pro 5x ($100/month) at roughly $3,500.
+ * Because OpenAI documents Pro 5x as 5x Plus usage and Pro 20x as 20x Plus,
+ * Plus ($20/month) back-solves to roughly $700 of monthly usage value. Weekly
+ * figures divide the month into four allowance windows, and the 5-hour figure
+ * uses a rough one-sixth-of-weekly burst heuristic. Every number here is an
+ * estimate, not a billing statement.
+ */
+public final class PlanPricing {
+    /** Rough share of a weekly allowance available inside one 5-hour burst window. */
+    private static final double FIVE_HOUR_SHARE_OF_WEEKLY = 1d / 6d;
+
+    public final String planKey;
+    public final String planLabel;
+    public final double monthlyPriceUsd;
+    public final double monthlyValueUsd;
+
+    private PlanPricing(String planKey, String planLabel, double monthlyPriceUsd,
+            double monthlyValueUsd) {
+        this.planKey = planKey;
+        this.planLabel = planLabel;
+        this.monthlyPriceUsd = monthlyPriceUsd;
+        this.monthlyValueUsd = monthlyValueUsd;
+    }
+
+    /** Returns pricing for a raw plan type, or null when no researched estimate exists. */
+    public static PlanPricing forPlan(String planType) {
+        if (planType == null) return null;
+        String normalized = planType.trim().toLowerCase(Locale.US)
+                .replace("_", "").replace("-", "");
+        switch (normalized) {
+            case "plus":
+                return new PlanPricing("plus", "Plus", 20d, 700d);
+            case "prolite":
+            case "pro5x":
+                return new PlanPricing("pro5x", "Pro 5x", 100d, 3500d);
+            case "pro":
+            case "pro20x":
+                return new PlanPricing("pro20x", "Pro 20x", 200d, 14000d);
+            default:
+                return null;
+        }
+    }
+
+    /** Estimated usage value covered by one week of the allowance (month / 4). */
+    public double weeklyValueUsd() {
+        return monthlyValueUsd / 4d;
+    }
+
+    /** Rough usage value available inside a single 5-hour burst window. */
+    public double fiveHourValueUsd() {
+        return weeklyValueUsd() * FIVE_HOUR_SHARE_OF_WEEKLY;
+    }
+
+    /** Estimated allowance value for a usage-history window kind. */
+    public double windowValueUsd(String historyKind) {
+        return UsageHistory.WEEKLY.equals(historyKind) ? weeklyValueUsd() : fiveHourValueUsd();
+    }
+
+    /** Estimated dollars burned for a used percentage of the given window kind. */
+    public double estimatedValueUsd(String historyKind, double usedPercent) {
+        double clamped = Math.max(0d, Math.min(100d, usedPercent));
+        return windowValueUsd(historyKind) * clamped / 100d;
+    }
+
+    /** How many times the subscription price the estimated monthly value represents. */
+    public double valueMultiplier() {
+        if (monthlyPriceUsd <= 0d) return 0d;
+        return monthlyValueUsd / monthlyPriceUsd;
+    }
+
+    /** Compact USD formatting: $3,500 · $29 · $4.20 · $0.35. */
+    public static String formatUsd(double value) {
+        double amount = Math.max(0d, value);
+        if (amount >= 10d) {
+            return String.format(Locale.US, "$%,d", Math.round(amount));
+        }
+        return String.format(Locale.US, "$%.2f", amount);
+    }
+}

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageStats.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageStats.java
@@ -1,0 +1,170 @@
+package dev.bennett.codexmeter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Pure aggregation over locally recorded usage samples: per-window statistics,
+ * cross-window typical pace, and time interpolation for chart scrubbing.
+ */
+public final class UsageStats {
+    /** Consecutive samples closer than this are too jittery for a burn-rate reading. */
+    private static final long MINIMUM_RATE_SPACING_MILLIS = TimeUnit.MINUTES.toMillis(1);
+
+    private UsageStats() {
+    }
+
+    /** Statistics for one reset window's recorded samples. */
+    public static final class WindowStats {
+        public final long windowStartMillis;
+        public final long resetAtMillis;
+        public final long firstSampleMillis;
+        public final long lastSampleMillis;
+        public final int firstPercent;
+        public final int finalPercent;
+        public final int sampleCount;
+        /** Average burn in percent per hour across the observed sample span. */
+        public final double averageBurnPercentPerHour;
+        /** Steepest observed burn in percent per hour between adjacent samples. */
+        public final double peakBurnPercentPerHour;
+        public final boolean exhausted;
+        public final boolean complete;
+
+        private WindowStats(long windowStartMillis, long resetAtMillis, long firstSampleMillis,
+                long lastSampleMillis, int firstPercent, int finalPercent, int sampleCount,
+                double averageBurnPercentPerHour, double peakBurnPercentPerHour,
+                boolean exhausted, boolean complete) {
+            this.windowStartMillis = windowStartMillis;
+            this.resetAtMillis = resetAtMillis;
+            this.firstSampleMillis = firstSampleMillis;
+            this.lastSampleMillis = lastSampleMillis;
+            this.firstPercent = firstPercent;
+            this.finalPercent = finalPercent;
+            this.sampleCount = sampleCount;
+            this.averageBurnPercentPerHour = averageBurnPercentPerHour;
+            this.peakBurnPercentPerHour = peakBurnPercentPerHour;
+            this.exhausted = exhausted;
+            this.complete = complete;
+        }
+    }
+
+    /** Builds statistics for one window's samples, or null when samples are unusable. */
+    public static WindowStats windowStats(List<UsageSample> samples, boolean complete) {
+        if (samples == null || samples.isEmpty()) return null;
+        UsageSample first = samples.get(0);
+        UsageSample last = samples.get(samples.size() - 1);
+        long windowStart = last.resetAtMillis - last.windowSeconds * 1000L;
+        double averageRate = 0d;
+        long span = last.observedAtMillis - first.observedAtMillis;
+        int burned = last.usedPercent - first.usedPercent;
+        if (span > 0L && burned > 0) {
+            averageRate = burned / hours(span);
+        }
+        double peakRate = 0d;
+        for (int i = 1; i < samples.size(); i++) {
+            UsageSample previous = samples.get(i - 1);
+            UsageSample current = samples.get(i);
+            long gap = current.observedAtMillis - previous.observedAtMillis;
+            int delta = current.usedPercent - previous.usedPercent;
+            if (gap < MINIMUM_RATE_SPACING_MILLIS || delta <= 0) continue;
+            peakRate = Math.max(peakRate, delta / hours(gap));
+        }
+        return new WindowStats(windowStart, last.resetAtMillis, first.observedAtMillis,
+                last.observedAtMillis, first.usedPercent, last.usedPercent, samples.size(),
+                averageRate, peakRate, last.usedPercent >= 100, complete);
+    }
+
+    /** Per-window statistics, oldest to newest; the final entry is the current window. */
+    public static List<WindowStats> windowBreakdown(UsageHistory history, int maximumWindows) {
+        if (history == null) return Collections.emptyList();
+        List<List<UsageSample>> windows = history.recentWindows(maximumWindows);
+        ArrayList<WindowStats> breakdown = new ArrayList<>();
+        for (int index = 0; index < windows.size(); index++) {
+            WindowStats stats = windowStats(windows.get(index), index < windows.size() - 1);
+            if (stats != null) breakdown.add(stats);
+        }
+        return Collections.unmodifiableList(breakdown);
+    }
+
+    /**
+     * Linearly interpolated used percent at a moment in time, or -1 when the moment
+     * falls outside the observed sample span.
+     */
+    public static double usedPercentAt(List<UsageSample> samples, long timeMillis) {
+        if (samples == null || samples.isEmpty()) return -1d;
+        UsageSample first = samples.get(0);
+        UsageSample last = samples.get(samples.size() - 1);
+        if (timeMillis < first.observedAtMillis || timeMillis > last.observedAtMillis) return -1d;
+        for (int i = 1; i < samples.size(); i++) {
+            UsageSample left = samples.get(i - 1);
+            UsageSample right = samples.get(i);
+            if (timeMillis > right.observedAtMillis) continue;
+            long span = right.observedAtMillis - left.observedAtMillis;
+            if (span <= 0L) return right.usedPercent;
+            double ratio = (timeMillis - left.observedAtMillis) / (double) span;
+            return left.usedPercent + (right.usedPercent - left.usedPercent) * ratio;
+        }
+        return last.usedPercent;
+    }
+
+    /**
+     * Typical used percent at an elapsed fraction of the window (0..1), averaged across
+     * completed windows. Returns -1 when no completed window covers that fraction.
+     */
+    public static double typicalUsedPercentAt(UsageHistory history, double elapsedFraction) {
+        if (history == null) return -1d;
+        double fraction = Math.max(0d, Math.min(1d, elapsedFraction));
+        List<List<UsageSample>> windows = history.recentWindows(Integer.MAX_VALUE);
+        double total = 0d;
+        int counted = 0;
+        for (int index = 0; index < windows.size() - 1; index++) {
+            List<UsageSample> window = windows.get(index);
+            if (window.size() < 2) continue;
+            UsageSample reference = window.get(window.size() - 1);
+            long windowStart = reference.resetAtMillis - reference.windowSeconds * 1000L;
+            long moment = windowStart
+                    + Math.round(fraction * reference.windowSeconds * 1000d);
+            double value = usedPercentAt(window, moment);
+            if (value < 0d) {
+                // Before the first sample usage is effectively the first reading; after the
+                // last sample the window ended at its final reading.
+                UsageSample first = window.get(0);
+                value = moment < first.observedAtMillis ? first.usedPercent
+                        : reference.usedPercent;
+            }
+            total += value;
+            counted++;
+        }
+        return counted == 0 ? -1d : total / counted;
+    }
+
+    /** Average final used percent across completed windows, or -1 when none exist. */
+    public static double averageFinalPercent(UsageHistory history) {
+        if (history == null) return -1d;
+        List<List<UsageSample>> windows = history.recentWindows(Integer.MAX_VALUE);
+        double total = 0d;
+        int counted = 0;
+        for (int index = 0; index < windows.size() - 1; index++) {
+            List<UsageSample> window = windows.get(index);
+            if (window.isEmpty()) continue;
+            total += window.get(window.size() - 1).usedPercent;
+            counted++;
+        }
+        return counted == 0 ? -1d : total / counted;
+    }
+
+    /** Steepest burn observed across every recorded window, or 0 when unavailable. */
+    public static double peakBurnPercentPerHour(UsageHistory history) {
+        double peak = 0d;
+        for (WindowStats stats : windowBreakdown(history, Integer.MAX_VALUE)) {
+            peak = Math.max(peak, stats.peakBurnPercentPerHour);
+        }
+        return peak;
+    }
+
+    private static double hours(long millis) {
+        return millis / (double) TimeUnit.HOURS.toMillis(1);
+    }
+}

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -32,6 +32,8 @@ public final class ParserSelfTest {
         testLowUsageAlertDedup();
         testUsageHistory();
         testUsagePace();
+        testPlanPricing();
+        testUsageStats();
         testAdaptiveRefreshPolicy();
         testNowBarAutoStart();
         testNowBarDisplayModes();
@@ -1640,6 +1642,107 @@ public final class ParserSelfTest {
         Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
         return encoder.encodeToString("{\"alg\":\"none\"}".getBytes(StandardCharsets.UTF_8)) + "." +
                 encoder.encodeToString(payload.getBytes(StandardCharsets.UTF_8)) + ".x";
+    }
+
+    private static void testPlanPricing() {
+        check(PlanPricing.forPlan(null) == null, "null plan has no pricing");
+        check(PlanPricing.forPlan("free") == null, "free plan has no researched estimates");
+        check(PlanPricing.forPlan("go") == null, "go plan has no researched estimates");
+        check(PlanPricing.forPlan("enterprise") == null, "unknown plans have no estimates");
+
+        PlanPricing plus = PlanPricing.forPlan("plus");
+        check(plus != null && plus.monthlyPriceUsd == 20d, "plus subscription price");
+        check(plus.monthlyValueUsd == 700d, "plus monthly value backsolves from 5x anchor");
+        check(plus.weeklyValueUsd() == 175d, "plus weekly value is month over four weeks");
+
+        PlanPricing pro5x = PlanPricing.forPlan("pro_5x");
+        check(pro5x != null && pro5x.monthlyPriceUsd == 100d, "pro 5x price normalizes underscores");
+        check(pro5x.monthlyValueUsd == 3500d, "pro 5x monthly value anchor");
+        check(pro5x.weeklyValueUsd() == 875d, "pro 5x weekly value");
+        check(PlanPricing.forPlan("prolite") != null
+                && PlanPricing.forPlan("prolite").monthlyValueUsd == 3500d,
+                "prolite aliases pro 5x");
+
+        PlanPricing pro20x = PlanPricing.forPlan("pro");
+        check(pro20x != null && pro20x.monthlyPriceUsd == 200d, "pro aliases pro 20x");
+        check(pro20x.monthlyValueUsd == 14000d, "pro 20x monthly value anchor");
+        check(pro20x.weeklyValueUsd() == 3500d, "pro 20x weekly value");
+        check(Math.round(pro20x.valueMultiplier()) == 70L, "pro 20x multiplier of price");
+        check(pro20x.fiveHourValueUsd() > 0d
+                && pro20x.fiveHourValueUsd() < pro20x.weeklyValueUsd(),
+                "5-hour burst allowance is a fraction of the weekly value");
+
+        check(pro20x.estimatedValueUsd(UsageHistory.WEEKLY, 0) == 0d, "zero percent burns nothing");
+        check(pro20x.estimatedValueUsd(UsageHistory.WEEKLY, 50) == 1750d,
+                "half the weekly window burns half the weekly value");
+        check(pro20x.estimatedValueUsd(UsageHistory.WEEKLY, 250)
+                == pro20x.weeklyValueUsd(), "burned value clamps at the full allowance");
+
+        check("$3,500".equals(PlanPricing.formatUsd(3500d)), "thousands formatting");
+        check("$29".equals(PlanPricing.formatUsd(29.2d)), "two-digit dollars drop cents");
+        check("$4.20".equals(PlanPricing.formatUsd(4.2d)), "small values keep cents");
+        check("$0.00".equals(PlanPricing.formatUsd(-3d)), "negative values clamp to zero");
+        System.out.println("Plan pricing demo: Plus $700/mo, Pro 5x $3,500/mo, Pro 20x $14,000/mo.");
+    }
+
+    private static void testUsageStats() {
+        long start = 2_100_000_000_000L;
+        long windowSeconds = TimeUnit.HOURS.toSeconds(5);
+        long firstReset = start + TimeUnit.HOURS.toMillis(5);
+        UsageHistory history = UsageHistory.empty(UsageHistory.FIVE_HOUR);
+        // Completed window: 10% -> 40% -> 90% over four hours.
+        history = history.append(new UsageWindow(10, windowSeconds, 0L, firstReset / 1000L),
+                start + TimeUnit.HOURS.toMillis(1));
+        history = history.append(new UsageWindow(40, windowSeconds, 0L, firstReset / 1000L),
+                start + TimeUnit.HOURS.toMillis(3));
+        history = history.append(new UsageWindow(90, windowSeconds, 0L, firstReset / 1000L),
+                start + TimeUnit.HOURS.toMillis(5) - TimeUnit.MINUTES.toMillis(1));
+        // Current window: slow burn.
+        long secondReset = firstReset + TimeUnit.HOURS.toMillis(5);
+        history = history.append(new UsageWindow(5, windowSeconds, 0L, secondReset / 1000L),
+                firstReset + TimeUnit.HOURS.toMillis(1));
+        history = history.append(new UsageWindow(10, windowSeconds, 0L, secondReset / 1000L),
+                firstReset + TimeUnit.HOURS.toMillis(2));
+
+        List<UsageStats.WindowStats> breakdown =
+                UsageStats.windowBreakdown(history, 5);
+        check(breakdown.size() == 2, "breakdown covers completed plus current window");
+        UsageStats.WindowStats completed = breakdown.get(0);
+        UsageStats.WindowStats current = breakdown.get(1);
+        check(completed.complete && !current.complete, "completion flags follow window order");
+        check(completed.finalPercent == 90, "completed window final percent");
+        check(completed.sampleCount == 3, "completed window sample count");
+        check(!completed.exhausted, "90% never reached the limit");
+        check(current.finalPercent == 10, "current window final percent");
+        double expectedAverage = 80d / (4d - 1d / 60d);
+        check(Math.abs(completed.averageBurnPercentPerHour - expectedAverage) < 0.1d,
+                "average burn spans first to last sample");
+        check(completed.peakBurnPercentPerHour > completed.averageBurnPercentPerHour,
+                "peak burn exceeds the average for an accelerating window");
+
+        // Interpolation: halfway between the 10% and 40% samples reads 25%.
+        List<UsageSample> completedSamples = history.recentWindows(5).get(0);
+        double midpoint = UsageStats.usedPercentAt(completedSamples,
+                start + TimeUnit.HOURS.toMillis(2));
+        check(Math.abs(midpoint - 25d) < 0.01d, "scrub interpolation between samples");
+        check(UsageStats.usedPercentAt(completedSamples, start) < 0d,
+                "times before the first sample are unavailable");
+        check(UsageStats.usedPercentAt(completedSamples,
+                start + TimeUnit.HOURS.toMillis(1)) == 10d, "exact sample time reads its value");
+
+        // Typical pace across completed windows at 60% elapsed (three hours in) is 40%.
+        double typical = UsageStats.typicalUsedPercentAt(history, 0.6d);
+        check(Math.abs(typical - 40d) < 0.01d, "typical pace at an elapsed fraction");
+        check(UsageStats.typicalUsedPercentAt(UsageHistory.empty(UsageHistory.FIVE_HOUR), 0.5d)
+                < 0d, "typical pace needs a completed window");
+        check(Math.abs(UsageStats.averageFinalPercent(history) - 90d) < 0.01d,
+                "average completed final percent");
+        check(UsageStats.peakBurnPercentPerHour(history) > 0d, "peak burn is available");
+        check(UsageStats.windowStats(java.util.Collections.emptyList(), false) == null,
+                "empty windows produce no stats");
+        System.out.println("Usage stats demo: completed window avg "
+                + Math.round(completed.averageBurnPercentPerHour) + "%/h, typical@60% = "
+                + Math.round(typical) + "%.");
     }
 
     private static void check(boolean condition, String name) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Drastically deepens the Usage history experience while keeping the One UI design language:

- **Finger scrubbing**: `UsageBurnChartView` now supports touch-and-drag inspection of any point in time — crosshair, dot on the burn line, time/percent bubble, gentle haptic ticks, and a live detail row under each chart showing the moment, percent used, and estimated dollar value of usage.
- **Per-window breakdown**: each chart card lists the current window plus up to four previous windows (date range, final %, average burn rate, estimated value, limit hits). Tapping a row highlights that window on the chart and points scrubbing at its own time axis.
- **Insights card per window kind**: pace vs. typical previous windows (interpolated at the same elapsed fraction), projected exhaustion, average completed-window usage, peak observed burn rate.
- **Estimated value card**: new `PlanPricing` (shared, pure Java) maps Plus / Pro 5x / Pro 20x to community-researched usage-value anchors — Pro 20x ($200/mo) ≈ $14,000/mo of equivalent API usage, Pro 5x ($100/mo) ≈ $3,500/mo, Plus back-solves to ≈ $700/mo via OpenAI's documented 5x/20x multipliers. Weekly = month/4, 5-hour burst ≈ weekly/6 heuristic, with a clear disclaimer that these are estimates.
- **New `UsageStats`** (shared, pure Java): per-window statistics, typical-pace interpolation across completed windows, average final percent, peak burn, and the linear interpolation backing the scrubber.
- Debug demo seeder now generates four varied historical windows per kind so the analytics are demonstrable.

## Testing

- `./run-tests.sh` passes, including new `testPlanPricing` / `testUsageStats` suites and structural guards for the scrub wiring.
- `./build.sh` (signed phone + Wear release APKs) and `./lint.sh` pass.
- Manually demonstrated on a software-rendered (no-KVM, SwiftShader) API 30 emulator using the debug demo seeder.

## Demo

[usage_history_scrub_and_window_selection_demo.mp4](https://cursor.com/agents/bc-38a1cfee-5683-4605-99ff-d474219966b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusage_history_scrub_and_window_selection_demo.mp4)

| Chart + window breakdown | Insights | Estimated value |
|---|---|---|
| [Chart and window breakdown](https://cursor.com/agents/bc-38a1cfee-5683-4605-99ff-d474219966b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusage_history_chart_and_window_breakdown.png) | [Insights card](https://cursor.com/agents/bc-38a1cfee-5683-4605-99ff-d474219966b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusage_history_insights_5hour.png) | [Estimated value card](https://cursor.com/agents/bc-38a1cfee-5683-4605-99ff-d474219966b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusage_history_estimated_value_card.png) |

[Scrubbing a selected historical window](https://cursor.com/agents/bc-38a1cfee-5683-4605-99ff-d474219966b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusage_history_scrubbing_historical_window.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38a1cfee-5683-4605-99ff-d474219966b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38a1cfee-5683-4605-99ff-d474219966b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

