### PR TITLE
Prepare Codex Meter 2.7.0: alpha release channel with one-tap in-place switching

### DIFF
--- a/.github/workflows/alpha-branch.yml
+++ b/.github/workflows/alpha-branch.yml
@@ -1,0 +1,34 @@
+name: Ensure alpha branch
+
+# Bootstraps the rapid-iteration alpha branch alongside main. Runs after every push to
+# main so merging the workflow itself creates the branch; it never force-updates an
+# existing alpha branch, which diverges from main between stable promotions.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  ensure-alpha:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Create alpha branch from main when missing
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/$GH_REPO/git/ref/heads/alpha" >/dev/null 2>&1; then
+            echo "alpha branch already exists; leaving it untouched"
+            exit 0
+          fi
+          gh api "repos/$GH_REPO/git/refs" \
+            -f ref="refs/heads/alpha" \
+            -f sha="$GITHUB_SHA"
+          echo "Created alpha branch at $GITHUB_SHA"

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -2,7 +2,7 @@ name: Build Codex Meter APK
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, alpha]
   push:
     tags: ['v*']
   workflow_dispatch:
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 25
     outputs:
       version: ${{ steps.version.outputs.name }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
     env:
       GH_USERNAME: ${{ github.actor }}
       GH_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -26,6 +27,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Java 21
         uses: actions/setup-java@v5
@@ -66,7 +70,33 @@ jobs:
             echo "::error::Tag $GITHUB_REF_NAME does not match app version v$VERSION_NAME"
             exit 1
           fi
+          PRERELEASE=false
+          if [[ "$VERSION_NAME" == *-* ]]; then
+            PRERELEASE=true
+          fi
+          # Channel invariant: alpha builds must reuse the newest stable versionCode so the
+          # in-app "return to stable" install is never an Android downgrade, and stable
+          # releases must strictly increase it.
+          VERSION_CODE="$(awk '/versionCode = / { print $3; exit }' app/build.gradle.kts)"
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            LATEST_STABLE_TAG="$(git tag -l 'v*' | grep -v -- - \
+              | grep -vx "$GITHUB_REF_NAME" | sort -V | tail -n 1 || true)"
+            if [[ -n "$LATEST_STABLE_TAG" ]]; then
+              STABLE_CODE="$(git show "$LATEST_STABLE_TAG:android/app/build.gradle.kts" \
+                2>/dev/null | awk '/versionCode = / { print $3; exit }' || true)"
+              if [[ -z "$STABLE_CODE" ]]; then
+                echo "::warning::Could not read versionCode from $LATEST_STABLE_TAG; skipping channel invariant check"
+              elif [[ "$PRERELEASE" == "true" && "$VERSION_CODE" -ne "$STABLE_CODE" ]]; then
+                echo "::error::Alpha tag $GITHUB_REF_NAME must keep versionCode $STABLE_CODE from $LATEST_STABLE_TAG (found $VERSION_CODE) so returning to stable stays an in-place install"
+                exit 1
+              elif [[ "$PRERELEASE" == "false" && "$VERSION_CODE" -le "$STABLE_CODE" ]]; then
+                echo "::error::Stable tag $GITHUB_REF_NAME must raise versionCode above $STABLE_CODE from $LATEST_STABLE_TAG (found $VERSION_CODE)"
+                exit 1
+              fi
+            fi
+          fi
           echo "name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Run regression tests
         shell: bash
@@ -182,16 +212,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           VERSION_NAME: ${{ needs.build.outputs.version }}
+          PRERELEASE: ${{ needs.build.outputs.prerelease }}
         run: |
           set -euo pipefail
           if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             gh release create "$GITHUB_REF_NAME" \
               --draft \
               --verify-tag \
+              --prerelease="$PRERELEASE" \
               --notes-file release-notes.md \
               --title "Codex Meter $VERSION_NAME"
           else
             gh release edit "$GITHUB_REF_NAME" \
+              --prerelease="$PRERELEASE" \
               --notes-file release-notes.md \
               --title "Codex Meter $VERSION_NAME"
           fi
@@ -200,4 +233,8 @@ jobs:
             "release-dist/CodexMeter-Wear-$VERSION_NAME.apk#Codex Meter Wear OS $VERSION_NAME APK" \
             "release-dist/SHA256SUMS.txt#SHA-256 checksums" \
             --clobber
-          gh release edit "$GITHUB_REF_NAME" --draft=false --latest
+          if [[ "$PRERELEASE" == "true" ]]; then
+            gh release edit "$GITHUB_REF_NAME" --draft=false
+          else
+            gh release edit "$GITHUB_REF_NAME" --draft=false --latest
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.7.0 — 2026-08-01
+
+### Added
+
+- Alpha release channel with one-tap in-place switching: Settings → Updates → Update channel opts into signed alpha builds, and returning to stable installs in place with no uninstall or data loss because alpha builds share the stable signing key and version code (#88).
+- Scrubbable usage-history analytics with per-window insights and plan value estimates (#87).
+
+### Development
+
+- New `alpha` branch (auto-created by CI after merge) feeds `v*-alpha.N` tags; release CI publishes them as GitHub prereleases, never marks them latest, and enforces the shared-versionCode invariant that keeps channel switching downgrade-free (#88).
+- Channel-selection self-tests and source guards cover stable/alpha update picks, alpha-to-alpha upgrades, stable promotions, and the return-to-stable flow (#88).
+
+**Full Changelog**: https://github.com/BenItBuhner/Codex-Meter/compare/v2.6.10...v2.7.0 <!-- pragma: allowlist secret -->
+
 ## 2.6.10 — 2026-07-31
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,38 @@ From the repository root (wrappers) or from `android/`:
 
 See [`android/README.md`](android/README.md) for module layout details.
 
+## Release channels (Android)
+
+Two long-lived branches feed two update channels in the app (Settings → Updates →
+Update channel):
+
+- `main` is the **stable** channel. Tags look like `v2.7.0`.
+- `alpha` is the **rapid-iteration** channel. Tags look like `v2.7.0-alpha.1` and
+  publish as GitHub prereleases. The `Ensure alpha branch` workflow creates the
+  branch from `main` automatically if it is ever missing.
+
+Both channels are built by the same tag-triggered CI job and signed with the same
+release keystore, so the in-app updater's SHA-256 and signing-certificate checks
+pass when switching channels in either direction — no uninstall/reinstall.
+
+Versioning rules (enforced by CI on tags):
+
+- **Alpha releases** bump only `versionName` (append/increment the `-alpha.N`
+  suffix) and must keep `versionCode` **equal to** the newest stable release's
+  `versionCode`. Android permits equal-`versionCode` installs, which is what makes
+  the one-tap "Return to stable" flow an ordinary in-place install.
+- **Stable releases** drop the suffix and bump `versionCode` by one, so a stable
+  promotion is a normal upgrade for both channels.
+
+Cutting an alpha: branch work off `alpha`, set `versionName` (for example,
+`2.7.0-alpha.1`) in `android/app/build.gradle.kts`, `android/wear/build.gradle.kts`,
+`AppConstants.java`, `android/build.sh`, and the guards in `android/run-tests.sh`,
+add a `## 2.7.0-alpha.1` section to `CHANGELOG.md`, then tag `v2.7.0-alpha.1`.
+
+Promoting to stable: merge `alpha` into `main`, drop the suffix, bump
+`versionCode`, consolidate the alpha changelog sections under the stable version,
+then tag as usual.
+
 ## iOS local setup
 
 Install Xcode 26 or newer. From `ios/`:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 26
         targetSdk = 36
-        versionCode = 28
-        versionName = "2.6.10"
+        versionCode = 29
+        versionName = "2.7.0"
         providers.gradleProperty("demoVersionCode").orNull?.toIntOrNull()?.let {
             versionCode = it
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppConstants.java
@@ -34,14 +34,14 @@ public final class AppConstants {
     public static final String REVOKE_URL = "https://auth.openai.com/oauth/revoke";
     public static final String TOKEN_URL = "https://auth.openai.com/oauth/token";
     public static final String USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-    public static final int VERSION_CODE = 28;
-    public static final String VERSION_NAME = "2.6.10";
+    public static final int VERSION_CODE = 29;
+    public static final String VERSION_NAME = "2.7.0";
 
     private AppConstants() {
     }
 
     public static String userAgent() {
-        return "codex-meter-android/2.6.10 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
+        return "codex-meter-android/2.7.0 (Android " + (Build.VERSION.RELEASE == null ? "unknown" : Build.VERSION.RELEASE) + "; " + (Build.MODEL == null ? "Android" : Build.MODEL) + ")";
     }
 
     public static String updaterUserAgent() {

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -303,14 +303,24 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     private LinearLayout buildUpdateCard(GitHubRelease release) {
+        boolean returnToStable = UpdateChannel.isReturnToStable(release,
+                UpdatePreferences.installedVersion(this));
         LinearLayout card = Ui.card(this, this.dark);
-        TextView title = Ui.text(this, "Codex Meter " + release.version + " is ready", 18,
+        TextView title = Ui.text(this, returnToStable
+                        ? "Return to Codex Meter " + release.version
+                        : "Codex Meter " + release.version + " is ready", 18,
                 Ui.mainText(this.dark));
         title.setTypeface(Ui.mediumTypeface(this));
         card.addView(title);
         TextView summary = Ui.text(this,
-                "A signed GitHub release is available. The APK will be checksum-verified before "
-                        + "Android asks you to approve installation.",
+                returnToStable
+                        ? "You are back on the stable channel. The stable APK installs in place "
+                        + "over this alpha build after checksum verification."
+                        : release.prerelease
+                        ? "A signed alpha release is available. The APK will be checksum-verified "
+                        + "before Android asks you to approve installation."
+                        : "A signed GitHub release is available. The APK will be checksum-verified "
+                        + "before Android asks you to approve installation.",
                 13, Ui.secondaryText(this.dark));
         LinearLayout.LayoutParams summaryParams = new LinearLayout.LayoutParams(-1, -2);
         summaryParams.setMargins(0, Ui.dp(this, 7), 0, Ui.dp(this, 14));

--- a/android/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ReleaseHistoryActivity.java
@@ -83,7 +83,9 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
                 + ReleaseUpdatePolicy.FIRST_IN_APP_UPDATE_VERSION
                 + " are irreversible and must be installed from GitHub because those builds lack "
                 + "working in-app updates. Other older versions still require uninstalling first, "
-                + "which removes local data and widgets.";
+                + "which removes local data and widgets. Alpha builds are the exception: they "
+                + "share the stable version code, so the newest stable release always installs "
+                + "back in place.";
         TextView detail = Ui.text(this, note, 13, Ui.secondaryText(dark));
         LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(-1, -2);
         detailParams.setMargins(0, Ui.dp(this, 8), 0, 0);
@@ -126,9 +128,10 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
     }
 
     private void addRelease(GitHubRelease release) {
-        int comparison = ReleaseVersion.compare(release.version,
-                UpdatePreferences.installedVersion(this));
+        String installedVersion = UpdatePreferences.installedVersion(this);
+        int comparison = ReleaseVersion.compare(release.version, installedVersion);
         boolean irreversible = ReleaseUpdatePolicy.isIrreversible(release.version);
+        boolean returnToStable = UpdateChannel.isReturnToStable(release, installedVersion);
         LinearLayout card = Ui.card(this, dark);
         String suffix = release.prerelease ? " · Prerelease"
                 : irreversible ? " · Irreversible"
@@ -180,8 +183,9 @@ public final class ReleaseHistoryActivity extends AppCompatActivity {
             card.addView(details, detailsParams);
         } else {
             Button action = Ui.button(this,
-                    comparison < 0 ? "View downgrade" : comparison == 0 ? "View reinstall"
-                            : "View update", comparison > 0, dark);
+                    returnToStable ? "View stable return"
+                            : comparison < 0 ? "View downgrade" : comparison == 0 ? "View reinstall"
+                            : "View update", comparison > 0 || returnToStable, dark);
             action.setOnClickListener(view -> startActivity(new Intent(this, UpdateActivity.class)
                     .putExtra(UpdateActivity.EXTRA_VERSION, release.version)));
             card.addView(action, new LinearLayout.LayoutParams(-1, Ui.dp(this, 54)));

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -130,6 +130,7 @@ public final class SettingsActivity extends AppCompatActivity {
         private ListPreference usagePaceSensitivityPreference;
         private Preference nowBarPermissionPreference;
         private SwitchPreferenceCompat automaticUpdatePreference;
+        private ListPreference updateChannelPreference;
         private ListPreference updateIntervalPreference;
         private SwitchPreferenceCompat notifyUpdatePreference;
         private boolean pendingExportAppSettings;
@@ -299,12 +300,14 @@ public final class SettingsActivity extends AppCompatActivity {
             findPreference("settings_now_bar").setSummary(nowBarSummary);
 
             GitHubRelease availableUpdate = UpdatePreferences.availableUpdate(requireContext());
-            findPreference("settings_updates").setSummary(availableUpdate != null
+            String channelSuffix = UpdateChannel.isAlpha(
+                    UpdatePreferences.channel(requireContext())) ? " · Alpha channel" : "";
+            findPreference("settings_updates").setSummary((availableUpdate != null
                     ? "v" + availableUpdate.version + " available"
                     : UpdatePreferences.automaticChecks(requireContext())
                     ? "Automatic · " + UpdateCheckFrequency.label(
                     UpdatePreferences.checkIntervalHours(requireContext()))
-                    : "Automatic checks off");
+                    : "Automatic checks off") + channelSuffix);
         }
 
         private String metricLabel(String metric) {
@@ -496,6 +499,31 @@ public final class SettingsActivity extends AppCompatActivity {
         }
 
         private void bindUpdates() {
+            updateChannelPreference = findPreference("update_channel_ui");
+            updateChannelPreference.setPersistent(false);
+            updateChannelPreference.setValue(UpdatePreferences.channel(requireContext()));
+            updateChannelPreference.setOnPreferenceChangeListener((preference, value) -> {
+                String channel = UpdateChannel.normalize(String.valueOf(value));
+                if (channel.equals(UpdatePreferences.channel(requireContext()))) {
+                    return true;
+                }
+                if (UpdateChannel.ALPHA.equals(channel)) {
+                    new AlertDialog.Builder(requireContext())
+                            .setTitle("Switch to the alpha channel?")
+                            .setMessage("Alpha builds ship faster with less testing and may be "
+                                    + "unstable. They use the same signing key and version code "
+                                    + "as stable releases, so switching back to stable later is "
+                                    + "one in-place install with no uninstalling or data loss.")
+                            .setNegativeButton("Cancel", null)
+                            .setPositiveButton("Use alpha", (dialog, which) ->
+                                    applyUpdateChannel(UpdateChannel.ALPHA))
+                            .show();
+                    return false;
+                }
+                applyUpdateChannel(UpdateChannel.STABLE);
+                return true;
+            });
+
             automaticUpdatePreference = findPreference("automatic_update_checks_ui");
             automaticUpdatePreference.setPersistent(false);
             automaticUpdatePreference.setChecked(UpdatePreferences.automaticChecks(requireContext()));
@@ -559,6 +587,16 @@ public final class SettingsActivity extends AppCompatActivity {
             updateUpdateSummary();
         }
 
+        private void applyUpdateChannel(String channel) {
+            UpdatePreferences.setChannel(requireContext(), channel);
+            if (updateChannelPreference != null) {
+                updateChannelPreference.setValue(channel);
+            }
+            updateUpdateSummary();
+            startActivity(new Intent(requireContext(), UpdateActivity.class)
+                    .putExtra(UpdateActivity.EXTRA_FORCE_CHECK, true));
+        }
+
         private void updateAutomaticUpdateEnabledState() {
             boolean enabled = UpdatePreferences.automaticChecks(requireContext());
             if (updateIntervalPreference != null) {
@@ -620,6 +658,9 @@ public final class SettingsActivity extends AppCompatActivity {
             if (notifyUpdatePreference != null) {
                 notifyUpdatePreference.setChecked(
                         UpdatePreferences.notifyUpdatesEnabled(requireContext()));
+            }
+            if (updateChannelPreference != null) {
+                updateChannelPreference.setValue(UpdatePreferences.channel(requireContext()));
             }
             updateAutomaticUpdateEnabledState();
             updateAutomaticUpdateSummary();

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -186,6 +186,7 @@ public final class SettingsTransferStore {
         json.put("usage_pace_enabled", UsagePacePreferences.isEnabled(context));
         json.put("usage_pace_sensitivity", UsagePacePreferences.getSensitivity(context));
         json.put("automatic_update_checks", UpdatePreferences.automaticChecks(context));
+        json.put("update_channel", UpdatePreferences.channel(context));
         json.put("notify_updates", UpdatePreferences.notifyUpdatesEnabled(context));
         json.put("check_interval_hours", UpdatePreferences.checkIntervalHours(context));
         json.put("default_widget", SettingsTransfer.widgetOptionsToJson(
@@ -260,6 +261,8 @@ public final class SettingsTransferStore {
                 UpdatePreferences.checkIntervalHours(context)));
         UpdatePreferences.setNotifyUpdatesEnabled(context,
                 json.optBoolean("notify_updates", UpdatePreferences.notifyUpdatesEnabled(context)));
+        UpdatePreferences.setChannel(context, json.optString("update_channel",
+                UpdatePreferences.channel(context)));
         JSONObject widget = json.optJSONObject("default_widget");
         if (widget != null) {
             AppPreferences.saveDefaultWidgetOptions(context,

--- a/android/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java
@@ -104,7 +104,8 @@ public final class UpdateActivity extends AppCompatActivity {
                 List<GitHubRelease> releases = ReleaseUpdateClient.check(getApplicationContext());
                 GitHubRelease selected = GitHubReleaseParser.findVersion(releases, requestedVersion);
                 if (selected == null) {
-                    selected = GitHubReleaseParser.latestStable(releases);
+                    selected = UpdateChannel.trackedRelease(releases,
+                            UpdatePreferences.channel(getApplicationContext()));
                 }
                 GitHubRelease result = selected;
                 postUi(() -> {
@@ -133,10 +134,12 @@ public final class UpdateActivity extends AppCompatActivity {
         String installedVersion = UpdatePreferences.installedVersion(this);
         int comparison = ReleaseVersion.compare(release.version, installedVersion);
         boolean irreversible = ReleaseUpdatePolicy.isIrreversible(release.version);
+        boolean returnToStable = UpdateChannel.isReturnToStable(release, installedVersion);
         LinearLayout card = Ui.card(this, dark);
         TextView title = Ui.text(this,
                 comparison > 0 ? "Codex Meter " + release.version + " is available"
                         : comparison == 0 ? "Codex Meter " + release.version
+                        : returnToStable ? "Return to Codex Meter " + release.version
                         : "Older release " + release.version,
                 20, Ui.mainText(dark));
         title.setTypeface(Ui.mediumTypeface(this));
@@ -146,9 +149,14 @@ public final class UpdateActivity extends AppCompatActivity {
             detail = ReleaseUpdatePolicy.irreversibleSummary()
                     + " · Installed: " + installedVersion;
         } else if (comparison > 0) {
-            detail = "Installed: " + installedVersion + " · Verified GitHub upgrade";
+            detail = "Installed: " + installedVersion + (release.prerelease
+                    ? " · Verified GitHub alpha upgrade" : " · Verified GitHub upgrade");
         } else if (comparison == 0) {
             detail = "This version is currently installed. You can verify and reinstall it.";
+        } else if (returnToStable) {
+            detail = "Installed: " + installedVersion + " · Alpha builds share the stable "
+                    + "version code, so the newest stable release installs in place without "
+                    + "uninstalling or losing data.";
         } else {
             detail = "Installed: " + installedVersion
                     + " · Android requires uninstalling before this downgrade.";
@@ -172,11 +180,12 @@ public final class UpdateActivity extends AppCompatActivity {
             status = null;
         } else {
             Button action = Ui.nativePrimaryButton(this,
-                    comparison < 0 ? "Download older APK"
+                    returnToStable ? "Return to stable"
+                            : comparison < 0 ? "Download older APK"
                             : comparison == 0 ? "Verify and reinstall"
                             : "Download and install");
             action.setOnClickListener(view -> {
-                if (comparison < 0) {
+                if (comparison < 0 && !returnToStable) {
                     confirmOlderDownload();
                 } else {
                     requestInstall();
@@ -218,7 +227,7 @@ public final class UpdateActivity extends AppCompatActivity {
         historyParams.setMargins(0, Ui.dp(this, 20), 0, 0);
         content.addView(history, historyParams);
 
-        if (startInstallPending && comparison > 0 && !irreversible) {
+        if (startInstallPending && (comparison > 0 || returnToStable) && !irreversible) {
             startInstallPending = false;
             content.post(this::requestInstall);
         } else {

--- a/android/app/src/main/java/dev/bennett/codexmeter/UpdateChannel.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UpdateChannel.java
@@ -1,0 +1,71 @@
+package dev.bennett.codexmeter;
+
+import java.util.List;
+
+/**
+ * Release-channel policy for the in-app updater.
+ *
+ * <p>Stable tracks the newest non-prerelease GitHub release. Alpha additionally tracks
+ * prerelease builds tagged from the alpha branch. Alpha builds are signed with the same
+ * release certificate as stable builds and keep the versionCode of the stable release they
+ * branched from, so switching between channels is always an ordinary in-place install:
+ * upgrading onto an alpha and returning to the newest stable both pass Android's signature
+ * and versionCode checks without uninstalling.
+ */
+public final class UpdateChannel {
+    public static final String STABLE = "stable";
+    public static final String ALPHA = "alpha";
+
+    private UpdateChannel() {
+    }
+
+    public static String normalize(String value) {
+        return ALPHA.equalsIgnoreCase(value == null ? "" : value.trim()) ? ALPHA : STABLE;
+    }
+
+    public static boolean isAlpha(String channel) {
+        return ALPHA.equals(normalize(channel));
+    }
+
+    /** Newest release the channel tracks, independent of the installed version. */
+    public static GitHubRelease trackedRelease(List<GitHubRelease> releases, String channel) {
+        if (releases == null || releases.isEmpty()) {
+            return null;
+        }
+        if (isAlpha(channel)) {
+            return releases.get(0);
+        }
+        return GitHubReleaseParser.latestStable(releases);
+    }
+
+    /** Release to offer as an update for the installed version, or null when up to date. */
+    public static GitHubRelease selectUpdate(List<GitHubRelease> releases,
+            String installedVersion, String channel) {
+        GitHubRelease tracked = trackedRelease(releases, channel);
+        if (tracked == null) {
+            return null;
+        }
+        if (tracked.isNewerThan(installedVersion)) {
+            return tracked;
+        }
+        if (!isAlpha(channel) && isReturnToStable(tracked, installedVersion)) {
+            return tracked;
+        }
+        return null;
+    }
+
+    /**
+     * True when installing {@code release} leaves a prerelease build for the newest stable
+     * release. Alpha builds reuse the versionCode of the stable release they branched from,
+     * so this install is an in-place update even though SemVer orders it as older.
+     */
+    public static boolean isReturnToStable(GitHubRelease release, String installedVersion) {
+        if (release == null || release.prerelease) {
+            return false;
+        }
+        ReleaseVersion installed = ReleaseVersion.parse(installedVersion);
+        ReleaseVersion target = ReleaseVersion.parse(release.version);
+        return installed != null && target != null && installed.isPrerelease()
+                && target.compareTo(installed) < 0;
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java
@@ -70,8 +70,16 @@ public final class UpdateNotificationManager {
         if (!canPost(context, manager)) {
             return false;
         }
-        String title = "Codex Meter " + release.version + " is available";
-        String text = "A signed GitHub release is ready to install.";
+        boolean returnToStable = UpdateChannel.isReturnToStable(release,
+                UpdatePreferences.installedVersion(context));
+        String title = returnToStable
+                ? "Return to Codex Meter " + release.version
+                : "Codex Meter " + release.version + " is available";
+        String text = returnToStable
+                ? "The stable release installs in place over this alpha build."
+                : release.prerelease
+                ? "A signed alpha release is ready to install."
+                : "A signed GitHub release is ready to install.";
         PendingIntent open = activityPending(context, NOTIFICATION_ID,
                 updateIntent(context, release.version, false));
         PendingIntent update = activityPending(context, NOTIFICATION_ID + 1,

--- a/android/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java
@@ -9,6 +9,7 @@ import java.util.List;
 public final class UpdatePreferences {
     private static final String PREFS = "codex_meter_updates_v1";
     private static final String KEY_AUTOMATIC = "automatic";
+    private static final String KEY_CHANNEL = "release_channel";
     private static final String KEY_NOTIFY = "notify_updates";
     private static final String KEY_CHECK_INTERVAL_HOURS = "check_interval_hours";
     private static final String KEY_NOTIFIED_VERSION = "notified_version";
@@ -39,6 +40,23 @@ public final class UpdatePreferences {
             UpdateNotificationManager.dismiss(context);
             clearNotifiedVersion(context);
         }
+    }
+
+    public static String channel(Context context) {
+        return UpdateChannel.normalize(
+                prefs(context).getString(KEY_CHANNEL, UpdateChannel.STABLE));
+    }
+
+    public static void setChannel(Context context, String channel) {
+        String normalized = UpdateChannel.normalize(channel);
+        if (normalized.equals(channel(context))) {
+            return;
+        }
+        prefs(context).edit().putString(KEY_CHANNEL, normalized).apply();
+        UpdateNotificationManager.dismiss(context);
+        clearNotifiedVersion(context);
+        broadcast(context);
+        UpdateNotificationManager.onReleasesUpdated(context);
     }
 
     public static boolean notifyUpdatesEnabled(Context context) {
@@ -180,8 +198,8 @@ public final class UpdatePreferences {
     }
 
     public static GitHubRelease availableUpdate(Context context) {
-        GitHubRelease latest = latestStable(context);
-        return latest != null && latest.isNewerThan(installedVersion(context)) ? latest : null;
+        return UpdateChannel.selectUpdate(releases(context), installedVersion(context),
+                channel(context));
     }
 
     public static String installedVersion(Context context) {

--- a/android/app/src/main/res/values/settings_arrays.xml
+++ b/android/app/src/main/res/values/settings_arrays.xml
@@ -26,6 +26,14 @@
     <string-array name="settings_refresh_values">
         <item>5</item><item>10</item><item>15</item><item>30</item><item>60</item><item>120</item>
     </string-array>
+    <string-array name="settings_update_channel_entries">
+        <item>Stable</item>
+        <item>Alpha (early builds)</item>
+    </string-array>
+    <string-array name="settings_update_channel_values">
+        <item>stable</item>
+        <item>alpha</item>
+    </string-array>
     <string-array name="settings_update_interval_entries">
         <item>Every hour</item>
         <item>Every 6 hours</item>

--- a/android/app/src/main/res/xml/preferences_settings_updates.xml
+++ b/android/app/src/main/res/xml/preferences_settings_updates.xml
@@ -2,6 +2,15 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <PreferenceCategory android:title="Release channel">
+        <ListPreference
+            android:entries="@array/settings_update_channel_entries"
+            android:entryValues="@array/settings_update_channel_values"
+            android:key="update_channel_ui"
+            android:title="Update channel"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="Automatic updates">
         <SwitchPreferenceCompat
             android:key="automatic_update_checks_ui"

--- a/android/build.sh
+++ b/android/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-VERSION_NAME="2.6.10"
+VERSION_NAME="2.7.0"
 DIST="$ROOT/dist"
 SIGNING_DIR="$ROOT/.local-signing"
 KEYSTORE="$SIGNING_DIR/codex-meter-local.p12"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -74,14 +74,14 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
 java -ea -cp "$OUT:$JSON_JAR" dev.bennett.codexmeter.ParserSelfTest
 
 # Source-level release checks.
-grep -q 'VERSION_NAME = "2.6.10"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_CODE = 28' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'versionName = "2.6.10"' "$ROOT/app/build.gradle.kts"
-grep -q 'versionCode = 28' "$ROOT/app/build.gradle.kts"
-grep -q 'versionName = "2.6.10"' "$ROOT/wear/build.gradle.kts"
-grep -q 'versionCode = 28' "$ROOT/wear/build.gradle.kts"
-grep -q 'codex-meter-android/2.6.10' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
-grep -q 'VERSION_NAME="2.6.10"' "$ROOT/build.sh"
+grep -q 'VERSION_NAME = "2.7.0"' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_CODE = 29' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'versionName = "2.7.0"' "$ROOT/app/build.gradle.kts"
+grep -q 'versionCode = 29' "$ROOT/app/build.gradle.kts"
+grep -q 'versionName = "2.7.0"' "$ROOT/wear/build.gradle.kts"
+grep -q 'versionCode = 29' "$ROOT/wear/build.gradle.kts"
+grep -q 'codex-meter-android/2.7.0' "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppConstants.java"
+grep -q 'VERSION_NAME="2.7.0"' "$ROOT/build.sh"
 WORKFLOW="$ROOT/../.github/workflows/build-apk.yml"
 grep -Fq 'release-dist/CodexMeter-Wear-$VERSION_NAME.apk' "$WORKFLOW"
 grep -Fq '"platforms;android-37.0"' "$WORKFLOW"

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -63,6 +63,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseSource.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubRelease.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/GitHubReleaseParser.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateChannel.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseIntegrity.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
@@ -251,6 +252,25 @@ grep -q 'UpdateNotificationManager.onReleasesUpdated' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java"
 grep -q 'testUpdateCheckFrequency' "$ROOT/tests/ParserSelfTest.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java"
+
+# Alpha/stable release channels with in-place channel switching.
+test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateChannel.java"
+grep -q 'testUpdateChannel' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'UpdateChannel.selectUpdate' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdatePreferences.java"
+grep -q 'UpdateChannel.isReturnToStable' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateActivity.java"
+grep -q 'update_channel_ui' \
+  "$ROOT/app/src/main/res/xml/preferences_settings_updates.xml"
+grep -q 'update_channel_ui' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'settings_update_channel_entries' \
+  "$ROOT/app/src/main/res/values/settings_arrays.xml"
+grep -q '"update_channel"' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
+grep -Fq 'branches: [main, alpha]' "$WORKFLOW"
+grep -Fq -- '--prerelease="$PRERELEASE"' "$WORKFLOW"
+test -f "$ROOT/../.github/workflows/alpha-branch.yml"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManager.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -51,6 +51,7 @@ public final class ParserSelfTest {
         testOAuthBrowserPage();
         testReleaseVersions();
         testGitHubReleases();
+        testUpdateChannel();
         testReleaseChecksums();
         testReleaseNotesMarkdown();
         testReleaseUpdatePolicy();
@@ -1500,6 +1501,49 @@ public final class ParserSelfTest {
                 "local fixture rejected by production parser");
         check(GitHubReleaseParser.parse(localFixture, true).size() == 1,
                 "local fixture accepted only in explicit debug mode");
+    }
+
+    private static void testUpdateChannel() throws Exception {
+        check(UpdateChannel.STABLE.equals(UpdateChannel.normalize(null)),
+                "update channel defaults to stable");
+        check(UpdateChannel.ALPHA.equals(UpdateChannel.normalize(" Alpha ")),
+                "update channel normalization");
+        check(!UpdateChannel.isAlpha("nonsense"), "unknown channel treated as stable");
+        String json = "["
+                + releaseJson("v2.7.0-alpha.2", false, true, true, true)
+                + "," + releaseJson("v2.6.10", false, false, true, true)
+                + "," + releaseJson("v2.6.9", false, false, true, true)
+                + "]";
+        java.util.List<GitHubRelease> releases = GitHubReleaseParser.parse(json);
+        check(UpdateChannel.selectUpdate(releases, "2.6.10", UpdateChannel.STABLE) == null,
+                "stable channel ignores alpha builds");
+        GitHubRelease alphaPick = UpdateChannel.selectUpdate(
+                releases, "2.6.10", UpdateChannel.ALPHA);
+        check(alphaPick != null && "2.7.0-alpha.2".equals(alphaPick.version),
+                "alpha channel offers newest alpha");
+        GitHubRelease alphaHop = UpdateChannel.selectUpdate(
+                releases, "2.7.0-alpha.1", UpdateChannel.ALPHA);
+        check(alphaHop != null && "2.7.0-alpha.2".equals(alphaHop.version),
+                "alpha channel upgrades between alphas");
+        check(UpdateChannel.selectUpdate(releases, "2.7.0-alpha.2", UpdateChannel.ALPHA) == null,
+                "alpha channel idle on newest alpha");
+        GitHubRelease revert = UpdateChannel.selectUpdate(
+                releases, "2.7.0-alpha.2", UpdateChannel.STABLE);
+        check(revert != null && "2.6.10".equals(revert.version),
+                "stable channel offers in-place return from alpha");
+        check(UpdateChannel.isReturnToStable(revert, "2.7.0-alpha.2"),
+                "return-to-stable detected from alpha build");
+        check(!UpdateChannel.isReturnToStable(revert, "2.6.9"),
+                "stable-to-stable downgrade is not a return");
+        check(UpdateChannel.selectUpdate(releases, "2.6.9", UpdateChannel.STABLE) != null,
+                "stable channel still upgrades stable builds");
+        String promoted = "[" + releaseJson("v2.7.0", false, false, true, true)
+                + "," + releaseJson("v2.7.0-alpha.2", false, true, true, true) + "]";
+        java.util.List<GitHubRelease> promotedReleases = GitHubReleaseParser.parse(promoted);
+        GitHubRelease promotedPick = UpdateChannel.selectUpdate(
+                promotedReleases, "2.7.0-alpha.2", UpdateChannel.ALPHA);
+        check(promotedPick != null && "2.7.0".equals(promotedPick.version),
+                "alpha channel follows stable promotions");
     }
 
     private static String releaseJson(String tag, boolean draft, boolean prerelease,

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.bennett.codexmeter"
         minSdk = 30
         targetSdk = 36
-        versionCode = 28
-        versionName = "2.6.10"
+        versionCode = 29
+        versionName = "2.7.0"
     }
 
     signingConfigs {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a rapid-iteration **alpha** channel alongside stable, end to end — branch automation, CI prerelease publishing with a versionCode invariant, and an in-app channel picker with a one-tap "Return to stable" flow (no uninstalling, no signature or checksum mismatches, no data loss in either direction) — **and prepares the 2.7.0 stable release** (versionCode 29) that ships the feature, so merging this PR and tagging `v2.7.0` on the merge commit is the complete rollout.

### Why channel switching never requires a reinstall

- Every tagged build (stable or alpha) is signed by CI with the **same release keystore**, so the updater's existing signing-certificate check passes in both directions.
- Alpha builds keep the **versionCode of the newest stable release** (only `versionName` gains the `-alpha.N` suffix). Android allows equal-versionCode installs, so returning to stable is an ordinary in-place update instead of a blocked downgrade. Stable promotions bump versionCode, so they upgrade cleanly over any alpha.
- SHA-256 verification is untouched and keeps working: alpha releases publish the same `CodexMeter-<version>.apk` + `SHA256SUMS.txt` asset contract.

### Branch + CI automation

- New `Ensure alpha branch` workflow (`.github/workflows/alpha-branch.yml`) creates the `alpha` branch from `main` if missing — merging this PR bootstraps it automatically. It never force-syncs an existing `alpha`.
- `build-apk.yml`: PRs into `alpha` now build; `v*-alpha.N` tags publish as GitHub **prereleases** (never `--latest`); tag builds enforce the channel invariant (alpha tags must keep the newest stable tag's versionCode, stable tags must raise it).

### App changes

- New `UpdateChannel` policy class (pure Java, covered by `run-tests.sh` self-tests): stable channel tracks the newest non-prerelease, alpha tracks the newest release including prereleases and follows stable promotions.
- Settings → Updates gains a **Release channel** picker with a confirmation dialog when opting into alpha; switching channels immediately opens the update screen showing what that channel offers.
- `UpdateActivity`, dashboard update card, notification, and release history all understand the **return-to-stable** case (running an alpha on the stable channel offers the newest stable as an in-place install labeled "Return to stable").
- Channel preference round-trips through backup & transfer (`update_channel`).
- `CONTRIBUTING.md` documents the alpha tagging/promotion process and versioning rules.

### 2.7.0 release prep

- Version bumped to `2.7.0` / versionCode `29` across `app/build.gradle.kts`, `wear/build.gradle.kts`, `AppConstants.java` (both user agents), `android/build.sh`, and the `run-tests.sh` guards.
- `CHANGELOG.md` gains the `## 2.7.0` section (channel feature #88 + usage-history analytics #87) that CI extracts for the release notes.

## Testing

- `./run-tests.sh` passes at 2.7.0, including new `testUpdateChannel` self-tests (channel normalization, stable channel ignoring alphas, alpha-to-alpha upgrades, in-place return-to-stable selection, stable promotion following) and new source guards.
- `./build.sh` and `./lint.sh` pass; `aapt dump badging` confirms both dist APKs carry `versionCode='29' versionName='2.7.0'`.
- CI channel-invariant shell logic validated against the real tag history (`v2.6.10` → code 28) plus all pass/fail branches of the conditional; the release-notes awk extraction was dry-run against the new `## 2.7.0` changelog section and produces non-empty notes.
- Audited `UpdateInstaller` (only rejects `archiveCode < installedCode`, so equal-code channel hops install), `UpdateInstallReceiver`, and `ReleaseUpdateJobService` for version assumptions — all channel-agnostic.
- No emulator on this VM; recommend one on-device smoke test of the first full channel round-trip (stable → alpha → return to stable) when the first alpha tag is cut.

## Rollout after merge

1. Merge → `Ensure alpha branch` creates `alpha` from `main` automatically.
2. Tag the merge commit `v2.7.0` → CI builds, signs, and publishes the stable release; both channels' users get a normal update.
3. First alpha cycle: branch work off `alpha`, set `versionName` to `2.7.1-alpha.1` (or `2.8.0-alpha.1`) while **keeping versionCode 29**, add the matching `CHANGELOG.md` heading, update the `run-tests.sh` guards, tag it — CI publishes the prerelease and enforces the invariant.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0b88c13-e6f5-4f4b-9b5f-81bac5a5e5a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0b88c13-e6f5-4f4b-9b5f-81bac5a5e5a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

