### PR TITLE
Declutter usage-history analytics with customizable highlights

### DIFF
--- a/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java
@@ -17,6 +17,7 @@ public final class AppPreferences {
     private static final String KEY_DASHBOARD_USAGE_CREDITS = "dashboard_usage_credits";
     private static final String KEY_DASHBOARD_USAGE_HISTORY = "dashboard_usage_history";
     private static final String KEY_DASHBOARD_WEEKLY = "dashboard_weekly";
+    private static final String KEY_HISTORY_SECTION_OVERRIDES = "history_section_overrides";
     private static final String KEY_MATERIAL_YOU = "material_you";
     private static final String KEY_ERROR = "last_error";
     private static final String KEY_ERROR_AT = "last_error_at";
@@ -330,6 +331,28 @@ public final class AppPreferences {
     public static void setDashboardSectionHidden(Context context, String key, boolean hidden) {
         setDashboardHiddenSections(context,
                 DashboardSections.setHidden(getDashboardHiddenSections(context), key, hidden));
+    }
+
+    /** Usage-history highlight overrides as a {@link HistorySections} CSV. */
+    public static String getHistorySectionOverrides(Context context) {
+        return prefs(context).getString(KEY_HISTORY_SECTION_OVERRIDES, "");
+    }
+
+    public static void setHistorySectionOverrides(Context context, String overridesCsv) {
+        if (overridesCsv == null || overridesCsv.trim().isEmpty()) {
+            prefs(context).edit().remove(KEY_HISTORY_SECTION_OVERRIDES).apply();
+        } else {
+            prefs(context).edit().putString(KEY_HISTORY_SECTION_OVERRIDES, overridesCsv).apply();
+        }
+    }
+
+    public static boolean isHistorySectionVisible(Context context, String key) {
+        return HistorySections.isVisible(getHistorySectionOverrides(context), key);
+    }
+
+    public static void setHistorySectionVisible(Context context, String key, boolean visible) {
+        setHistorySectionOverrides(context,
+                HistorySections.setVisible(getHistorySectionOverrides(context), key, visible));
     }
 
     public static void setDashboardVisibility(Context context, boolean fiveHour,

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java
@@ -183,6 +183,8 @@ public final class SettingsTransferStore {
         json.put("dashboard_usage_history", AppPreferences.showDashboardUsageHistory(context));
         json.put("dashboard_hidden_sections",
                 AppPreferences.getDashboardHiddenSections(context));
+        json.put("history_section_overrides",
+                AppPreferences.getHistorySectionOverrides(context));
         json.put("usage_pace_enabled", UsagePacePreferences.isEnabled(context));
         json.put("usage_pace_sensitivity", UsagePacePreferences.getSensitivity(context));
         json.put("automatic_update_checks", UpdatePreferences.automaticChecks(context));
@@ -249,6 +251,9 @@ public final class SettingsTransferStore {
         AppPreferences.setDashboardHiddenSections(context,
                 json.optString("dashboard_hidden_sections",
                         AppPreferences.getDashboardHiddenSections(context)));
+        AppPreferences.setHistorySectionOverrides(context,
+                json.optString("history_section_overrides",
+                        AppPreferences.getHistorySectionOverrides(context)));
         UsagePacePreferences.setEnabled(context, json.optBoolean("usage_pace_enabled",
                 UsagePacePreferences.isEnabled(context)));
         UsagePacePreferences.setSensitivity(context, json.optString("usage_pace_sensitivity",

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java
@@ -5,6 +5,8 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.text.format.DateFormat;
 import android.view.Gravity;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -15,9 +17,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-/** Full local-history view with scrubbable charts, insights, and value estimates. */
+/**
+ * Full local-history view: scrubbable charts always, with every extra highlight —
+ * chart guide, previous-window list, insight rows, and value estimates — individually
+ * customizable so the page can stay as minimal as the user likes.
+ */
 public final class UsageHistoryActivity extends AppCompatActivity {
     private static final int MAX_BREAKDOWN_WINDOWS = 5;
+    private static final int MENU_CUSTOMIZE = 8201;
 
     private LinearLayout content;
     private boolean dark;
@@ -37,29 +44,65 @@ public final class UsageHistoryActivity extends AppCompatActivity {
         return true;
     }
 
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        menu.add(Menu.NONE, MENU_CUSTOMIZE, 0, "Customize")
+                .setIcon(R.drawable.ic_oui_edit_outline)
+                .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == MENU_CUSTOMIZE) {
+            showCustomizeDialog();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    /** Checklist of every optional highlight; changes persist and apply immediately. */
+    private void showCustomizeDialog() {
+        List<String> keys = HistorySections.all();
+        String[] labels = new String[keys.size()];
+        boolean[] checked = new boolean[keys.size()];
+        for (int i = 0; i < keys.size(); i++) {
+            labels[i] = HistorySections.label(keys.get(i));
+            checked[i] = AppPreferences.isHistorySectionVisible(this, keys.get(i));
+        }
+        new AlertDialog.Builder(this)
+                .setTitle("Highlights to show")
+                .setMultiChoiceItems(labels, checked, (dialog, which, isChecked) ->
+                        AppPreferences.setHistorySectionVisible(this, keys.get(which), isChecked))
+                .setPositiveButton("Done", null)
+                .setOnDismissListener(dialog -> render())
+                .show();
+    }
+
+    private boolean visible(String key) {
+        return AppPreferences.isHistorySectionVisible(this, key);
+    }
+
     private void render() {
         content.removeAllViews();
         UsageSnapshot snapshot = AppPreferences.loadSnapshot(this);
         UsageHistory five = AppPreferences.loadUsageHistory(this, UsageHistory.FIVE_HOUR);
         UsageHistory weekly = AppPreferences.loadUsageHistory(this, UsageHistory.WEEKLY);
-        PlanPricing pricing = snapshot == null ? null : PlanPricing.forPlan(snapshot.planType);
+        // Dollar figures ride on the value-estimates highlight; hiding it hides them all.
+        PlanPricing pricing = snapshot == null || !visible(HistorySections.VALUE_ESTIMATES)
+                ? null : PlanPricing.forPlan(snapshot.planType);
 
-        LinearLayout intro = Ui.card(this, dark);
-        TextView title = Ui.text(this, "Burn trends", 20, Ui.mainText(dark));
-        title.setTypeface(Ui.mediumTypeface(this));
-        intro.addView(title);
-        TextView detail = Ui.text(this,
-                "Samples stay on this device and are recorded only after a successful refresh. "
-                        + "The solid line is current usage, faint lines are previous windows, "
-                        + "the dotted diagonal is a sustainable pace, and the dashed extension "
-                        + "is the estimate. Touch and drag a chart to inspect any moment, and "
-                        + "tap a window below a chart to compare previous windows.",
-                13, Ui.secondaryText(dark));
-        LinearLayout.LayoutParams detailParams = new LinearLayout.LayoutParams(-1, -2);
-        detailParams.setMargins(0, Ui.dp(this, 8), 0, 0);
-        intro.addView(detail, detailParams);
-        content.addView(intro);
-        Ui.addSpacer(content, 20);
+        if (visible(HistorySections.GUIDE)) {
+            LinearLayout guide = Ui.card(this, dark);
+            guide.addView(Ui.text(this,
+                    "The solid line is this window's usage, faint lines are previous windows, "
+                            + "the dotted diagonal is a sustainable pace, and the dashed line is "
+                            + "the projection. Drag a chart to inspect any moment. Samples are "
+                            + "recorded after each successful refresh and stay on this device.",
+                    13, Ui.secondaryText(dark)));
+            content.addView(guide);
+            Ui.addSpacer(content, 20);
+        }
 
         // Windows still waiting for usage data are skipped instead of rendering blank charts.
         boolean hasCharts = false;
@@ -83,7 +126,7 @@ public final class UsageHistoryActivity extends AppCompatActivity {
             Ui.addSpacer(content, 20);
         }
 
-        if (snapshot != null && hasCharts) {
+        if (pricing != null && hasCharts) {
             content.addView(Ui.separator(this, "Estimated value"));
             content.addView(buildValueCard(snapshot, pricing));
             Ui.addSpacer(content, 20);
@@ -131,10 +174,15 @@ public final class UsageHistoryActivity extends AppCompatActivity {
                 snapshot == null ? now : snapshot.fetchedAtMillis, pace);
         card.addView(chart, new LinearLayout.LayoutParams(-1, Ui.dp(this, 200)));
 
-        String defaultDetail = "Touch and drag the chart to inspect any moment in time.";
+        List<UsageStats.WindowStats> breakdown =
+                UsageStats.windowBreakdown(history, MAX_BREAKDOWN_WINDOWS);
+        boolean showWindowRows = visible(HistorySections.WINDOW_LIST) && breakdown.size() > 1;
+
+        String defaultDetail = showWindowRows
+                ? "Drag to inspect · tap a window to compare" : "Drag to inspect";
         TextView scrubDetail = Ui.text(this, defaultDetail, 12, Ui.secondaryText(dark));
         LinearLayout.LayoutParams scrubParams = new LinearLayout.LayoutParams(-1, -2);
-        scrubParams.setMargins(Ui.dp(this, 12), Ui.dp(this, 2), Ui.dp(this, 12), 0);
+        scrubParams.setMargins(Ui.dp(this, 12), Ui.dp(this, 2), Ui.dp(this, 12), Ui.dp(this, 6));
         card.addView(scrubDetail, scrubParams);
         chart.setOnScrubListener(new UsageBurnChartView.OnScrubListener() {
             @Override
@@ -144,7 +192,7 @@ public final class UsageHistoryActivity extends AppCompatActivity {
                 String text = moment + " — " + Math.round(usedPercent) + "% used";
                 if (pricing != null) {
                     text += " · ≈ " + PlanPricing.formatUsd(
-                            pricing.estimatedValueUsd(history.kind, usedPercent)) + " of usage";
+                            pricing.estimatedValueUsd(history.kind, usedPercent));
                 }
                 scrubDetail.setTextColor(Ui.mainText(dark));
                 scrubDetail.setText(text);
@@ -157,17 +205,7 @@ public final class UsageHistoryActivity extends AppCompatActivity {
             }
         });
 
-        String summary = history.samples.size() + " samples · "
-                + history.completedWindowCount() + " completed window"
-                + (history.completedWindowCount() == 1 ? "" : "s");
-        TextView stats = Ui.text(this, summary, 12, Ui.secondaryText(dark));
-        LinearLayout.LayoutParams statsParams = new LinearLayout.LayoutParams(-1, -2);
-        statsParams.setMargins(Ui.dp(this, 12), Ui.dp(this, 6), Ui.dp(this, 12), Ui.dp(this, 6));
-        card.addView(stats, statsParams);
-
-        List<UsageStats.WindowStats> breakdown =
-                UsageStats.windowBreakdown(history, MAX_BREAKDOWN_WINDOWS);
-        if (breakdown.size() > 1) {
+        if (showWindowRows) {
             View divider = new View(this);
             divider.setBackgroundColor(Ui.divider(dark));
             LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(-1, 1);
@@ -244,7 +282,7 @@ public final class UsageHistoryActivity extends AppCompatActivity {
         // Current position against the typical pace of completed windows.
         long resetAt = window.effectiveResetAtMillis(observedAt);
         long durationMillis = window.windowSeconds * 1000L;
-        if (resetAt > 0L && durationMillis > 0L) {
+        if (visible(HistorySections.INSIGHT_PACE) && resetAt > 0L && durationMillis > 0L) {
             double elapsedFraction = 1d - Math.max(0d, Math.min(1d,
                     (resetAt - now) / (double) durationMillis));
             double typical = UsageStats.typicalUsedPercentAt(history, elapsedFraction);
@@ -263,29 +301,35 @@ public final class UsageHistoryActivity extends AppCompatActivity {
             }
         }
 
-        UsagePace.Assessment pace = snapshot == null ? null
-                : UsagePacePreferences.assess(this, snapshot, window, now);
-        if (pace != null && pace.available) {
-            addStatRow(card, "Projected exhaustion",
-                    UsageFormat.relative(pace.estimatedExhaustionAtMillis, now));
-            rows++;
-        }
-
-        double averageFinal = UsageStats.averageFinalPercent(history);
-        if (averageFinal >= 0d) {
-            addStatRow(card, "Avg. completed window", Math.round(averageFinal) + "% used");
-            rows++;
-        }
-
-        double peakBurn = UsageStats.peakBurnPercentPerHour(history);
-        if (peakBurn > 0d) {
-            String value = formatRate(peakBurn);
-            if (pricing != null) {
-                value += " · ≈ " + PlanPricing.formatUsd(
-                        pricing.windowValueUsd(history.kind) * peakBurn / 100d) + "/h";
+        if (visible(HistorySections.INSIGHT_EXHAUSTION)) {
+            UsagePace.Assessment pace = snapshot == null ? null
+                    : UsagePacePreferences.assess(this, snapshot, window, now);
+            if (pace != null && pace.available) {
+                addStatRow(card, "Projected exhaustion",
+                        UsageFormat.relative(pace.estimatedExhaustionAtMillis, now));
+                rows++;
             }
-            addStatRow(card, "Peak burn observed", value);
-            rows++;
+        }
+
+        if (visible(HistorySections.INSIGHT_AVERAGE)) {
+            double averageFinal = UsageStats.averageFinalPercent(history);
+            if (averageFinal >= 0d) {
+                addStatRow(card, "Avg. completed window", Math.round(averageFinal) + "% used");
+                rows++;
+            }
+        }
+
+        if (visible(HistorySections.INSIGHT_PEAK)) {
+            double peakBurn = UsageStats.peakBurnPercentPerHour(history);
+            if (peakBurn > 0d) {
+                String value = formatRate(peakBurn);
+                if (pricing != null) {
+                    value += " · ≈ " + PlanPricing.formatUsd(
+                            pricing.windowValueUsd(history.kind) * peakBurn / 100d) + "/h";
+                }
+                addStatRow(card, "Peak burn observed", value);
+                rows++;
+            }
         }
 
         if (pricing != null) {
@@ -301,15 +345,6 @@ public final class UsageHistoryActivity extends AppCompatActivity {
 
     private LinearLayout buildValueCard(UsageSnapshot snapshot, PlanPricing pricing) {
         LinearLayout card = Ui.card(this, dark);
-        if (pricing == null) {
-            String plan = UsageFormat.planLabel(snapshot.planType);
-            card.addView(Ui.text(this,
-                    (plan.isEmpty() ? "Your plan" : "The " + plan + " plan")
-                            + " has no researched usage-value estimates yet. Estimates cover "
-                            + "Plus, Pro 5x, and Pro 20x subscriptions.",
-                    13, Ui.secondaryText(dark)));
-            return card;
-        }
         TextView title = Ui.text(this, pricing.planLabel + " · "
                 + PlanPricing.formatUsd(pricing.monthlyPriceUsd) + "/month", 16,
                 Ui.mainText(dark));
@@ -329,9 +364,8 @@ public final class UsageHistoryActivity extends AppCompatActivity {
                             snapshot.weekly.remainingPercent())));
         }
         TextView disclaimer = Ui.text(this,
-                "Rough estimates from community research comparing subscription allowances "
-                        + "with equivalent API pricing. Actual limits vary by model and "
-                        + "workload; nothing here is a billing statement.",
+                "Rough community estimates comparing plan allowances with API pricing; "
+                        + "not a billing statement.",
                 12, Ui.secondaryText(dark));
         LinearLayout.LayoutParams disclaimerParams = new LinearLayout.LayoutParams(-1, -2);
         disclaimerParams.setMargins(0, Ui.dp(this, 10), 0, 0);

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -30,6 +30,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageCredits.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageLimit.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/DashboardSections.java" \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/HistorySections.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/WidgetMeters.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSnapshot.java" \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageSample.java" \
@@ -141,6 +142,23 @@ grep -q 'UsageStats.windowBreakdown' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
 test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/PlanPricing.java"
 test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageStats.java"
+
+# Usage-history declutter: customizable highlights with minimal defaults.
+test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/HistorySections.java"
+grep -q 'testHistorySections' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'MENU_CUSTOMIZE' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
+grep -q 'HistorySections.GUIDE' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
+grep -q 'isHistorySectionVisible' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/AppPreferences.java"
+grep -q 'history_section_overrides' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
+# The old always-on explainer card and sample-count summary row must stay gone.
+! grep -q 'Burn trends' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
+! grep -q 'completed window count' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageHistoryActivity.java"
 
 # Usage-history charts must be gated on real usage data instead of blank placeholders.
 grep -q 'fiveWindow != null && snapshot.fetchedAtMillis > 0L' \

--- a/android/shared/src/main/java/dev/bennett/codexmeter/HistorySections.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/HistorySections.java
@@ -1,0 +1,109 @@
+package dev.bennett.codexmeter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Stable keys for the optional Usage history highlights: the chart guide, the tappable
+ * previous-window list, each insight row, and the dollar value estimates. Visibility is
+ * stored as a comma-separated list of keys the user toggled away from their default, so
+ * changing a default later never overrides an explicit user choice. The chart itself and
+ * the clear-history action are always shown and have no key here.
+ */
+public final class HistorySections {
+    public static final String GUIDE = "guide";
+    public static final String WINDOW_LIST = "window_list";
+    public static final String INSIGHT_PACE = "insight_pace";
+    public static final String INSIGHT_EXHAUSTION = "insight_exhaustion";
+    public static final String INSIGHT_AVERAGE = "insight_average";
+    public static final String INSIGHT_PEAK = "insight_peak";
+    public static final String VALUE_ESTIMATES = "value_estimates";
+
+    private static final List<String> ALL = Arrays.asList(GUIDE, WINDOW_LIST, INSIGHT_PACE,
+            INSIGHT_EXHAUSTION, INSIGHT_AVERAGE, INSIGHT_PEAK, VALUE_ESTIMATES);
+
+    private HistorySections() {
+    }
+
+    /** Every customizable highlight, in the order the customize sheet lists them. */
+    public static List<String> all() {
+        return ALL;
+    }
+
+    /** The guide is opt-in extra reading; every other highlight starts visible. */
+    public static boolean defaultVisible(String key) {
+        return !GUIDE.equals(key);
+    }
+
+    /** User-facing label for a highlight key. */
+    public static String label(String key) {
+        switch (key == null ? "" : key) {
+            case GUIDE:
+                return "How to read the charts";
+            case WINDOW_LIST:
+                return "Previous window list";
+            case INSIGHT_PACE:
+                return "Pace vs. typical";
+            case INSIGHT_EXHAUSTION:
+                return "Projected exhaustion";
+            case INSIGHT_AVERAGE:
+                return "Average completed window";
+            case INSIGHT_PEAK:
+                return "Peak burn rate";
+            case VALUE_ESTIMATES:
+                return "Value estimates ($)";
+            default:
+                return key == null ? "" : key;
+        }
+    }
+
+    /** Whether a highlight is visible given the saved override CSV. */
+    public static boolean isVisible(String overridesCsv, String key) {
+        return defaultVisible(key) != parseCsv(overridesCsv).contains(key);
+    }
+
+    /** Returns the override CSV updated so the key resolves to the requested visibility. */
+    public static String setVisible(String overridesCsv, String key, boolean visible) {
+        if (key == null || key.trim().isEmpty()) {
+            return serialize(parseCsv(overridesCsv));
+        }
+        List<String> keys = new ArrayList<>(new LinkedHashSet<>(parseCsv(overridesCsv)));
+        String trimmed = key.trim();
+        if (visible == defaultVisible(trimmed)) {
+            keys.remove(trimmed);
+        } else if (!keys.contains(trimmed)) {
+            keys.add(trimmed);
+        }
+        return serialize(keys);
+    }
+
+    private static String serialize(List<String> keys) {
+        StringBuilder csv = new StringBuilder();
+        for (String key : keys) {
+            if (key == null || key.trim().isEmpty()) {
+                continue;
+            }
+            if (csv.length() > 0) {
+                csv.append(',');
+            }
+            csv.append(key.trim());
+        }
+        return csv.toString();
+    }
+
+    private static List<String> parseCsv(String csv) {
+        List<String> keys = new ArrayList<>();
+        if (csv == null || csv.trim().isEmpty()) {
+            return keys;
+        }
+        for (String part : csv.split(",")) {
+            String key = part.trim();
+            if (!key.isEmpty()) {
+                keys.add(key);
+            }
+        }
+        return keys;
+    }
+}

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -34,6 +34,7 @@ public final class ParserSelfTest {
         testUsagePace();
         testPlanPricing();
         testUsageStats();
+        testHistorySections();
         testAdaptiveRefreshPolicy();
         testNowBarAutoStart();
         testNowBarDisplayModes();
@@ -1756,6 +1757,52 @@ public final class ParserSelfTest {
         System.out.println("Usage stats demo: completed window avg "
                 + Math.round(completed.averageBurnPercentPerHour) + "%/h, typical@60% = "
                 + Math.round(typical) + "%.");
+    }
+
+    private static void testHistorySections() {
+        check(HistorySections.all().size() == 7, "seven customizable history highlights");
+        check(!HistorySections.defaultVisible(HistorySections.GUIDE),
+                "chart guide starts hidden for a minimal default page");
+        check(HistorySections.defaultVisible(HistorySections.WINDOW_LIST),
+                "previous-window list starts visible");
+        check(HistorySections.defaultVisible(HistorySections.VALUE_ESTIMATES),
+                "value estimates start visible");
+        check(HistorySections.isVisible("", HistorySections.INSIGHT_PACE),
+                "empty overrides keep defaults");
+        check(!HistorySections.isVisible(null, HistorySections.GUIDE),
+                "null overrides keep defaults");
+
+        String overrides = HistorySections.setVisible("", HistorySections.GUIDE, true);
+        check(HistorySections.isVisible(overrides, HistorySections.GUIDE),
+                "guide can be switched on");
+        overrides = HistorySections.setVisible(overrides,
+                HistorySections.VALUE_ESTIMATES, false);
+        check(!HistorySections.isVisible(overrides, HistorySections.VALUE_ESTIMATES),
+                "value estimates can be switched off");
+        check(HistorySections.isVisible(overrides, HistorySections.INSIGHT_PEAK),
+                "untouched highlights keep their defaults");
+        check("guide,value_estimates".equals(overrides),
+                "overrides serialize as a stable csv");
+
+        overrides = HistorySections.setVisible(overrides, HistorySections.GUIDE, false);
+        overrides = HistorySections.setVisible(overrides,
+                HistorySections.VALUE_ESTIMATES, true);
+        check(overrides.isEmpty(), "restoring defaults clears every override");
+        check("guide".equals(HistorySections.setVisible("guide, guide ,",
+                HistorySections.WINDOW_LIST, true)),
+                "duplicate and blank override entries collapse");
+
+        // Full minimal mode: everything optional switched off leaves just the charts.
+        String minimal = "";
+        for (String key : HistorySections.all()) {
+            minimal = HistorySections.setVisible(minimal, key, false);
+            check(!HistorySections.label(key).isEmpty(), "every highlight has a label");
+        }
+        for (String key : HistorySections.all()) {
+            check(!HistorySections.isVisible(minimal, key),
+                    "minimal mode hides every optional highlight");
+        }
+        System.out.println("History highlights: minimal defaults + per-insight overrides verified.");
     }
 
     private static void check(boolean condition, String name) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #87: the Usage history page was too verbose. This slims the default layout way down and makes every extra highlight individually customizable, so the page can be tuned to show only wanted insights — or stripped to just the charts.

### Decluttered defaults
- Removed the always-on "Burn trends" intro card (five lines of legend prose). A compact version now lives behind an opt-in "How to read the charts" highlight, hidden by default.
- Removed the redundant "N samples · N completed windows" summary row under each chart (the chart corner already shows the sample count).
- Collapsed the standing two-line scrub hint into one short line: "Drag to inspect · tap a window to compare" (drops the window-list half when that list is hidden).
- Trimmed the scrub readout ("of usage" suffix gone) and cut the value-card disclaimer to a single sentence.
- Dropped the "your plan has no researched estimates" filler card for unsupported plans; the value section simply doesn't render.

### Customizable highlights
- New toolbar Customize action (matching the dashboard's Edit pattern) opens a checklist of highlights: chart guide, previous-window list, the four insight rows (pace vs. typical, projected exhaustion, average window, peak burn), and value estimates.
- Hiding "Value estimates ($)" removes the plan card and every inline dollar figure (scrub readout, window rows, insights) in one switch; unchecking everything leaves a fully minimal page of just the charts and the clear-history button.
- Choices persist via a new pure-Java `HistorySections` override CSV (`shared/`), stored so a key only appears when toggled away from its default — future default changes never clobber explicit user choices. Included in settings export/import.

### Tests
- New `testHistorySections` self-test covering defaults, override round-trips, CSV dedup, and full minimal mode; `run-tests.sh` compiles the new class and adds source-wiring guards (including regression greps keeping the old intro card and summary row gone).

## Verification
- `./run-tests.sh` — all self-tests pass, including the new highlight-override checks.
- `./build.sh` — signed phone + Wear release APKs built (`CodexMeter-2.6.10.apk`, `CodexMeter-Wear-2.6.10.apk`).
- `./lint.sh` — `:app:lintRelease` + `:wear:lintRelease` pass.

## Emulator demo (software-emulated, no KVM)

Verified live on a Pixel 5 AVD (API 30, TCG/SwiftShader) using the debug-only `UsagePaceDemoActivity` seed data: chart scrubbing with dollar readout, the Customize dialog, and the fully minimal re-render.

[usage_history_declutter_customize_demo.mp4](https://cursor.com/agents/bc-11fc6082-b97f-41ab-bb8e-480fb9e70ed4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusage_history_declutter_customize_demo.mp4)

| Default (decluttered) | Minimal mode (everything unchecked) |
|---|---|
| [Default decluttered usage history](https://cursor.com/agents/bc-11fc6082-b97f-41ab-bb8e-480fb9e70ed4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_default_decluttered.png) | [Minimal mode with charts only](https://cursor.com/agents/bc-11fc6082-b97f-41ab-bb8e-480fb9e70ed4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_minimal_mode.png) |

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11fc6082-b97f-41ab-bb8e-480fb9e70ed4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11fc6082-b97f-41ab-bb8e-480fb9e70ed4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

