### PR TITLE
Add opt-in diagnostic log tracing and export

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <application
+        android:name="dev.bennett.codexmeter.CodexMeterApplication"
         android:theme="@style/AppTheme"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.view.Gravity;
 import android.view.Menu;
@@ -14,6 +15,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.graphics.Insets;
@@ -28,7 +30,10 @@ import dev.oneuiproject.oneui.utils.EdgeToEdge;
 public final class AboutActivity extends AppCompatActivity {
     private static final int MENU_GITHUB = 8201;
     private static final int MENU_APP_INFO = 8202;
+    private static final int DIAGNOSTIC_TAPS = 7;
     private boolean dark;
+    private int versionTaps;
+    private long lastVersionTap;
 
     @Override
     protected void onCreate(Bundle bundle) {
@@ -40,7 +45,9 @@ public final class AboutActivity extends AppCompatActivity {
         applySystemBarInsets();
         setupToolbar();
         setupCollapsingContent();
-        ((TextView) findViewById(R.id.about_header_version)).setText(getString(R.string.about_version, Ui.versionName(this)));
+        TextView version = findViewById(R.id.about_header_version);
+        version.setText(getString(R.string.about_version, Ui.versionName(this)));
+        version.setOnClickListener(this::onVersionTap);
         build(findViewById(R.id.about_content));
     }
 
@@ -111,7 +118,26 @@ public final class AboutActivity extends AppCompatActivity {
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(0, -2, 1);
         params.setMargins(Ui.dp(this, 20), 0, 0, 0);
         card.addView(text, params);
+        card.setOnClickListener(this::onVersionTap);
         return card;
+    }
+
+    private void onVersionTap(View ignored) {
+        long now = SystemClock.elapsedRealtime();
+        if (now - lastVersionTap > 3_000L) {
+            versionTaps = 0;
+        }
+        lastVersionTap = now;
+        versionTaps++;
+        int remaining = DIAGNOSTIC_TAPS - versionTaps;
+        if (remaining <= 0) {
+            versionTaps = 0;
+            Toast.makeText(this, "Diagnostics unlocked.", Toast.LENGTH_SHORT).show();
+            startActivity(SettingsActivity.diagnosticsIntent(this));
+        } else if (remaining <= 3) {
+            Toast.makeText(this, remaining + " more tap" + (remaining == 1 ? "" : "s")
+                    + " for diagnostics.", Toast.LENGTH_SHORT).show();
+        }
     }
 
     private CardItemView personRow(String title, String summary, int avatar, boolean divider, String url) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
@@ -6,7 +6,6 @@ import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.SystemClock;
 import android.provider.Settings;
 import android.view.Gravity;
 import android.view.Menu;
@@ -33,7 +32,6 @@ public final class AboutActivity extends AppCompatActivity {
     private static final int DIAGNOSTIC_TAPS = 7;
     private boolean dark;
     private int versionTaps;
-    private long lastVersionTap;
 
     @Override
     protected void onCreate(Bundle bundle) {
@@ -124,17 +122,12 @@ public final class AboutActivity extends AppCompatActivity {
     }
 
     private void onVersionTap(View ignored) {
-        long now = SystemClock.elapsedRealtime();
-        if (now - lastVersionTap > 10_000L) {
-            versionTaps = 0;
-        }
-        lastVersionTap = now;
         versionTaps++;
         int remaining = DIAGNOSTIC_TAPS - versionTaps;
         if (remaining <= 0) {
-            versionTaps = 0;
             Toast.makeText(this, "Diagnostics unlocked.", Toast.LENGTH_SHORT).show();
             startActivity(SettingsActivity.diagnosticsIntent(this));
+            versionTaps = 0;
         } else if (remaining <= 3) {
             Toast.makeText(this, remaining + " more tap" + (remaining == 1 ? "" : "s")
                     + " for diagnostics.", Toast.LENGTH_SHORT).show();

--- a/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/AboutActivity.java
@@ -48,6 +48,7 @@ public final class AboutActivity extends AppCompatActivity {
         TextView version = findViewById(R.id.about_header_version);
         version.setText(getString(R.string.about_version, Ui.versionName(this)));
         version.setOnClickListener(this::onVersionTap);
+        findViewById(R.id.about_header_icon).setOnClickListener(this::onVersionTap);
         build(findViewById(R.id.about_content));
     }
 
@@ -124,7 +125,7 @@ public final class AboutActivity extends AppCompatActivity {
 
     private void onVersionTap(View ignored) {
         long now = SystemClock.elapsedRealtime();
-        if (now - lastVersionTap > 3_000L) {
+        if (now - lastVersionTap > 10_000L) {
             versionTaps = 0;
         }
         lastVersionTap = now;

--- a/android/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/BootReceiver.java
@@ -10,6 +10,8 @@ public final class BootReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         String action = intent == null ? null : intent.getAction();
         if ("android.intent.action.BOOT_COMPLETED".equals(action) || "android.intent.action.MY_PACKAGE_REPLACED".equals(action)) {
+            DiagnosticLog.info(context, "process", "boot_receiver",
+                    "action", action);
             RefreshScheduler.schedulePeriodic(context);
             ReleaseUpdateScheduler.ensureScheduled(context);
             ResetAlertScheduler.scheduleFromSnapshot(context, AppPreferences.loadSnapshot(context));

--- a/android/app/src/main/java/dev/bennett/codexmeter/CodexMeterApplication.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/CodexMeterApplication.java
@@ -1,0 +1,67 @@
+package dev.bennett.codexmeter;
+
+import android.app.Activity;
+import android.app.Application;
+import android.content.ComponentCallbacks2;
+import android.os.Bundle;
+
+/** Installs opt-in process and screen lifecycle diagnostics without touching normal app data. */
+public final class CodexMeterApplication extends Application
+        implements Application.ActivityLifecycleCallbacks {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        DiagnosticLog.install(this);
+        registerActivityLifecycleCallbacks(this);
+        DiagnosticLog.info(this, "process", "application_started");
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        super.onTrimMemory(level);
+        DiagnosticLog.info(this, "process", "memory_trimmed", "level", level,
+                "ui_hidden", level == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN);
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        DiagnosticLog.warn(this, "process", "low_memory");
+    }
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle state) {
+        DiagnosticLog.info(this, "screen", "created",
+                "activity", activity.getClass().getSimpleName(),
+                "restored", state != null);
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        DiagnosticLog.info(this, "screen", "resumed",
+                "activity", activity.getClass().getSimpleName());
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+        DiagnosticLog.info(this, "screen", "stopped",
+                "activity", activity.getClass().getSimpleName(),
+                "changing_configuration", activity.isChangingConfigurations());
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle state) {
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/DiagnosticLog.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DiagnosticLog.java
@@ -1,0 +1,346 @@
+package dev.bennett.codexmeter;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Build;
+import android.os.SystemClock;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/** Opt-in, privacy-filtered, rotating JSONL diagnostics stored only in app-private storage. */
+public final class DiagnosticLog {
+    private static final String DIRECTORY = "diagnostic-logs";
+    private static final String CURRENT_FILE = "events.jsonl";
+    private static final String PREF_ENABLED = "enabled";
+    private static final String PREF_SESSION = "session_id";
+    private static final String PREFERENCES = "codex_meter_diagnostic_log_v1";
+    private static final int MAX_ARCHIVES = 2;
+    private static final long MAX_FILE_BYTES = 1024L * 1024L;
+    private static final Object FILE_LOCK = new Object();
+    private static final AtomicBoolean INSTALLED = new AtomicBoolean();
+    private static final AtomicLong SEQUENCE = new AtomicLong();
+    private static volatile Context applicationContext;
+
+    public static final class Stats {
+        public final long bytes;
+        public final int files;
+
+        Stats(long bytes, int files) {
+            this.bytes = bytes;
+            this.files = files;
+        }
+
+        public boolean hasLogs() {
+            return bytes > 0L;
+        }
+    }
+
+    private DiagnosticLog() {
+    }
+
+    public static void install(Context context) {
+        Context app = appContext(context);
+        if (app != null) {
+            applicationContext = app;
+        }
+        if (app == null || !INSTALLED.compareAndSet(false, true)) {
+            return;
+        }
+        Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            error(app, "process", "uncaught_exception", throwable,
+                    "crashed_thread", thread == null ? "" : thread.getName());
+            if (previous != null) {
+                previous.uncaughtException(thread, throwable);
+            }
+        });
+    }
+
+    public static boolean isEnabled(Context context) {
+        Context app = appContext(context);
+        return app != null && preferences(app).getBoolean(PREF_ENABLED, false);
+    }
+
+    public static void setEnabled(Context context, boolean enabled) {
+        Context app = appContext(context);
+        if (app == null) {
+            return;
+        }
+        install(app);
+        boolean wasEnabled = isEnabled(app);
+        if (wasEnabled == enabled) {
+            return;
+        }
+        if (enabled) {
+            String session = UUID.randomUUID().toString();
+            preferences(app).edit()
+                    .putString(PREF_SESSION, session)
+                    .putBoolean(PREF_ENABLED, true)
+                    .commit();
+            info(app, "diagnostics", "tracing_enabled",
+                    "app_version", appVersion(app),
+                    "android_sdk", Build.VERSION.SDK_INT,
+                    "device", Build.MANUFACTURER + " " + Build.MODEL);
+        } else {
+            info(app, "diagnostics", "tracing_disabled");
+            preferences(app).edit().putBoolean(PREF_ENABLED, false).commit();
+        }
+    }
+
+    public static void info(Context context, String category, String event, Object... fields) {
+        write(context, "info", category, event, null, fields);
+    }
+
+    public static void warn(Context context, String category, String event, Object... fields) {
+        write(context, "warn", category, event, null, fields);
+    }
+
+    public static void error(Context context, String category, String event, Throwable error,
+            Object... fields) {
+        write(context, "error", category, event, error, fields);
+    }
+
+    public static void info(String category, String event, Object... fields) {
+        info(applicationContext, category, event, fields);
+    }
+
+    public static void warn(String category, String event, Object... fields) {
+        warn(applicationContext, category, event, fields);
+    }
+
+    public static void error(String category, String event, Throwable error, Object... fields) {
+        error(applicationContext, category, event, error, fields);
+    }
+
+    public static Stats stats(Context context) {
+        Context app = appContext(context);
+        if (app == null) {
+            return new Stats(0L, 0);
+        }
+        synchronized (FILE_LOCK) {
+            long bytes = 0L;
+            int files = 0;
+            for (File file : orderedFiles(app)) {
+                if (file.isFile() && file.length() > 0L) {
+                    bytes += file.length();
+                    files++;
+                }
+            }
+            return new Stats(bytes, files);
+        }
+    }
+
+    public static void clear(Context context) {
+        Context app = appContext(context);
+        if (app == null) {
+            return;
+        }
+        synchronized (FILE_LOCK) {
+            for (File file : orderedFiles(app)) {
+                if (file.exists()) {
+                    file.delete();
+                }
+            }
+        }
+    }
+
+    public static void export(Context context, Uri destination) throws Exception {
+        Context app = appContext(context);
+        if (app == null || destination == null) {
+            throw new IllegalArgumentException("A diagnostic log destination is required.");
+        }
+        info(app, "diagnostics", "export_started");
+        synchronized (FILE_LOCK) {
+            try (OutputStream raw = app.getContentResolver().openOutputStream(destination, "wt")) {
+                if (raw == null) {
+                    throw new IllegalStateException("Android could not open the export file.");
+                }
+                try (BufferedOutputStream output = new BufferedOutputStream(raw)) {
+                    byte[] buffer = new byte[16 * 1024];
+                    for (File file : orderedFiles(app)) {
+                        if (!file.isFile() || file.length() == 0L) {
+                            continue;
+                        }
+                        try (BufferedInputStream input =
+                                new BufferedInputStream(new FileInputStream(file))) {
+                            int read;
+                            while ((read = input.read(buffer)) != -1) {
+                                output.write(buffer, 0, read);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        info(app, "diagnostics", "export_finished");
+    }
+
+    public static String formatBytes(long bytes) {
+        if (bytes < 1024L) {
+            return bytes + " B";
+        }
+        if (bytes < 1024L * 1024L) {
+            return Math.max(1L, bytes / 1024L) + " KB";
+        }
+        return String.format(java.util.Locale.US, "%.1f MB", bytes / (1024.0 * 1024.0));
+    }
+
+    private static void write(Context context, String level, String category, String event,
+            Throwable error, Object... fields) {
+        Context app = appContext(context);
+        if (app == null || !isEnabled(app)) {
+            return;
+        }
+        try {
+            JSONObject record = new JSONObject();
+            record.put("timestamp", Instant.now().toString());
+            record.put("elapsed_ms", SystemClock.elapsedRealtime());
+            record.put("sequence", SEQUENCE.incrementAndGet());
+            record.put("session_id", preferences(app).getString(PREF_SESSION, ""));
+            record.put("level", safe(level));
+            record.put("category", safe(category));
+            record.put("event", safe(event));
+            record.put("thread", safe(Thread.currentThread().getName()));
+            JSONObject details = details(fields);
+            if (details.length() > 0) {
+                record.put("details", details);
+            }
+            if (error != null) {
+                record.put("error", errorDetails(error));
+            }
+            append(app, record.toString() + "\n");
+        } catch (Exception ignored) {
+            // Diagnostics must never break the operation being diagnosed.
+        }
+    }
+
+    private static JSONObject details(Object... fields) throws Exception {
+        JSONObject result = new JSONObject();
+        if (fields == null) {
+            return result;
+        }
+        for (int index = 0; index + 1 < fields.length; index += 2) {
+            String key = safe(String.valueOf(fields[index]));
+            Object value = fields[index + 1];
+            if (value == null) {
+                result.put(key, JSONObject.NULL);
+            } else if (value instanceof Number || value instanceof Boolean) {
+                result.put(key, value);
+            } else {
+                result.put(key, safe(String.valueOf(value)));
+            }
+        }
+        return result;
+    }
+
+    private static JSONObject errorDetails(Throwable throwable) throws Exception {
+        JSONObject result = new JSONObject();
+        result.put("type", throwable.getClass().getName());
+        result.put("message", safe(throwable.getMessage()));
+        JSONArray stack = new JSONArray();
+        StackTraceElement[] elements = throwable.getStackTrace();
+        for (int index = 0; index < elements.length && index < 20; index++) {
+            stack.put(safe(elements[index].toString()));
+        }
+        result.put("stack", stack);
+        Throwable cause = throwable.getCause();
+        if (cause != null && cause != throwable) {
+            result.put("cause_type", cause.getClass().getName());
+            result.put("cause_message", safe(cause.getMessage()));
+        }
+        return result;
+    }
+
+    private static void append(Context app, String line) throws Exception {
+        byte[] encoded = line.getBytes(StandardCharsets.UTF_8);
+        synchronized (FILE_LOCK) {
+            File directory = directory(app);
+            if (!directory.exists() && !directory.mkdirs()) {
+                return;
+            }
+            File current = new File(directory, CURRENT_FILE);
+            if (current.length() + encoded.length > MAX_FILE_BYTES) {
+                rotate(directory);
+            }
+            try (FileOutputStream output = new FileOutputStream(current, true);
+                    BufferedWriter writer = new BufferedWriter(
+                            new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
+                writer.write(line);
+            }
+        }
+    }
+
+    private static void rotate(File directory) {
+        File oldest = archive(directory, MAX_ARCHIVES);
+        if (oldest.exists()) {
+            oldest.delete();
+        }
+        for (int index = MAX_ARCHIVES - 1; index >= 1; index--) {
+            File source = archive(directory, index);
+            if (source.exists()) {
+                source.renameTo(archive(directory, index + 1));
+            }
+        }
+        File current = new File(directory, CURRENT_FILE);
+        if (current.exists()) {
+            current.renameTo(archive(directory, 1));
+        }
+    }
+
+    private static File[] orderedFiles(Context app) {
+        File directory = directory(app);
+        return new File[] {
+                archive(directory, 2),
+                archive(directory, 1),
+                new File(directory, CURRENT_FILE)
+        };
+    }
+
+    private static File archive(File directory, int index) {
+        return new File(directory, "events." + index + ".jsonl");
+    }
+
+    private static File directory(Context app) {
+        return new File(app.getFilesDir(), DIRECTORY);
+    }
+
+    private static SharedPreferences preferences(Context app) {
+        return app.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+    }
+
+    private static Context appContext(Context context) {
+        if (context == null) {
+            return applicationContext;
+        }
+        Context app = context.getApplicationContext();
+        return app == null ? context : app;
+    }
+
+    private static String safe(String value) {
+        return DiagnosticSanitizer.redact(value == null ? "" : value);
+    }
+
+    private static String appVersion(Context app) {
+        try {
+            String version = app.getPackageManager()
+                    .getPackageInfo(app.getPackageName(), 0).versionName;
+            return version == null ? "" : version;
+        } catch (Exception ignored) {
+            return "";
+        }
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/DiagnosticLog.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DiagnosticLog.java
@@ -2,6 +2,8 @@ package dev.bennett.codexmeter;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.net.NetworkCapabilities;
 import android.net.Uri;
 import android.os.Build;
 import android.os.SystemClock;
@@ -60,6 +62,9 @@ public final class DiagnosticLog {
         if (app == null || !INSTALLED.compareAndSet(false, true)) {
             return;
         }
+        if (isEnabled(app)) {
+            preferences(app).edit().putString(PREF_SESSION, UUID.randomUUID().toString()).apply();
+        }
         Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
             error(app, "process", "uncaught_exception", throwable,
@@ -90,14 +95,14 @@ public final class DiagnosticLog {
             preferences(app).edit()
                     .putString(PREF_SESSION, session)
                     .putBoolean(PREF_ENABLED, true)
-                    .commit();
+                    .apply();
             info(app, "diagnostics", "tracing_enabled",
                     "app_version", appVersion(app),
                     "android_sdk", Build.VERSION.SDK_INT,
                     "device", Build.MANUFACTURER + " " + Build.MODEL);
         } else {
             info(app, "diagnostics", "tracing_disabled");
-            preferences(app).edit().putBoolean(PREF_ENABLED, false).commit();
+            preferences(app).edit().putBoolean(PREF_ENABLED, false).apply();
         }
     }
 
@@ -219,6 +224,9 @@ public final class DiagnosticLog {
             if (details.length() > 0) {
                 record.put("details", details);
             }
+            if ("network".equals(category)) {
+                record.put("connectivity", connectivity(app));
+            }
             if (error != null) {
                 record.put("error", errorDetails(error));
             }
@@ -226,6 +234,40 @@ public final class DiagnosticLog {
         } catch (Exception ignored) {
             // Diagnostics must never break the operation being diagnosed.
         }
+    }
+
+    private static JSONObject connectivity(Context app) throws Exception {
+        JSONObject result = new JSONObject();
+        try {
+            ConnectivityManager manager =
+                    (ConnectivityManager) app.getSystemService(Context.CONNECTIVITY_SERVICE);
+            if (manager == null) {
+                result.put("available", false);
+                return result;
+            }
+            NetworkCapabilities capabilities =
+                    manager.getNetworkCapabilities(manager.getActiveNetwork());
+            result.put("available", capabilities != null);
+            result.put("metered", manager.isActiveNetworkMetered());
+            if (capabilities != null) {
+                result.put("internet",
+                        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET));
+                result.put("validated",
+                        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED));
+                result.put("wifi",
+                        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI));
+                result.put("cellular",
+                        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR));
+                result.put("ethernet",
+                        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET));
+                result.put("vpn",
+                        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN));
+            }
+        } catch (RuntimeException exception) {
+            result.put("available", false);
+            result.put("read_error", safe(exception.getClass().getSimpleName()));
+        }
+        return result;
     }
 
     private static JSONObject details(Object... fields) throws Exception {

--- a/android/app/src/main/java/dev/bennett/codexmeter/DiagnosticSanitizer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DiagnosticSanitizer.java
@@ -1,6 +1,7 @@
 package dev.bennett.codexmeter;
 
 import java.net.URI;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,9 +51,9 @@ public final class DiagnosticSanitizer {
                 return redact(value);
             }
             StringBuilder safe = new StringBuilder()
-                    .append(scheme.toLowerCase())
+                    .append(scheme.toLowerCase(Locale.ROOT))
                     .append("://")
-                    .append(host.toLowerCase());
+                    .append(host.toLowerCase(Locale.ROOT));
             if (uri.getPort() >= 0) {
                 safe.append(':').append(uri.getPort());
             }

--- a/android/app/src/main/java/dev/bennett/codexmeter/DiagnosticSanitizer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/DiagnosticSanitizer.java
@@ -1,0 +1,79 @@
+package dev.bennett.codexmeter;
+
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Pure-Java privacy filters shared by diagnostic logging and its self-tests. */
+public final class DiagnosticSanitizer {
+    private static final String REDACTED = "[REDACTED]";
+    private static final Pattern AUTH_SCHEME = Pattern.compile(
+            "(?i)\\b(?:Bearer|Basic)\\s+[A-Za-z0-9._~+/=-]+");
+    private static final Pattern EMAIL = Pattern.compile(
+            "(?i)\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b");
+    private static final Pattern JWT = Pattern.compile(
+            "\\b[A-Za-z0-9_-]{12,}\\.[A-Za-z0-9_-]{12,}\\.[A-Za-z0-9_-]{8,}\\b");
+    private static final Pattern SENSITIVE_ASSIGNMENT = Pattern.compile(
+            "(?i)\\b(authorization|proxy-authorization|cookie|set-cookie|"
+                    + "access[_-]?token|refresh[_-]?token|id[_-]?token|"
+                    + "client[_-]?secret|code[_-]?verifier|password|passwd|"
+                    + "session(?:id)?|api[_-]?key)\\b"
+                    + "\\s*[\"']?\\s*[:=]\\s*[\"']?"
+                    + "([^\\s,;&}\\]]+)");
+    private static final Pattern SENSITIVE_QUERY = Pattern.compile(
+            "(?i)([?&](?:code|state|token|access_token|refresh_token|id_token|"
+                    + "code_verifier|client_secret|password|session)=)[^&#\\s]+");
+
+    private DiagnosticSanitizer() {
+    }
+
+    public static String redact(String value) {
+        if (value == null || value.isEmpty()) {
+            return value == null ? "" : value;
+        }
+        String result = AUTH_SCHEME.matcher(value).replaceAll(REDACTED);
+        result = JWT.matcher(result).replaceAll(REDACTED);
+        result = EMAIL.matcher(result).replaceAll("[REDACTED_EMAIL]");
+        result = replaceAssignments(result);
+        return SENSITIVE_QUERY.matcher(result).replaceAll("$1" + REDACTED);
+    }
+
+    public static String safeUrl(String value) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+        try {
+            URI uri = URI.create(value);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if (scheme == null || host == null) {
+                return redact(value);
+            }
+            StringBuilder safe = new StringBuilder()
+                    .append(scheme.toLowerCase())
+                    .append("://")
+                    .append(host.toLowerCase());
+            if (uri.getPort() >= 0) {
+                safe.append(':').append(uri.getPort());
+            }
+            String path = uri.getRawPath();
+            if (path != null && !path.isEmpty()) {
+                safe.append(path);
+            }
+            return safe.toString();
+        } catch (RuntimeException ignored) {
+            return redact(value);
+        }
+    }
+
+    private static String replaceAssignments(String value) {
+        Matcher matcher = SENSITIVE_ASSIGNMENT.matcher(value);
+        StringBuffer result = new StringBuffer();
+        while (matcher.find()) {
+            matcher.appendReplacement(result,
+                    Matcher.quoteReplacement(matcher.group(1) + "=" + REDACTED));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+}

--- a/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/MainActivity.java
@@ -124,10 +124,12 @@ public final class MainActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == MENU_SETTINGS) {
+            DiagnosticLog.info(this, "user", "settings_opened");
             Ui.startSecondaryActivity(this, SettingsActivity.class);
             return true;
         }
         if (item.getItemId() == MENU_REORDER) {
+            DiagnosticLog.info(this, "user", "dashboard_editor_opened");
             Ui.startSecondaryActivity(this, DashboardReorderActivity.class);
             return true;
         }
@@ -839,6 +841,8 @@ public final class MainActivity extends AppCompatActivity {
 
     public void startOrContinueSignIn() {
         String str;
+        DiagnosticLog.info(this, "user", "sign_in_requested",
+                "already_signed_in", SecureTokenStore.isSignedIn(this));
         if (SecureTokenStore.isSignedIn(this)) {
             AppPreferences.setOAuthPending(this, false, "");
             rebuild();
@@ -853,6 +857,7 @@ public final class MainActivity extends AppCompatActivity {
             }
             Toast.makeText(this, str, 0).show();
         } catch (RuntimeException e) {
+            DiagnosticLog.error(this, "auth", "sign_in_service_start_failed", e);
             AppPreferences.setOAuthPending(this, false, "");
             Toast.makeText(this, "Could not start sign-in: " + safeMessage(e), 1).show();
         }
@@ -870,6 +875,7 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     public void refreshNow(Button button) {
+        DiagnosticLog.info(this, "user", "manual_refresh_requested", "source", "button");
         button.setEnabled(false);
         button.setText(R.string.refreshing);
         final Context applicationContext = getApplicationContext();
@@ -882,11 +888,15 @@ public final class MainActivity extends AppCompatActivity {
                     MainActivity.this.runOnUiThread(new Runnable() { // from class: dev.bennett.codexmeter.MainActivity.9.1
                         @Override // java.lang.Runnable
                         public void run() {
+                            DiagnosticLog.info(applicationContext, "user",
+                                    "manual_refresh_finished", "source", "button");
                             Toast.makeText(MainActivity.this, "Usage updated.", 0).show();
                             MainActivity.this.rebuild();
                         }
                     });
                 } catch (Exception e) {
+                    DiagnosticLog.error(applicationContext, "user", "manual_refresh_failed", e,
+                            "source", "button");
                     AppPreferences.setLastError(applicationContext, MainActivity.safeMessage(e));
                     WidgetRenderer.updateAll(applicationContext);
                     MainActivity.this.runOnUiThread(new Runnable() { // from class: dev.bennett.codexmeter.MainActivity.9.2
@@ -902,7 +912,10 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     private void refreshFromPull() {
+        DiagnosticLog.info(this, "user", "manual_refresh_requested", "source", "pull");
         if (!SecureTokenStore.isSignedIn(this)) {
+            DiagnosticLog.warn(this, "user", "manual_refresh_rejected",
+                    "source", "pull", "reason", "signed_out");
             this.swipeRefresh.setRefreshing(false);
             Toast.makeText(this, "Sign in from Settings to refresh usage.", Toast.LENGTH_SHORT).show();
             Ui.startSecondaryActivity(this, SettingsActivity.class);
@@ -914,10 +927,14 @@ public final class MainActivity extends AppCompatActivity {
                 RefreshScheduler.scheduleAtNextReset(applicationContext, UsageApi.refreshAndCache(applicationContext));
                 WidgetRenderer.updateAll(applicationContext);
                 runOnUiThread(() -> {
+                    DiagnosticLog.info(applicationContext, "user",
+                            "manual_refresh_finished", "source", "pull");
                     this.swipeRefresh.setRefreshing(false);
                     rebuild();
                 });
             } catch (Exception e) {
+                DiagnosticLog.error(applicationContext, "user", "manual_refresh_failed", e,
+                        "source", "pull");
                 AppPreferences.setLastError(applicationContext, safeMessage(e));
                 WidgetRenderer.updateAll(applicationContext);
                 runOnUiThread(() -> {
@@ -940,6 +957,7 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     public void signOut() {
+        DiagnosticLog.info(this, "user", "sign_out_confirmed");
         final AuthTokens authTokensLoad = SecureTokenStore.load(this);
         SecureTokenStore.clear(this);
         AppPreferences.clearSnapshot(this);
@@ -951,7 +969,8 @@ public final class MainActivity extends AppCompatActivity {
         this.executor.execute(new Runnable() { // from class: dev.bennett.codexmeter.MainActivity.11
             @Override // java.lang.Runnable
             public void run() {
-                OAuthClient.revokeBestEffort(authTokensLoad);
+                OAuthClient.revokeBestEffort(MainActivity.this.getApplicationContext(),
+                        authTokensLoad);
             }
         });
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/NowBarManager.java
@@ -64,8 +64,11 @@ public final class NowBarManager {
 
     private static boolean startInternal(Context context, String reason, String triggerFocus,
             long requestedUntil) {
+        DiagnosticLog.info(context, "now_bar", "start_requested", "reason", reason);
         UsageSnapshot snapshot = AppPreferences.loadSnapshot(context);
         if (snapshot == null || (snapshot.fiveHour == null && snapshot.weekly == null)) {
+            DiagnosticLog.warn(context, "now_bar", "start_rejected",
+                    "reason", "missing_usage");
             return false;
         }
         long now = System.currentTimeMillis();
@@ -88,10 +91,15 @@ public final class NowBarManager {
                 : null;
         saveState(context, false, until, focus, true, autoTrigger, reason);
         if (post(context, snapshot, until, false)) {
+            DiagnosticLog.info(context, "now_bar", "started",
+                    "reason", reason,
+                    "focus", focus,
+                    "until", until);
             PhoneWearSync.pushSettings(context);
             return true;
         }
         stop(context, false);
+        DiagnosticLog.warn(context, "now_bar", "start_failed", "reason", reason);
         return false;
     }
 
@@ -312,6 +320,9 @@ public final class NowBarManager {
     public static synchronized void stop(Context context, boolean suppressAutoRestart) {
         long until = activeUntil(context);
         boolean wasActive = hasStoredActiveState(context);
+        DiagnosticLog.info(context, "now_bar", "stop_requested",
+                "was_active", wasActive,
+                "suppress_auto_restart", suppressAutoRestart);
         state(context).edit().clear().apply();
         if (suppressAutoRestart && wasActive && until > System.currentTimeMillis()) {
             // Respect an explicit stop/dismiss until the window would have ended anyway.
@@ -322,6 +333,8 @@ public final class NowBarManager {
             try {
                 manager.cancel(NOTIFICATION_ID);
             } catch (RuntimeException exception) {
+                DiagnosticLog.error(context, "now_bar", "notification_cancel_failed",
+                        exception);
                 Log.w(TAG, "Could not cancel live monitor notification", exception);
             }
         }
@@ -330,6 +343,7 @@ public final class NowBarManager {
             try {
                 alarms.cancel(endIntent(context));
             } catch (RuntimeException exception) {
+                DiagnosticLog.error(context, "now_bar", "expiry_cancel_failed", exception);
                 Log.w(TAG, "Could not cancel live monitor expiry", exception);
             }
         }
@@ -401,6 +415,7 @@ public final class NowBarManager {
         try {
             createChannel(manager);
         } catch (RuntimeException exception) {
+            DiagnosticLog.error(context, "now_bar", "channel_create_failed", exception);
             Log.w(TAG, "Could not create live monitor notification channel", exception);
             return false;
         }
@@ -507,6 +522,7 @@ public final class NowBarManager {
                 }
             }
         } catch (RuntimeException exception) {
+            DiagnosticLog.error(context, "now_bar", "notification_build_failed", exception);
             Log.w(TAG, "Could not build live monitor notification", exception);
             return false;
         }
@@ -518,6 +534,14 @@ public final class NowBarManager {
                 + " legacyColorizedFallback=" + legacyColorizedFallback
                 + " preview=" + preview + " remaining=" + remaining
                 + " focusCritical=" + focusCritical);
+        DiagnosticLog.info(context, "now_bar", "notification_posting",
+                "display_mode", displayMode,
+                "promotable", promotable,
+                "promotion_allowed", canPostPromotedNotifications(context),
+                "legacy_colorized_fallback", legacyColorizedFallback,
+                "preview", preview,
+                "remaining_percent", remaining,
+                "focus", focus);
         try {
             manager.notify(NOTIFICATION_ID, notification);
             state(context).edit()
@@ -531,6 +555,8 @@ public final class NowBarManager {
                         () -> Api36.logPostedPromotionState(manager, NOTIFICATION_ID), 1000L);
             }
         } catch (RuntimeException exception) {
+            DiagnosticLog.error(context, "now_bar", "notification_post_failed", exception,
+                    "display_mode", displayMode);
             Log.w(TAG, "Could not post live monitor notification", exception);
             try {
                 manager.cancel(NOTIFICATION_ID);
@@ -541,6 +567,8 @@ public final class NowBarManager {
         try {
             scheduleEnd(context, until);
         } catch (RuntimeException exception) {
+            DiagnosticLog.error(context, "now_bar", "expiry_schedule_failed", exception,
+                    "until", until);
             Log.w(TAG, "Could not schedule live monitor expiry", exception);
         }
         PhoneWearSync.pushMonitorState(context);

--- a/android/app/src/main/java/dev/bennett/codexmeter/OAuthClient.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/OAuthClient.java
@@ -1,5 +1,7 @@
 package dev.bennett.codexmeter;
 
+import android.content.Context;
+import android.os.SystemClock;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -17,40 +19,47 @@ public final class OAuthClient {
     private OAuthClient() {
     }
 
-    public static AuthTokens exchangeCode(String str, String str2, String str3) throws Exception {
+    public static AuthTokens exchangeCode(Context context, String str, String str2, String str3)
+            throws Exception {
         LinkedHashMap linkedHashMap = new LinkedHashMap();
         linkedHashMap.put("grant_type", "authorization_code");
         linkedHashMap.put("code", str);
         linkedHashMap.put("redirect_uri", str2);
         linkedHashMap.put("client_id", AppConstants.OAUTH_CLIENT_ID);
         linkedHashMap.put("code_verifier", str3);
-        return parseTokens(postForm(AppConstants.TOKEN_URL, linkedHashMap), null);
+        return parseTokens(postForm(context, "oauth_code_exchange", AppConstants.TOKEN_URL,
+                linkedHashMap), null);
     }
 
-    public static AuthTokens refresh(AuthTokens authTokens) throws Exception {
+    public static AuthTokens refresh(Context context, AuthTokens authTokens) throws Exception {
         JSONObject jSONObject = new JSONObject();
         jSONObject.put("grant_type", "refresh_token");
         jSONObject.put("refresh_token", authTokens.refreshToken);
         jSONObject.put("client_id", AppConstants.OAUTH_CLIENT_ID);
-        return authTokens.mergeRefresh(parseTokens(postJson(AppConstants.TOKEN_URL, jSONObject), authTokens));
+        return authTokens.mergeRefresh(parseTokens(postJson(context, "oauth_token_refresh",
+                AppConstants.TOKEN_URL, jSONObject), authTokens));
     }
 
-    public static void revokeBestEffort(AuthTokens authTokens) {
+    public static void revokeBestEffort(Context context, AuthTokens authTokens) {
         if (authTokens != null && !authTokens.refreshToken.isEmpty()) {
             JSONObject jSONObject = new JSONObject();
             try {
                 jSONObject.put("token", authTokens.refreshToken);
                 jSONObject.put("token_type_hint", "refresh_token");
                 jSONObject.put("client_id", AppConstants.OAUTH_CLIENT_ID);
-                postJson(AppConstants.REVOKE_URL, jSONObject);
-            } catch (Exception e) {
+                postJson(context, "oauth_token_revoke", AppConstants.REVOKE_URL, jSONObject);
+            } catch (Exception firstError) {
+                DiagnosticLog.warn(context, "auth", "json_revocation_failed_trying_form",
+                        "error", firstError.getClass().getSimpleName());
                 try {
                     LinkedHashMap linkedHashMap = new LinkedHashMap();
                     linkedHashMap.put("token", authTokens.refreshToken);
                     linkedHashMap.put("token_type_hint", "refresh_token");
                     linkedHashMap.put("client_id", AppConstants.OAUTH_CLIENT_ID);
-                    postForm(AppConstants.REVOKE_URL, linkedHashMap);
-                } catch (Exception e2) {
+                    postForm(context, "oauth_token_revoke", AppConstants.REVOKE_URL,
+                            linkedHashMap);
+                } catch (Exception secondError) {
+                    DiagnosticLog.error(context, "auth", "token_revocation_failed", secondError);
                 }
             }
         }
@@ -100,16 +109,27 @@ public final class OAuthClient {
         throw new Exception("The authorization server returned incomplete credentials.");
     }
 
-    private static String postForm(String str, Map<String, String> map) throws Exception {
-        return post(str, "application/x-www-form-urlencoded", formEncode(map).getBytes(StandardCharsets.UTF_8));
+    private static String postForm(Context context, String operation, String str,
+            Map<String, String> map) throws Exception {
+        return post(context, operation, str, "application/x-www-form-urlencoded",
+                formEncode(map).getBytes(StandardCharsets.UTF_8));
     }
 
-    private static String postJson(String str, JSONObject jSONObject) throws Exception {
-        return post(str, "application/json", jSONObject.toString().getBytes(StandardCharsets.UTF_8));
+    private static String postJson(Context context, String operation, String str,
+            JSONObject jSONObject) throws Exception {
+        return post(context, operation, str, "application/json",
+                jSONObject.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    private static String post(String str, String str2, byte[] bArr) throws Exception {
+    private static String post(Context context, String operation, String str, String str2,
+            byte[] bArr) throws Exception {
         HttpsURLConnection httpsURLConnection = (HttpsURLConnection) URI.create(str).toURL().openConnection();
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(context, "network", "request_started",
+                "operation", operation,
+                "method", "POST",
+                "url", DiagnosticSanitizer.safeUrl(str),
+                "request_bytes", bArr.length);
         try {
             httpsURLConnection.setRequestMethod("POST");
             httpsURLConnection.setConnectTimeout(15000);
@@ -128,12 +148,23 @@ public final class OAuthClient {
                 }
                 int responseCode = httpsURLConnection.getResponseCode();
                 String body = readBody(httpsURLConnection, responseCode);
+                DiagnosticLog.info(context, "network", "request_finished",
+                        "operation", operation,
+                        "status", responseCode,
+                        "duration_ms", SystemClock.elapsedRealtime() - started,
+                        "response_bytes",
+                        body.getBytes(StandardCharsets.UTF_8).length);
                 if (responseCode < 200 || responseCode >= 300) {
                     throw new Exception(readError(body, "Authentication failed (HTTP " + responseCode + ")."));
                 }
                 return body;
             } finally {
             }
+        } catch (Exception exception) {
+            DiagnosticLog.error(context, "network", "request_failed", exception,
+                    "operation", operation,
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
+            throw exception;
         } finally {
             httpsURLConnection.disconnect();
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/OAuthService.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/OAuthService.java
@@ -52,6 +52,8 @@ public final class OAuthService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         String action = intent == null ? ACTION_START : intent.getAction();
+        DiagnosticLog.info(this, "auth", "oauth_service_command",
+                "action", action == null ? "" : action);
         if (ACTION_CANCEL.equals(action) || ACTION_CANCEL_SILENT.equals(action)) {
             cancelFlow("Sign-in cancelled.", ACTION_CANCEL.equals(action));
             return START_NOT_STICKY;
@@ -93,6 +95,8 @@ public final class OAuthService extends Service {
     private void runFlow() {
         Socket browser = null;
         boolean credentialsCommitted = false;
+        long started = android.os.SystemClock.elapsedRealtime();
+        DiagnosticLog.info(this, "auth", "oauth_flow_started");
         try {
             Pkce pkce = Pkce.generate();
             int port = bindServer();
@@ -117,6 +121,7 @@ public final class OAuthService extends Service {
                     continue;
                 }
                 if (!secureEquals(pkce.state, callback.parameters.get("state"))) {
+                    DiagnosticLog.warn(this, "auth", "oauth_callback_state_mismatch");
                     writeBrowser(browser, 400,
                             "The sign-in state did not match. Return to Codex Meter and try again.", false);
                     closeQuietly(browser);
@@ -142,7 +147,8 @@ public final class OAuthService extends Service {
                 }
 
                 updateNotification("Securing your ChatGPT session…", null);
-                AuthTokens tokens = OAuthClient.exchangeCode(code, redirectUri, pkce.verifier);
+                AuthTokens tokens = OAuthClient.exchangeCode(this, code, redirectUri,
+                        pkce.verifier);
                 SecureTokenStore.save(this, tokens);
                 credentialsCommitted = true;
                 AppPreferences.setOAuthPending(this, false, "");
@@ -163,10 +169,15 @@ public final class OAuthService extends Service {
 
                 updateNotification("Loading Codex usage…", null);
                 performPostAuthenticationSetup();
+                DiagnosticLog.info(this, "auth", "oauth_flow_succeeded",
+                        "duration_ms", android.os.SystemClock.elapsedRealtime() - started);
                 finishService();
                 return;
             }
         } catch (Exception exception) {
+            DiagnosticLog.error(this, "auth", "oauth_flow_failed", exception,
+                    "credentials_committed", credentialsCommitted,
+                    "duration_ms", android.os.SystemClock.elapsedRealtime() - started);
             if (credentialsCommitted) {
                 // A post-commit failure is not an authentication failure. Preserve the session,
                 // show a valid success state, and let manual refresh recover later.

--- a/android/app/src/main/java/dev/bennett/codexmeter/RefreshScheduler.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/RefreshScheduler.java
@@ -27,6 +27,8 @@ public final class RefreshScheduler {
             return false;
         }
         if (!SecureTokenStore.isSignedIn(contextAppContext)) {
+            DiagnosticLog.info(contextAppContext, "scheduler",
+                    "refresh_schedule_skipped_signed_out");
             cancelAll(contextAppContext);
             return true;
         }
@@ -39,10 +41,18 @@ public final class RefreshScheduler {
                 jobSchedulerScheduler.cancel(SHORT_JOB_ID_A);
                 jobSchedulerScheduler.cancel(SHORT_JOB_ID_B);
                 if (AppPreferences.getAutomaticRefresh(contextAppContext)) {
+                    DiagnosticLog.info(contextAppContext, "scheduler",
+                            "refresh_schedule_requested",
+                            "mode", "adaptive",
+                            "minutes", effectiveRefreshMinutes(contextAppContext));
                     zSubmit = scheduleNextChained(contextAppContext, SHORT_JOB_ID_B,
                             REASON_ADAPTIVE);
                 } else {
                     int refreshMinutes = AppPreferences.getRefreshMinutes(contextAppContext);
+                    DiagnosticLog.info(contextAppContext, "scheduler",
+                            "refresh_schedule_requested",
+                            "mode", "fixed",
+                            "minutes", refreshMinutes);
                     if (refreshMinutes < 15) {
                         zSubmit = scheduleNextChained(contextAppContext, SHORT_JOB_ID_B,
                                 REASON_SHORT_PERIODIC);
@@ -128,6 +138,8 @@ public final class RefreshScheduler {
             return true;
         }
         try {
+            DiagnosticLog.info(contextAppContext, "scheduler",
+                    "immediate_refresh_requested");
             return submit(contextAppContext, base(contextAppContext, IMMEDIATE_JOB_ID, "immediate").setMinimumLatency(0L).setOverrideDeadline(5000L).build());
         } catch (RuntimeException e) {
             return failed(contextAppContext, e);
@@ -146,6 +158,9 @@ public final class RefreshScheduler {
         }
         try {
             long jMax = Math.max(1000L, (jNextResetMillis - jCurrentTimeMillis) + 5000);
+            DiagnosticLog.info(contextAppContext, "scheduler",
+                    "reset_refresh_requested",
+                    "delay_ms", jMax);
             return submit(contextAppContext, base(contextAppContext, RESET_JOB_ID, ResetConsumeResult.RESET).setMinimumLatency(jMax).setOverrideDeadline(jMax + 300000).build());
         } catch (RuntimeException e) {
             return failed(contextAppContext, e);
@@ -164,6 +179,8 @@ public final class RefreshScheduler {
                     jobSchedulerScheduler.cancel(SHORT_JOB_ID_A);
                     jobSchedulerScheduler.cancel(SHORT_JOB_ID_B);
                     AppPreferences.setSchedulerError(contextAppContext, "");
+                    DiagnosticLog.info(contextAppContext, "scheduler",
+                            "all_refresh_jobs_cancelled");
                 }
             } catch (RuntimeException e) {
                 failed(contextAppContext, e);
@@ -177,10 +194,20 @@ public final class RefreshScheduler {
             AppPreferences.setSchedulerError(context, "Android's background scheduler is unavailable.");
             return false;
         }
-        if (jobSchedulerScheduler.schedule(jobInfo) == 1) {
+        int result = jobSchedulerScheduler.schedule(jobInfo);
+        String reason = jobInfo.getExtras() == null
+                ? "" : jobInfo.getExtras().getString("reason", "");
+        if (result == 1) {
             AppPreferences.setSchedulerError(context, "");
+            DiagnosticLog.info(context, "scheduler", "job_scheduled",
+                    "job_id", jobInfo.getId(),
+                    "reason", reason);
             return true;
         }
+        DiagnosticLog.warn(context, "scheduler", "job_rejected",
+                "job_id", jobInfo.getId(),
+                "reason", reason,
+                "result", result);
         AppPreferences.setSchedulerError(context, "Android declined the background refresh request.");
         return false;
     }
@@ -209,6 +236,7 @@ public final class RefreshScheduler {
             message = runtimeException.getClass().getSimpleName();
         }
         AppPreferences.setSchedulerError(context, "Background refresh: " + message);
+        DiagnosticLog.error(context, "scheduler", "scheduler_failed", runtimeException);
         return false;
     }
 }

--- a/android/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateClient.java
@@ -1,6 +1,7 @@
 package dev.bennett.codexmeter;
 
 import android.content.Context;
+import android.os.SystemClock;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -22,9 +23,17 @@ public final class ReleaseUpdateClient {
             app = context;
         }
         synchronized (LOCK) {
+            long started = SystemClock.elapsedRealtime();
+            DiagnosticLog.info(app, "update", "release_check_started");
             try {
-                return request(app, true);
+                List<GitHubRelease> releases = request(app, true);
+                DiagnosticLog.info(app, "update", "release_check_succeeded",
+                        "duration_ms", SystemClock.elapsedRealtime() - started,
+                        "release_count", releases.size());
+                return releases;
             } catch (Exception exception) {
+                DiagnosticLog.error(app, "update", "release_check_failed", exception,
+                        "duration_ms", SystemClock.elapsedRealtime() - started);
                 UpdatePreferences.saveError(app, safeMessage(exception));
                 throw exception;
             }
@@ -39,6 +48,12 @@ public final class ReleaseUpdateClient {
                     ? BuildConfig.UPDATE_API_URL : GitHubReleaseSource.RELEASES_API_URL;
             boolean localDebugServer = isLocalDebugServer(endpoint);
             connection = (HttpURLConnection) new URL(endpoint).openConnection();
+            long started = SystemClock.elapsedRealtime();
+            DiagnosticLog.info(app, "network", "request_started",
+                    "operation", "github_release_check",
+                    "method", "GET",
+                    "url", DiagnosticSanitizer.safeUrl(endpoint),
+                    "conditional", conditional);
             connection.setConnectTimeout(15_000);
             connection.setReadTimeout(25_000);
             connection.setInstanceFollowRedirects(true);
@@ -52,6 +67,11 @@ public final class ReleaseUpdateClient {
             }
             int status = connection.getResponseCode();
             URL finalUrl = connection.getURL();
+            DiagnosticLog.info(app, "network", "request_finished",
+                    "operation", "github_release_check",
+                    "status", status,
+                    "duration_ms", SystemClock.elapsedRealtime() - started,
+                    "url", DiagnosticSanitizer.safeUrl(finalUrl.toString()));
             if (!trustedApiUrl(finalUrl, localDebugServer)) {
                 throw new SecurityException("GitHub redirected the update check to an untrusted host.");
             }

--- a/android/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateJobService.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdateJobService.java
@@ -15,14 +15,20 @@ public final class ReleaseUpdateJobService extends JobService {
     @Override
     public boolean onStartJob(JobParameters params) {
         if (!UpdatePreferences.automaticChecks(this)) {
+            DiagnosticLog.info(this, "scheduler", "release_job_skipped_disabled");
             return false;
         }
+        DiagnosticLog.info(this, "scheduler", "release_job_started",
+                "job_id", params.getJobId());
         activeParameters = params;
         active = executor.submit(() -> {
             boolean retry = false;
             try {
                 ReleaseUpdateClient.check(getApplicationContext());
             } catch (Exception exception) {
+                DiagnosticLog.error(getApplicationContext(), "scheduler",
+                        "release_job_failed", exception,
+                        "job_id", params.getJobId());
                 retry = true;
             } finally {
                 if (activeParameters == params) {
@@ -37,6 +43,8 @@ public final class ReleaseUpdateJobService extends JobService {
 
     @Override
     public boolean onStopJob(JobParameters params) {
+        DiagnosticLog.warn(this, "scheduler", "release_job_stopped",
+                "job_id", params.getJobId());
         Future<?> task = active;
         if (activeParameters == params) {
             activeParameters = null;

--- a/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditApi.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/ResetCreditApi.java
@@ -2,6 +2,7 @@ package dev.bennett.codexmeter;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.SystemClock;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -26,14 +27,19 @@ public final class ResetCreditApi {
     }
 
     static ResetCreditsSnapshot refreshAndCacheLocked(Context context, AuthTokens authTokens) throws Exception {
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(context, "refresh", "reset_credit_refresh_started");
         if (authTokens == null) {
             authTokens = UsageApi.usableTokens(context);
         }
-        Response responseRequest = request("GET", AppConstants.RESET_CREDITS_URL, authTokens, null);
+        Response responseRequest = request(context, "reset_credit_list", "GET",
+                AppConstants.RESET_CREDITS_URL, authTokens, null);
         if (responseRequest.status == 401) {
-            AuthTokens authTokensRefresh = OAuthClient.refresh(authTokens);
+            DiagnosticLog.warn(context, "auth", "reset_credit_token_rejected_refreshing");
+            AuthTokens authTokensRefresh = OAuthClient.refresh(context, authTokens);
             SecureTokenStore.save(context, authTokensRefresh);
-            responseRequest = request("GET", AppConstants.RESET_CREDITS_URL, authTokensRefresh, null);
+            responseRequest = request(context, "reset_credit_list", "GET",
+                    AppConstants.RESET_CREDITS_URL, authTokensRefresh, null);
         }
         ensureSuccess(responseRequest, "Could not load Codex reset credits");
         ResetCreditsSnapshot resetCreditsSnapshot = ResetCreditsParser.parse(responseRequest.body, System.currentTimeMillis());
@@ -42,11 +48,16 @@ public final class ResetCreditApi {
         }
         ResetNotificationManager.onResetCreditsUpdated(context, resetCreditsSnapshot);
         notifyUpdated(context);
+        DiagnosticLog.info(context, "refresh", "reset_credit_refresh_succeeded",
+                "duration_ms", SystemClock.elapsedRealtime() - started,
+                "available", resetCreditsSnapshot.availableCount);
         return resetCreditsSnapshot;
     }
 
     public static ResetConsumeResult consumeBestAvailable(Context context) throws Exception {
         Context app = context.getApplicationContext() == null ? context : context.getApplicationContext();
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(app, "user", "reset_credit_use_requested");
         synchronized (UsageApi.NETWORK_LOCK) {
             UsageApi.installCookieManager();
             AuthTokens tokens = UsageApi.usableTokens(app);
@@ -75,11 +86,14 @@ public final class ResetCreditApi {
             }
             byte[] payload = requestBody.toString().getBytes(StandardCharsets.UTF_8);
 
-            Response response = request("POST", AppConstants.RESET_CREDITS_CONSUME_URL, tokens, payload);
+            Response response = request(app, "reset_credit_consume", "POST",
+                    AppConstants.RESET_CREDITS_CONSUME_URL, tokens, payload);
             if (response.status == 401) {
-                tokens = OAuthClient.refresh(tokens);
+                DiagnosticLog.warn(app, "auth", "reset_consume_token_rejected_refreshing");
+                tokens = OAuthClient.refresh(app, tokens);
                 SecureTokenStore.save(app, tokens);
-                response = request("POST", AppConstants.RESET_CREDITS_CONSUME_URL, tokens, payload);
+                response = request(app, "reset_credit_consume", "POST",
+                        AppConstants.RESET_CREDITS_CONSUME_URL, tokens, payload);
             }
             ensureSuccess(response, "Could not apply the Codex reset");
 
@@ -107,12 +121,23 @@ public final class ResetCreditApi {
             }
             WidgetRenderer.updateAll(app);
             notifyUpdated(app);
+            DiagnosticLog.info(app, "user", "reset_credit_use_finished",
+                    "result", code,
+                    "windows_reset", windowsReset,
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
             return new ResetConsumeResult(code, windowsReset, message);
         }
     }
 
-    private static Response request(String str, String str2, AuthTokens authTokens, byte[] bArr) throws Exception {
+    private static Response request(Context context, String operation, String str, String str2,
+            AuthTokens authTokens, byte[] bArr) throws Exception {
         HttpsURLConnection httpsURLConnection = (HttpsURLConnection) URI.create(str2).toURL().openConnection();
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(context, "network", "request_started",
+                "operation", operation,
+                "method", str,
+                "url", DiagnosticSanitizer.safeUrl(str2),
+                "request_bytes", bArr == null ? 0 : bArr.length);
         try {
             UsageApi.applyHeaders(httpsURLConnection, authTokens);
             httpsURLConnection.setRequestMethod(str);
@@ -130,7 +155,19 @@ public final class ResetCreditApi {
                 }
             }
             int responseCode = httpsURLConnection.getResponseCode();
-            return new Response(responseCode, OAuthClient.readBody(httpsURLConnection, responseCode));
+            String body = OAuthClient.readBody(httpsURLConnection, responseCode);
+            DiagnosticLog.info(context, "network", "request_finished",
+                    "operation", operation,
+                    "status", responseCode,
+                    "duration_ms", SystemClock.elapsedRealtime() - started,
+                    "response_bytes",
+                    body.getBytes(StandardCharsets.UTF_8).length);
+            return new Response(responseCode, body);
+        } catch (Exception exception) {
+            DiagnosticLog.error(context, "network", "request_failed", exception,
+                    "operation", operation,
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
+            throw exception;
         } finally {
             httpsURLConnection.disconnect();
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java
@@ -3,6 +3,7 @@ package dev.bennett.codexmeter;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -52,6 +53,12 @@ public final class SettingsActivity extends AppCompatActivity {
     private static final String PAGE_UPDATES = "updates";
     private static final String PAGE_TRANSFER = "transfer";
     private static final String PAGE_PRIVACY = "privacy";
+    private static final String PAGE_DIAGNOSTICS = "diagnostics";
+
+    static Intent diagnosticsIntent(Context context) {
+        return new Intent(context, SettingsActivity.class)
+                .putExtra(EXTRA_PAGE, PAGE_DIAGNOSTICS);
+    }
 
     @Override
     protected void onCreate(Bundle bundle) {
@@ -76,7 +83,8 @@ public final class SettingsActivity extends AppCompatActivity {
                 || PAGE_NOW_BAR.equals(page)
                 || PAGE_UPDATES.equals(page)
                 || PAGE_TRANSFER.equals(page)
-                || PAGE_PRIVACY.equals(page)) {
+                || PAGE_PRIVACY.equals(page)
+                || PAGE_DIAGNOSTICS.equals(page)) {
             return page;
         }
         return PAGE_ROOT;
@@ -98,6 +106,8 @@ public final class SettingsActivity extends AppCompatActivity {
                 return "Backup & transfer";
             case PAGE_PRIVACY:
                 return "Privacy";
+            case PAGE_DIAGNOSTICS:
+                return "Diagnostics";
             case PAGE_ROOT:
             default:
                 return "Settings";
@@ -111,6 +121,7 @@ public final class SettingsActivity extends AppCompatActivity {
         private static final String ARG_PAGE = "page";
         private static final int REQUEST_EXPORT_TRANSFER = 9201;
         private static final int REQUEST_IMPORT_TRANSFER = 9202;
+        private static final int REQUEST_EXPORT_DIAGNOSTICS = 9203;
 
         private String page = PAGE_ROOT;
         private Preference expiryTimesPreference;
@@ -181,6 +192,10 @@ public final class SettingsActivity extends AppCompatActivity {
                 case PAGE_PRIVACY:
                     addPreferencesFromResource(R.xml.preferences_settings_privacy);
                     break;
+                case PAGE_DIAGNOSTICS:
+                    addPreferencesFromResource(R.xml.preferences_settings_diagnostics);
+                    bindDiagnostics();
+                    break;
                 case PAGE_ROOT:
                 default:
                     addPreferencesFromResource(R.xml.preferences_settings);
@@ -200,6 +215,8 @@ public final class SettingsActivity extends AppCompatActivity {
                 finishExport(uri);
             } else if (requestCode == REQUEST_IMPORT_TRANSFER) {
                 beginImport(uri);
+            } else if (requestCode == REQUEST_EXPORT_DIAGNOSTICS) {
+                finishDiagnosticExport(uri);
             }
         }
 
@@ -225,6 +242,8 @@ public final class SettingsActivity extends AppCompatActivity {
                 updateNowBarSummary();
             } else if (PAGE_UPDATES.equals(page)) {
                 updateUpdateSummary();
+            } else if (PAGE_DIAGNOSTICS.equals(page)) {
+                updateDiagnosticSummary();
             }
         }
 
@@ -246,10 +265,104 @@ public final class SettingsActivity extends AppCompatActivity {
 
         private void bindPageLink(String key, String targetPage) {
             findPreference(key).setOnPreferenceClickListener(preference -> {
+                DiagnosticLog.info(requireContext(), "user", "settings_page_opened",
+                        "page", targetPage);
                 startActivity(new Intent(requireContext(), SettingsActivity.class)
                         .putExtra(EXTRA_PAGE, targetPage));
                 return true;
             });
+        }
+
+        private void bindDiagnostics() {
+            SwitchPreferenceCompat enabled = findPreference("diagnostic_logging_enabled");
+            enabled.setPersistent(false);
+            enabled.setChecked(DiagnosticLog.isEnabled(requireContext()));
+            enabled.setOnPreferenceChangeListener((preference, value) -> {
+                boolean loggingEnabled = (Boolean) value;
+                DiagnosticLog.setEnabled(requireContext(), loggingEnabled);
+                enabled.setChecked(loggingEnabled);
+                updateDiagnosticSummary();
+                Toast.makeText(requireContext(), loggingEnabled
+                                ? "Diagnostic tracing enabled."
+                                : "Diagnostic tracing disabled. Saved logs were kept.",
+                        Toast.LENGTH_LONG).show();
+                return true;
+            });
+            findPreference("export_diagnostic_logs").setOnPreferenceClickListener(preference -> {
+                launchDiagnosticExport();
+                return true;
+            });
+            findPreference("clear_diagnostic_logs").setOnPreferenceClickListener(preference -> {
+                new AlertDialog.Builder(requireContext())
+                        .setTitle("Clear diagnostic logs?")
+                        .setMessage("This permanently deletes all saved diagnostic events.")
+                        .setNegativeButton("Cancel", null)
+                        .setPositiveButton("Clear", (dialog, which) -> {
+                            DiagnosticLog.clear(requireContext());
+                            updateDiagnosticSummary();
+                            Toast.makeText(requireContext(), "Diagnostic logs cleared.",
+                                    Toast.LENGTH_SHORT).show();
+                        })
+                        .show();
+                return true;
+            });
+            updateDiagnosticSummary();
+        }
+
+        private void updateDiagnosticSummary() {
+            if (!PAGE_DIAGNOSTICS.equals(page) || getContext() == null) {
+                return;
+            }
+            boolean enabled = DiagnosticLog.isEnabled(requireContext());
+            SwitchPreferenceCompat toggle = findPreference("diagnostic_logging_enabled");
+            if (toggle != null) {
+                toggle.setChecked(enabled);
+            }
+            DiagnosticLog.Stats stats = DiagnosticLog.stats(requireContext());
+            Preference status = findPreference("diagnostic_log_status");
+            status.setSummary((enabled ? "Tracing on" : "Tracing off")
+                    + " · " + DiagnosticLog.formatBytes(stats.bytes)
+                    + (stats.files == 1 ? " in 1 file" : " across " + stats.files + " files"));
+            findPreference("export_diagnostic_logs").setEnabled(stats.hasLogs());
+            findPreference("clear_diagnostic_logs").setEnabled(stats.hasLogs());
+        }
+
+        private void launchDiagnosticExport() {
+            DiagnosticLog.Stats stats = DiagnosticLog.stats(requireContext());
+            if (!stats.hasLogs()) {
+                Toast.makeText(requireContext(), "There are no diagnostic logs to export.",
+                        Toast.LENGTH_SHORT).show();
+                return;
+            }
+            String stamp = new SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(new Date());
+            Intent create = new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                    .addCategory(Intent.CATEGORY_OPENABLE)
+                    .setType("application/x-ndjson")
+                    .putExtra(Intent.EXTRA_TITLE, "codex-meter-diagnostics-" + stamp + ".jsonl");
+            try {
+                startActivityForResult(create, REQUEST_EXPORT_DIAGNOSTICS);
+            } catch (RuntimeException exception) {
+                DiagnosticLog.error(requireContext(), "diagnostics", "export_picker_failed",
+                        exception);
+                Toast.makeText(requireContext(),
+                        "No file picker is available to export diagnostic logs.",
+                        Toast.LENGTH_LONG).show();
+            }
+        }
+
+        private void finishDiagnosticExport(Uri uri) {
+            try {
+                DiagnosticLog.export(requireContext(), uri);
+                updateDiagnosticSummary();
+                Toast.makeText(requireContext(),
+                        "Diagnostic logs exported. Review the file before sharing it.",
+                        Toast.LENGTH_LONG).show();
+            } catch (Exception exception) {
+                DiagnosticLog.error(requireContext(), "diagnostics", "export_failed", exception);
+                Toast.makeText(requireContext(),
+                        "Could not export diagnostic logs: " + MainActivity.safeMessage(exception),
+                        Toast.LENGTH_LONG).show();
+            }
         }
 
         private void updateRootSummaries() {
@@ -382,7 +495,9 @@ public final class SettingsActivity extends AppCompatActivity {
                         Toast.makeText(requireContext(), "Signed out.", Toast.LENGTH_SHORT).show();
                         requireActivity().recreate();
                         if (tokens != null) {
-                            new Thread(() -> OAuthClient.revokeBestEffort(tokens), "codex-sign-out").start();
+                            Context app = requireContext().getApplicationContext();
+                            new Thread(() -> OAuthClient.revokeBestEffort(app, tokens),
+                                    "codex-sign-out").start();
                         }
                     })
                     .create();

--- a/android/app/src/main/java/dev/bennett/codexmeter/UpdateInstaller.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UpdateInstaller.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageInstaller;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
 import android.os.Build;
+import android.os.SystemClock;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -59,7 +60,12 @@ public final class UpdateInstaller {
         if (release.apkSize <= 0L || release.apkSize > MAX_APK_BYTES) {
             throw new IllegalStateException("The release APK has an unsafe file size.");
         }
-        String checksumFile = downloadText(release.checksumUrl, MAX_CHECKSUM_BYTES);
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(context, "update", "update_prepare_started",
+                "version", release.version,
+                "expected_bytes", release.apkSize);
+        String checksumFile = downloadText(context, "update_checksum",
+                release.checksumUrl, MAX_CHECKSUM_BYTES);
         String expected = ReleaseIntegrity.expectedSha256(checksumFile, release.apkName);
         if (expected.isEmpty()) {
             throw new SecurityException("The release checksum does not list "
@@ -74,7 +80,8 @@ public final class UpdateInstaller {
         deleteQuietly(partial);
         deleteQuietly(apk);
         try {
-            downloadFile(release.apkUrl, partial, release.apkSize, listener);
+            downloadFile(context, "update_apk", release.apkUrl, partial, release.apkSize,
+                    listener);
             if (partial.length() != release.apkSize) {
                 throw new SecurityException("The APK size does not match the GitHub release.");
             }
@@ -86,8 +93,16 @@ public final class UpdateInstaller {
                 copy(partial, apk);
                 deleteQuietly(partial);
             }
-            return verifyPackage(context, release, apk);
+            PreparedUpdate prepared = verifyPackage(context, release, apk);
+            DiagnosticLog.info(context, "update", "update_prepare_succeeded",
+                    "version", prepared.versionName,
+                    "version_code", prepared.versionCode,
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
+            return prepared;
         } catch (Exception exception) {
+            DiagnosticLog.error(context, "update", "update_prepare_failed", exception,
+                    "version", release.version,
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
             deleteQuietly(partial);
             deleteQuietly(apk);
             throw exception;
@@ -107,6 +122,10 @@ public final class UpdateInstaller {
             params.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_REQUIRED);
         }
         int sessionId = installer.createSession(params);
+        DiagnosticLog.info(context, "update", "installer_session_created",
+                "session_id", sessionId,
+                "version", update.versionName,
+                "apk_bytes", update.apk.length());
         PackageInstaller.Session session = null;
         try {
             session = installer.openSession(sessionId);
@@ -126,8 +145,14 @@ public final class UpdateInstaller {
                     PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
             IntentSender sender = callback.getIntentSender();
             session.commit(sender);
+            DiagnosticLog.info(context, "update", "installer_session_committed",
+                    "session_id", sessionId,
+                    "version", update.versionName);
             return sessionId;
         } catch (Exception exception) {
+            DiagnosticLog.error(context, "update", "installer_session_failed", exception,
+                    "session_id", sessionId,
+                    "version", update.versionName);
             try {
                 installer.abandonSession(sessionId);
             } catch (RuntimeException ignored) {
@@ -198,10 +223,16 @@ public final class UpdateInstaller {
         return result;
     }
 
-    private static String downloadText(String url, int limit) throws Exception {
+    private static String downloadText(Context context, String operation, String url, int limit)
+            throws Exception {
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(context, "network", "request_started",
+                "operation", operation,
+                "method", "GET",
+                "url", DiagnosticSanitizer.safeUrl(url));
         HttpURLConnection connection = open(url);
         try {
-            requireOk(connection);
+            int status = requireOk(connection);
             try (InputStream input = connection.getInputStream();
                     ByteArrayOutputStream output = new ByteArrayOutputStream()) {
                 byte[] buffer = new byte[4096];
@@ -214,18 +245,36 @@ public final class UpdateInstaller {
                     }
                     output.write(buffer, 0, read);
                 }
-                return output.toString(java.nio.charset.StandardCharsets.UTF_8.name());
+                String result = output.toString(java.nio.charset.StandardCharsets.UTF_8.name());
+                DiagnosticLog.info(context, "network", "request_finished",
+                        "operation", operation,
+                        "status", status,
+                        "duration_ms", SystemClock.elapsedRealtime() - started,
+                        "response_bytes", result.getBytes(
+                                java.nio.charset.StandardCharsets.UTF_8).length);
+                return result;
             }
+        } catch (Exception exception) {
+            DiagnosticLog.error(context, "network", "request_failed", exception,
+                    "operation", operation,
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
+            throw exception;
         } finally {
             connection.disconnect();
         }
     }
 
-    private static void downloadFile(String url, File destination, long expected,
-            ProgressListener listener) throws Exception {
+    private static void downloadFile(Context context, String operation, String url,
+            File destination, long expected, ProgressListener listener) throws Exception {
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(context, "network", "request_started",
+                "operation", operation,
+                "method", "GET",
+                "url", DiagnosticSanitizer.safeUrl(url),
+                "expected_bytes", expected);
         HttpURLConnection connection = open(url);
         try {
-            requireOk(connection);
+            int status = requireOk(connection);
             long declared = connection.getContentLengthLong();
             if (declared > MAX_APK_BYTES || (declared > 0L && declared != expected)) {
                 throw new SecurityException("The APK download size changed unexpectedly.");
@@ -248,7 +297,17 @@ public final class UpdateInstaller {
                         listener.onProgress(total, expected);
                     }
                 }
+                DiagnosticLog.info(context, "network", "request_finished",
+                        "operation", operation,
+                        "status", status,
+                        "duration_ms", SystemClock.elapsedRealtime() - started,
+                        "response_bytes", total);
             }
+        } catch (Exception exception) {
+            DiagnosticLog.error(context, "network", "request_failed", exception,
+                    "operation", operation,
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
+            throw exception;
         } finally {
             connection.disconnect();
         }
@@ -269,7 +328,7 @@ public final class UpdateInstaller {
         return connection;
     }
 
-    private static void requireOk(HttpURLConnection connection) throws Exception {
+    private static int requireOk(HttpURLConnection connection) throws Exception {
         int status = connection.getResponseCode();
         URL finalUrl = connection.getURL();
         if (!trustedDownloadUrl(finalUrl)) {
@@ -278,6 +337,7 @@ public final class UpdateInstaller {
         if (status != HttpURLConnection.HTTP_OK) {
             throw new IllegalStateException("GitHub download failed with HTTP " + status + ".");
         }
+        return status;
     }
 
     private static boolean allowedHost(String host) {

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageApi.java
@@ -1,6 +1,7 @@
 package dev.bennett.codexmeter;
 
 import android.content.Context;
+import android.os.SystemClock;
 import dev.bennett.codexmeter.wear.PhoneWearSync;
 import java.net.CookieHandler;
 import java.net.CookieManager;
@@ -21,51 +22,71 @@ public final class UsageApi {
         Response responseRequestUsage;
         String str;
         UsageSnapshot usageSnapshot;
-        synchronized (NETWORK_LOCK) {
-            installCookieManager();
-            AuthTokens authTokensUsableTokens = usableTokens(context);
-            Response responseRequestUsage2 = requestUsage(authTokensUsableTokens);
-            if (responseRequestUsage2.status == 401) {
-                AuthTokens authTokensRefresh = OAuthClient.refresh(authTokensUsableTokens);
-                SecureTokenStore.save(context, authTokensRefresh);
-                authTokens = authTokensRefresh;
-                responseRequestUsage = requestUsage(authTokensRefresh);
-            } else {
-                authTokens = authTokensUsableTokens;
-                responseRequestUsage = responseRequestUsage2;
-            }
-            if (responseRequestUsage.status < 200 || responseRequestUsage.status >= 300) {
-                if (responseRequestUsage.status == 403) {
-                    str = "Codex usage access was denied for this account.";
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(context, "refresh", "usage_refresh_started");
+        try {
+            synchronized (NETWORK_LOCK) {
+                installCookieManager();
+                AuthTokens authTokensUsableTokens = usableTokens(context);
+                Response responseRequestUsage2 = requestUsage(context, authTokensUsableTokens);
+                if (responseRequestUsage2.status == 401) {
+                    DiagnosticLog.warn(context, "auth", "usage_token_rejected_refreshing");
+                    AuthTokens authTokensRefresh = OAuthClient.refresh(context,
+                            authTokensUsableTokens);
+                    SecureTokenStore.save(context, authTokensRefresh);
+                    authTokens = authTokensRefresh;
+                    responseRequestUsage = requestUsage(context, authTokensRefresh);
                 } else {
-                    str = responseRequestUsage.status == 404 ? "The Codex usage endpoint is unavailable or has changed." : "Usage refresh failed (HTTP " + responseRequestUsage.status + ").";
+                    authTokens = authTokensUsableTokens;
+                    responseRequestUsage = responseRequestUsage2;
                 }
-                throw new Exception(OAuthClient.readError(responseRequestUsage.body, str));
+                if (responseRequestUsage.status < 200 || responseRequestUsage.status >= 300) {
+                    if (responseRequestUsage.status == 403) {
+                        str = "Codex usage access was denied for this account.";
+                    } else {
+                        str = responseRequestUsage.status == 404 ? "The Codex usage endpoint is unavailable or has changed." : "Usage refresh failed (HTTP " + responseRequestUsage.status + ").";
+                    }
+                    throw new Exception(OAuthClient.readError(responseRequestUsage.body, str));
+                }
+                usageSnapshot = UsageParser.parse(responseRequestUsage.body,
+                        System.currentTimeMillis());
+                if (!usageSnapshot.hasDisplayableData()) {
+                    throw new Exception("OpenAI returned no recognizable Codex usage data.");
+                }
+                UsageSnapshot previousSnapshot = AppPreferences.loadSnapshot(context);
+                if (!AppPreferences.saveSnapshot(context, usageSnapshot)) {
+                    throw new Exception("Usage was received, but it could not be saved on this device.");
+                }
+                UsageHistoryRecorder.record(context, usageSnapshot);
+                PhoneWearSync.pushUsage(context, usageSnapshot);
+                NowBarManager.onUsageUpdated(context, usageSnapshot);
+                ResetNotificationManager.onUsageUpdated(context, previousSnapshot, usageSnapshot);
+                try {
+                    ResetAlertScheduler.scheduleFromSnapshot(context, usageSnapshot);
+                } catch (RuntimeException exception) {
+                    DiagnosticLog.error(context, "scheduler", "reset_alert_schedule_failed",
+                            exception);
+                }
+                try {
+                    ResetCreditApi.refreshAndCacheLocked(context, authTokens);
+                } catch (Exception exception) {
+                    DiagnosticLog.error(context, "refresh", "reset_credit_side_refresh_failed",
+                            exception);
+                    ResetNotificationManager.onResetCreditSummaryUpdated(context,
+                            usageSnapshot.resetCreditsAvailable);
+                    AppPreferences.setResetCreditsError(context, safeMessage(exception));
+                }
             }
-            usageSnapshot = UsageParser.parse(responseRequestUsage.body, System.currentTimeMillis());
-            if (!usageSnapshot.hasDisplayableData()) {
-                throw new Exception("OpenAI returned no recognizable Codex usage data.");
-            }
-            UsageSnapshot previousSnapshot = AppPreferences.loadSnapshot(context);
-            if (!AppPreferences.saveSnapshot(context, usageSnapshot)) {
-                throw new Exception("Usage was received, but it could not be saved on this device.");
-            }
-            UsageHistoryRecorder.record(context, usageSnapshot);
-            PhoneWearSync.pushUsage(context, usageSnapshot);
-            NowBarManager.onUsageUpdated(context, usageSnapshot);
-            ResetNotificationManager.onUsageUpdated(context, previousSnapshot, usageSnapshot);
-            try {
-                ResetAlertScheduler.scheduleFromSnapshot(context, usageSnapshot);
-            } catch (RuntimeException e) {
-            }
-            try {
-                ResetCreditApi.refreshAndCacheLocked(context, authTokens);
-            } catch (Exception e2) {
-                ResetNotificationManager.onResetCreditSummaryUpdated(context,
-                        usageSnapshot.resetCreditsAvailable);
-                AppPreferences.setResetCreditsError(context, safeMessage(e2));
-            }
+        } catch (Exception exception) {
+            DiagnosticLog.error(context, "refresh", "usage_refresh_failed", exception,
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
+            throw exception;
         }
+        DiagnosticLog.info(context, "refresh", "usage_refresh_succeeded",
+                "duration_ms", SystemClock.elapsedRealtime() - started,
+                "five_hour", usageSnapshot.fiveHour != null,
+                "weekly", usageSnapshot.weekly != null,
+                "additional_limits", usageSnapshot.additionalLimits.size());
         return usageSnapshot;
     }
 
@@ -75,20 +96,37 @@ public final class UsageApi {
             throw new Exception("Sign in to ChatGPT first.");
         }
         if (authTokensLoad.shouldRefresh(System.currentTimeMillis())) {
-            AuthTokens authTokensRefresh = OAuthClient.refresh(authTokensLoad);
+            DiagnosticLog.info(context, "auth", "token_refresh_due");
+            AuthTokens authTokensRefresh = OAuthClient.refresh(context, authTokensLoad);
             SecureTokenStore.save(context, authTokensRefresh);
             return authTokensRefresh;
         }
         return authTokensLoad;
     }
 
-    private static Response requestUsage(AuthTokens authTokens) throws Exception {
+    private static Response requestUsage(Context context, AuthTokens authTokens) throws Exception {
         HttpsURLConnection httpsURLConnection = (HttpsURLConnection) URI.create(AppConstants.USAGE_URL).toURL().openConnection();
+        long started = SystemClock.elapsedRealtime();
+        DiagnosticLog.info(context, "network", "request_started",
+                "operation", "usage",
+                "method", "GET",
+                "url", DiagnosticSanitizer.safeUrl(AppConstants.USAGE_URL));
         try {
             applyHeaders(httpsURLConnection, authTokens);
             httpsURLConnection.setRequestMethod("GET");
             int responseCode = httpsURLConnection.getResponseCode();
-            return new Response(responseCode, OAuthClient.readBody(httpsURLConnection, responseCode));
+            String body = OAuthClient.readBody(httpsURLConnection, responseCode);
+            DiagnosticLog.info(context, "network", "request_finished",
+                    "operation", "usage",
+                    "status", responseCode,
+                    "duration_ms", SystemClock.elapsedRealtime() - started,
+                    "response_bytes", body.getBytes(java.nio.charset.StandardCharsets.UTF_8).length);
+            return new Response(responseCode, body);
+        } catch (Exception exception) {
+            DiagnosticLog.error(context, "network", "request_failed", exception,
+                    "operation", "usage",
+                    "duration_ms", SystemClock.elapsedRealtime() - started);
+            throw exception;
         } finally {
             httpsURLConnection.disconnect();
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/UsageRefreshJobService.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/UsageRefreshJobService.java
@@ -16,6 +16,8 @@ public final class UsageRefreshJobService extends JobService {
     @Override // android.app.job.JobService
     public boolean onStartJob(final JobParameters jobParameters) {
         if (!SecureTokenStore.isSignedIn(this)) {
+            DiagnosticLog.info(this, "scheduler", "refresh_job_skipped_signed_out",
+                    "job_id", jobParameters.getJobId());
             WidgetRenderer.updateAll(this);
             return false;
         }
@@ -40,6 +42,8 @@ public final class UsageRefreshJobService extends JobService {
 
     @Override // android.app.job.JobService
     public boolean onStopJob(JobParameters jobParameters) {
+        DiagnosticLog.warn(this, "scheduler", "refresh_job_stopped",
+                "job_id", jobParameters.getJobId());
         JobRun jobRunRemove = this.active.remove(Integer.valueOf(jobParameters.getJobId()));
         if (jobRunRemove != null) {
             jobRunRemove.stopped = true;
@@ -62,25 +66,36 @@ public final class UsageRefreshJobService extends JobService {
     private final class JobRun implements Runnable {
         private final JobParameters params;
         private final boolean chainedCycle;
+        private final String reason;
         private volatile boolean stopped;
         private FutureTask<Void> task;
 
         JobRun(JobParameters jobParameters) {
             this.params = jobParameters;
-            String reason = jobParameters.getExtras() == null
+            this.reason = jobParameters.getExtras() == null
                     ? "" : jobParameters.getExtras().getString("reason", "");
-            this.chainedCycle = RefreshScheduler.REASON_SHORT_PERIODIC.equals(reason)
-                    || RefreshScheduler.REASON_ADAPTIVE.equals(reason);
+            this.chainedCycle = RefreshScheduler.REASON_SHORT_PERIODIC.equals(this.reason)
+                    || RefreshScheduler.REASON_ADAPTIVE.equals(this.reason);
         }
 
         @Override // java.lang.Runnable
         public void run() {
+            long started = android.os.SystemClock.elapsedRealtime();
+            DiagnosticLog.info(UsageRefreshJobService.this, "scheduler",
+                    "refresh_job_started",
+                    "job_id", this.params.getJobId(),
+                    "reason", this.reason);
             try {
                 try {
                     RefreshScheduler.scheduleAtNextReset(UsageRefreshJobService.this.getApplicationContext(), UsageApi.refreshAndCache(UsageRefreshJobService.this.getApplicationContext()));
                     AppPreferences.recordRefreshSuccess(
                             UsageRefreshJobService.this.getApplicationContext());
                     WidgetRenderer.updateAll(UsageRefreshJobService.this.getApplicationContext());
+                    DiagnosticLog.info(UsageRefreshJobService.this, "scheduler",
+                            "refresh_job_succeeded",
+                            "job_id", this.params.getJobId(),
+                            "reason", this.reason,
+                            "duration_ms", android.os.SystemClock.elapsedRealtime() - started);
                     UsageRefreshJobService.this.active.remove(Integer.valueOf(this.params.getJobId()), this);
                     if (!this.stopped) {
                         UsageRefreshJobService usageRefreshJobService = UsageRefreshJobService.this;
@@ -91,6 +106,11 @@ public final class UsageRefreshJobService extends JobService {
                         }
                     }
                 } catch (Exception e) {
+                    DiagnosticLog.error(UsageRefreshJobService.this, "scheduler",
+                            "refresh_job_failed", e,
+                            "job_id", this.params.getJobId(),
+                            "reason", this.reason,
+                            "duration_ms", android.os.SystemClock.elapsedRealtime() - started);
                     AppPreferences.setLastError(UsageRefreshJobService.this.getApplicationContext(), UsageRefreshJobService.safeMessage(e));
                     AppPreferences.recordRefreshFailure(
                             UsageRefreshJobService.this.getApplicationContext());

--- a/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/WidgetRenderer.java
@@ -41,11 +41,16 @@ public final class WidgetRenderer {
                 AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
                 int[] appWidgetIds = appWidgetManager.getAppWidgetIds(new ComponentName(context, (Class<?>) CodexUsageWidget.class));
                 int length = appWidgetIds.length;
+                DiagnosticLog.info(context, "widget", "update_all_started",
+                        "home_widget_count", length,
+                        "lock_widget_count", SamsungLockWidgetSupport.countAll(context));
                 for (int i = GRAPHIC_STANDARD; i < length; i += GRAPHIC_LARGE) {
                     update(context, appWidgetManager, appWidgetIds[i]);
                 }
                 SamsungLockWidgetSupport.updateAll(context);
+                DiagnosticLog.info(context, "widget", "update_all_finished");
             } catch (RuntimeException e) {
+                DiagnosticLog.error(context, "widget", "update_all_failed", e);
                 Log.w("CodexMeterWidget", "Widget update failed: " + safeMessage(e));
             }
         }
@@ -66,10 +71,14 @@ public final class WidgetRenderer {
                 }
                 appWidgetManager.updateAppWidget(i, remoteViewsBuildViews);
             } catch (RuntimeException e) {
+                DiagnosticLog.error(context, "widget", "render_failed", e,
+                        "widget_id", i);
                 Log.w("CodexMeterWidget", "Widget render failed: " + safeMessage(e));
                 try {
                     appWidgetManager.updateAppWidget(i, buildFallback(context, i));
                 } catch (RuntimeException e2) {
+                    DiagnosticLog.error(context, "widget", "fallback_render_failed", e2,
+                            "widget_id", i);
                 }
             }
         }

--- a/android/app/src/main/java/dev/bennett/codexmeter/wear/PhoneWearListenerService.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/wear/PhoneWearListenerService.java
@@ -9,6 +9,7 @@ import com.google.android.gms.wearable.MessageEvent;
 import com.google.android.gms.wearable.Node;
 import com.google.android.gms.wearable.WearableListenerService;
 import dev.bennett.codexmeter.AppPreferences;
+import dev.bennett.codexmeter.DiagnosticLog;
 import dev.bennett.codexmeter.NowBarManager;
 import dev.bennett.codexmeter.UsageApi;
 import org.json.JSONObject;
@@ -36,10 +37,13 @@ public final class PhoneWearListenerService extends WearableListenerService {
     public void onMessageReceived(MessageEvent event) {
         if (event == null) return;
         if (!PhoneWearTrust.isTrustedWearMessage(this, event.getSourceNodeId(), event.getData())) {
+            DiagnosticLog.warn(this, "wear", "untrusted_message_rejected",
+                    "path", event.getPath());
             Log.w(TAG, "Ignoring message from untrusted Wear sender: " + event.getSourceNodeId());
             return;
         }
         String path = event.getPath();
+        DiagnosticLog.info(this, "wear", "message_received", "path", path);
         if (WearSyncPaths.MSG_REFRESH.equals(path)) {
             refreshInBackground();
         } else if (WearSyncPaths.MSG_SYNC_NOW.equals(path)) {
@@ -55,6 +59,7 @@ public final class PhoneWearListenerService extends WearableListenerService {
 
     @Override
     public void onPeerConnected(Node peer) {
+        DiagnosticLog.info(this, "wear", "peer_connected");
         PhoneWearSync.pushAll(getApplicationContext());
     }
 
@@ -64,11 +69,13 @@ public final class PhoneWearListenerService extends WearableListenerService {
             if (payload == null || payload.isEmpty()) return;
             WearSettingsState remote = WearSettingsState.fromJson(new JSONObject(payload));
             if (!PhoneWearTrust.isTrustedWearSettings(this, nodeId, remote)) {
+                DiagnosticLog.warn(this, "wear", "untrusted_settings_rejected");
                 Log.w(TAG, "Ignoring settings from untrusted Wear sender: " + nodeId);
                 return;
             }
             PhoneWearSync.applyRemoteSettings(getApplicationContext(), remote);
         } catch (Exception exception) {
+            DiagnosticLog.error(this, "wear", "settings_apply_failed", exception);
             Log.w(TAG, "Could not apply Wear settings payload", exception);
         }
     }
@@ -76,15 +83,18 @@ public final class PhoneWearListenerService extends WearableListenerService {
     private void refreshInBackground() {
         final android.content.Context app = getApplicationContext();
         new Thread(() -> {
+            DiagnosticLog.info(app, "wear", "wear_refresh_started");
             PhoneWearSync.pushStatus(app, true, "");
             try {
                 UsageApi.refreshAndCache(app);
             } catch (Exception exception) {
+                DiagnosticLog.error(app, "wear", "wear_refresh_failed", exception);
                 AppPreferences.setLastError(app, exception.getMessage());
                 PhoneWearSync.pushStatus(app, false, exception.getMessage());
                 Log.w(TAG, "Wear-requested usage refresh failed", exception);
                 return;
             }
+            DiagnosticLog.info(app, "wear", "wear_refresh_succeeded");
             PhoneWearSync.pushStatus(app, false, "");
         }, "codex-wear-refresh").start();
     }

--- a/android/app/src/main/java/dev/bennett/codexmeter/wear/PhoneWearSync.java
+++ b/android/app/src/main/java/dev/bennett/codexmeter/wear/PhoneWearSync.java
@@ -8,6 +8,7 @@ import com.google.android.gms.wearable.PutDataMapRequest;
 import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
 import dev.bennett.codexmeter.AppPreferences;
+import dev.bennett.codexmeter.DiagnosticLog;
 import dev.bennett.codexmeter.NowBarManager;
 import dev.bennett.codexmeter.NowBarPreferences;
 import dev.bennett.codexmeter.RefreshScheduler;
@@ -123,6 +124,9 @@ public final class PhoneWearSync {
                 .putLong(KEY_LAST_APPLIED_SETTINGS_AT, remote.updatedAtMillis)
                 .putLong(KEY_LOCAL_SETTINGS_AT, remote.updatedAtMillis)
                 .apply();
+        DiagnosticLog.info(app, "wear", "remote_settings_applied",
+                "monitor_active", remote.monitorActive,
+                "source", remote.sourceNode);
         return true;
     }
 
@@ -130,9 +134,16 @@ public final class PhoneWearSync {
         if (context == null || path == null || path.isEmpty()) return;
         Context app = context.getApplicationContext();
         Wearable.getNodeClient(app).getConnectedNodes()
-                .addOnSuccessListener(nodes -> sendMessageToNodes(app, nodes, path))
-                .addOnFailureListener(error -> Log.w(TAG,
-                        "Could not resolve Wear nodes for " + path, error));
+                .addOnSuccessListener(nodes -> {
+                    DiagnosticLog.info(app, "wear", "nodes_resolved",
+                            "path", path, "node_count", nodes.size());
+                    sendMessageToNodes(app, nodes, path);
+                })
+                .addOnFailureListener(error -> {
+                    DiagnosticLog.error(app, "wear", "node_resolution_failed", error,
+                            "path", path);
+                    Log.w(TAG, "Could not resolve Wear nodes for " + path, error);
+                });
     }
 
     private static void sendMessageToNodes(Context context, List<Node> nodes, String path) {
@@ -140,8 +151,13 @@ public final class PhoneWearSync {
         for (Node node : nodes) {
             Wearable.getMessageClient(context)
                     .sendMessage(node.getId(), path, auth)
-                    .addOnFailureListener(error -> Log.w(TAG,
-                            "Could not send Wear message " + path, error));
+                    .addOnSuccessListener(result -> DiagnosticLog.info(context, "wear",
+                            "message_sent", "path", path))
+                    .addOnFailureListener(error -> {
+                        DiagnosticLog.error(context, "wear", "message_send_failed", error,
+                                "path", path);
+                        Log.w(TAG, "Could not send Wear message " + path, error);
+                    });
         }
     }
 
@@ -182,9 +198,17 @@ public final class PhoneWearSync {
             PutDataRequest request = map.asPutDataRequest().setUrgent();
             Wearable.getDataClient(context.getApplicationContext())
                     .putDataItem(request)
-                    .addOnFailureListener(error -> Log.w(TAG,
-                            "Could not push Wear data " + path, error));
+                    .addOnSuccessListener(item -> DiagnosticLog.info(context, "wear",
+                            "data_pushed", "path", path,
+                            "payload_bytes", json.getBytes(StandardCharsets.UTF_8).length))
+                    .addOnFailureListener(error -> {
+                        DiagnosticLog.error(context, "wear", "data_push_failed", error,
+                                "path", path);
+                        Log.w(TAG, "Could not push Wear data " + path, error);
+                    });
         } catch (Exception exception) {
+            DiagnosticLog.error(context, "wear", "data_encode_failed", exception,
+                    "path", path);
             Log.w(TAG, "Could not encode Wear data " + path, exception);
         }
     }

--- a/android/app/src/main/res/xml/preferences_settings_diagnostics.xml
+++ b/android/app/src/main/res/xml/preferences_settings_diagnostics.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory android:title="Log tracing">
+        <SwitchPreferenceCompat
+            android:key="diagnostic_logging_enabled"
+            android:summary="Record detailed app, refresh, scheduler, Wear, and network events"
+            android:title="Save diagnostic logs"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="diagnostic_log_status"
+            android:title="Saved logs"
+            app:iconSpaceReserved="false"
+            app:selectable="false" />
+        <Preference
+            android:key="export_diagnostic_logs"
+            android:summary="Save a structured JSON Lines file"
+            android:title="Export logs"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="clear_diagnostic_logs"
+            android:summary="Permanently delete saved diagnostic events"
+            android:title="Clear logs"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Privacy">
+        <Preference
+            android:summary="Logs stay in private app storage until you export or clear them. Authentication tokens, cookies, authorization codes, email addresses, URL queries, and request/response bodies are never intentionally recorded. Review an export before sharing it."
+            android:title="Sensitive data protection"
+            app:iconSpaceReserved="false"
+            app:selectable="false" />
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -68,6 +68,7 @@ javac -encoding UTF-8 -cp "$JSON_JAR" -d "$OUT" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseNotesMarkdown.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/ReleaseUpdatePolicy.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateCheckFrequency.java" \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/DiagnosticSanitizer.java" \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java" \
   "$ROOT/tests/ParserSelfTest.java"
 
@@ -275,6 +276,15 @@ test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/UpdateNotificationManage
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransfer.java"
 test -f "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsTransferStore.java"
 grep -q 'testSettingsTransfer' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'testDiagnosticSanitizer' "$ROOT/tests/ParserSelfTest.java"
+grep -q 'android:name="dev.bennett.codexmeter.CodexMeterApplication"' \
+  "$ROOT/app/src/main/AndroidManifest.xml"
+grep -q 'preferences_settings_diagnostics' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'application/x-ndjson' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/SettingsActivity.java"
+grep -q 'DiagnosticSanitizer.safeUrl' \
+  "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageApi.java"
 grep -q 'export_settings_transfer' \
   "$ROOT/app/src/main/res/xml/preferences_settings_transfer.xml"
 grep -q 'import_settings_transfer' \

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -56,8 +56,36 @@ public final class ParserSelfTest {
         testReleaseNotesMarkdown();
         testReleaseUpdatePolicy();
         testUpdateCheckFrequency();
+        testDiagnosticSanitizer();
         testSettingsTransfer();
         System.out.println("All parser, updater, OAuth, onboarding, and widget-option self-tests passed.");
+    }
+
+    private static void testDiagnosticSanitizer() {
+        String jwt = "abcdefghijklmnop.qrstuvwxyzABCDE.FGHIJKLMNOP";
+        String input = "Authorization: Bearer top-secret "
+                + "access_token=\"access-secret\" refresh_token=refresh-secret "
+                + "Cookie: session=private-cookie email=user@example.com jwt=" + jwt + " "
+                + "https://example.com/callback?code=oauth-code&state=oauth-state";
+        String redacted = DiagnosticSanitizer.redact(input);
+        check(!redacted.contains("top-secret"), "bearer token redacted");
+        check(!redacted.contains("access-secret"), "access token redacted");
+        check(!redacted.contains("refresh-secret"), "refresh token redacted");
+        check(!redacted.contains("private-cookie"), "cookie redacted");
+        check(!redacted.contains("user@example.com"), "email redacted");
+        check(!redacted.contains(jwt), "JWT redacted");
+        check(!redacted.contains("oauth-code"), "OAuth code redacted");
+        check(!redacted.contains("oauth-state"), "OAuth state redacted");
+        check(redacted.contains("[REDACTED]"), "redaction marker present");
+        check("https://example.com:8443/path/to/resource".equals(
+                        DiagnosticSanitizer.safeUrl(
+                                "https://example.com:8443/path/to/resource?token=secret#fragment")),
+                "safe URL strips query and fragment");
+        check("The authorization server returned an error.".equals(
+                        DiagnosticSanitizer.redact(
+                                "The authorization server returned an error.")),
+                "ordinary authorization wording remains readable");
+        System.out.println("Diagnostic sanitizer strips credentials, identity, and URL queries.");
     }
 
     private static void testFullWindowHidesResetCountdown() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a hidden diagnostics settings page unlocked by tapping the large About icon, version, or app card seven times
- persist privacy-filtered, rotating JSONL logs in app-private storage with export and clear controls
- trace process/screen lifecycle, refresh scheduling, connectivity state, network timing/status, OAuth, updates, widgets, Now Bar, and phone-side Wear sync
- redact credentials, cookies, OAuth parameters, email addresses, JWTs, URL queries, and omit request/response bodies
- preserve unlock taps across slow/accessibility-driven input and reset only after opening Diagnostics

## Testing
- `./run-tests.sh` passes, including credential, email, JWT, OAuth-query, and safe-URL redaction coverage
- `./build.sh` passes and produces signed phone and Wear release APKs
- `./lint.sh` passes for phone and Wear
- API 36 AOSP software-emulator walkthrough unlocks Diagnostics, enables tracing, writes nonzero logs, and saves a `.jsonl` file through Android's file picker
- forced a real GitHub release-check job and validated its exported JSONL: 14 valid records, request start/finish, HTTP 304, 1875 ms duration, validated connectivity context, query stripping, and no sensitive-pattern matches

## Walkthrough
[diagnostics_unlock_enable_export_demo.mp4](https://cursor.com/agents/bc-232eaf97-06f6-472d-9151-5538d1da3830/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiagnostics_unlock_enable_export_demo.mp4)

[Diagnostics enabled with saved logs](https://cursor.com/agents/bc-232eaf97-06f6-472d-9151-5538d1da3830/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiagnostics_enabled_with_saved_logs.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-232eaf97-06f6-472d-9151-5538d1da3830?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-232eaf97-06f6-472d-9151-5538d1da3830&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

