### PR TITLE
ios: bring portable 2.8.0 behavior up to the Android release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ attached to a signed-in ChatGPT account. This repository is a **monorepo**:
 |------|----------|--------|
 | Repository root | Shared | Docs, license, changelog, CI, convenience script wrappers |
 | [`android/`](android/) | **Android** | Phone app + Wear companion: One UI dashboard, home widgets, Samsung lock/AOD, notifications, optional live usage monitor |
-| [`ios/`](ios/) | **iPhone / iPad** | Native SwiftUI + WidgetKit client with portable behavior (meters, reset credits, notifications, demo mode) |
+| [`ios/`](ios/) | **iPhone / iPad** | Native SwiftUI + WidgetKit client with portable 2.8.0 behavior (meters, monthly Free-tier windows, history analytics, diagnostics, widgets) |
 
 There is no shared backend. Each platform talks to ChatGPT/Codex endpoints
 directly and stores credentials only on-device.
@@ -86,6 +86,9 @@ Or from `android/` directly. `build.sh` assembles the release APKs with Gradle a
 ### iOS
 
 See [`ios/README.md`](ios/README.md). Requires Xcode 26+ and iOS/iPadOS 26+.
+The iOS client now carries portable Android 2.8.0 behavior: Free-tier monthly
+windows, scrubbable usage-history analytics with customize, and opt-in
+diagnostic log export.
 
 ```bash
 cd ios

--- a/ios/APP_STORE_METADATA.md
+++ b/ios/APP_STORE_METADATA.md
@@ -1,0 +1,84 @@
+# App Store metadata
+
+## Name
+
+Codex Meter for iOS
+
+The installed app display name remains **Codex Meter**. The exact App Store name
+“Codex Meter” was unavailable when the app record was created.
+
+## Version
+
+- Marketing version: `2.8.0`
+- Build number: `1`
+
+## Subtitle
+
+Codex usage at a glance
+
+## Promotional text
+
+See monthly Free-tier windows, local burn trends, plan-value estimates, reset
+times, and credits from a native app and WidgetKit widgets.
+
+## Description
+
+Codex Meter puts your Codex allowance where it is easy to check—on your iPhone,
+iPad, and Home Screen.
+
+Sign in with your existing OpenAI account to see current five-hour, weekly, and
+model-specific usage windows, upcoming reset times, plan status, purchased
+usage credits, and earned reset credits. Clear visual meters and local burn
+charts make the important numbers easy to understand without repeatedly
+opening a browser.
+
+FEATURES
+
+- Five-hour, weekly, and Free-tier monthly Codex allowance meters
+- Automatically detected model-specific limits
+- Reorderable dashboard with per-card visibility
+- On-device burn history with scrubbable charts, insights, and plan-value estimates
+- Customizable history highlights so the page can stay as minimal as you like
+- Purchased usage-credit balance with automatic empty-balance hiding
+- Locally updating reset countdowns
+- Earned reset-credit inventory and expiry information
+- Confirmation before reset-credit redemption
+- Responsive Home Screen and accessory widgets that follow weekly or monthly windows
+- Adaptive automatic background-refresh scheduling
+- Optional refill, credit increase, and credit expiry notifications
+- Opt-in diagnostic log tracing and export unlocked from About
+- Background refresh and offline display of the latest successful update
+- Offline demo mode for exploring the interface without signing in
+
+PRIVATE BY DESIGN
+
+Codex Meter has no analytics, advertising, developer-operated account system,
+or relay server. Credentials stay in Apple Keychain, and authenticated requests
+go directly from your device to OpenAI.
+
+Codex Meter is an independent, unofficial client and is not affiliated with or
+endorsed by OpenAI. ChatGPT and Codex are trademarks of their respective owners.
+
+## Keywords
+
+`codex,usage,allowance,meter,reset,credits,widgets,developer,productivity`
+
+## App Privacy
+
+Select **No, we do not collect data from this app**.
+
+This answer reflects the submitted binary: there is no developer server,
+analytics, advertising, tracking, or telemetry SDK. OAuth credentials and the
+latest successful usage response are stored only on the device. Authenticated
+requests go directly to OpenAI to service the user’s existing account request.
+
+## Legal and support URLs
+
+Use the deployed site URLs:
+
+- Support URL: `/`
+- Privacy Policy URL: `/privacy`
+- EULA information: `/eula`
+
+Apple’s Standard EULA applies. Do not enter a custom EULA in App Store Connect
+unless the legal text is intentionally reviewed and supplied as plain text.

--- a/ios/CodexMeter.xcodeproj/project.pbxproj
+++ b/ios/CodexMeter.xcodeproj/project.pbxproj
@@ -534,17 +534,18 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CodexMeter/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Codex Meter";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -568,17 +569,18 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CodexMeter/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Codex Meter";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -607,7 +609,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -637,7 +639,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bukovinafilip.CodexMeter.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/ios/CodexMeter/AppModel.swift
+++ b/ios/CodexMeter/AppModel.swift
@@ -32,7 +32,7 @@ extension AlertMetric {
         switch self {
         case .both: "Both"
         case .fiveHour: "5-hour"
-        case .weekly: "Weekly"
+        case .weekly: "Weekly / Monthly"
         }
     }
 }
@@ -57,6 +57,9 @@ final class AppModel {
     var mode: AppMode = .signedOut
     var usage: UsageSnapshot?
     var credits: ResetCreditsSnapshot?
+    var fiveHourHistory: UsageHistory = .empty(.fiveHour)
+    var weeklyHistory: UsageHistory = .empty(.weekly)
+    var monthlyHistory: UsageHistory = .empty(.monthly)
     var settings: AppSettings
     var accountEmail = ""
     var accountPlan = ""
@@ -73,12 +76,14 @@ final class AppModel {
     var isShowingSettings = false
     var isShowingReset = false
     var isShowingSignIn = false
+    var diagnosticsUnlocked = false
 
     private let liveService: LiveCodexService
     private var demoService: DemoCodexService
     private let cache: AppCacheStore
     private let settingsStore: AppSettingsStore
     private let notificationCoordinator: NotificationCoordinator
+    private let usageHistoryStore: UsageHistoryStore
     private let refreshEngagementStore: RefreshEngagementStore
     private let defaults: UserDefaults
     private var hasStarted = false
@@ -104,6 +109,7 @@ final class AppModel {
         cache: AppCacheStore = .shared,
         settingsStore: AppSettingsStore = AppSettingsStore(),
         notificationCoordinator: NotificationCoordinator = NotificationCoordinator(),
+        usageHistoryStore: UsageHistoryStore = .shared,
         defaults: UserDefaults = .standard,
         refreshEngagementStore: RefreshEngagementStore? = nil,
         preview: Bool = false
@@ -113,11 +119,13 @@ final class AppModel {
         self.cache = cache
         self.settingsStore = settingsStore
         self.notificationCoordinator = notificationCoordinator
+        self.usageHistoryStore = usageHistoryStore
         self.defaults = defaults
         self.refreshEngagementStore = refreshEngagementStore
             ?? RefreshEngagementStore(defaults: defaults)
         self.settings = settingsStore.settings
         self.isPreview = preview
+        self.diagnosticsUnlocked = DiagnosticLog.isUnlocked(defaults: defaults)
 
         if preview {
             let now = Date()
@@ -184,6 +192,11 @@ final class AppModel {
     func startIfNeeded() async {
         guard !hasStarted, !isPreview else { return }
         hasStarted = true
+        apply(history: await usageHistoryStore.load())
+        DiagnosticLog.info("process", "started", details: [
+            "mode": mode.rawValue,
+            "app_version": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        ])
         defer {
             hasFinishedStartup = true
             applyPendingRouteIfNeeded()
@@ -193,6 +206,8 @@ final class AppModel {
         if ProcessInfo.processInfo.arguments.contains("-ui-testing-reset-settings") {
             settingsStore.reset()
             settings = settingsStore.settings
+            try? await usageHistoryStore.clear()
+            apply(history: .empty)
         }
 
         if ProcessInfo.processInfo.arguments.contains("-ui-testing-signed-out") {
@@ -235,6 +250,8 @@ final class AppModel {
             }
         } else {
             await liveService.signOut()
+            try? await usageHistoryStore.clear()
+            apply(history: .empty)
             mode = .signedOut
             defaults.set(AppMode.signedOut.rawValue, forKey: Self.modeDefaultsKey)
         }
@@ -255,15 +272,22 @@ final class AppModel {
         isRefreshing = true
         visibleError = nil
         defer { isRefreshing = false }
+        DiagnosticLog.info("refresh", "started", details: ["mode": mode.rawValue])
 
         do {
             let snapshot = try await activeService.refresh()
             refreshEngagementStore.recordRefreshSuccess()
+            DiagnosticLog.info("refresh", "finished", details: [
+                "plan": snapshot.usage.planType,
+                "has_monthly": snapshot.usage.monthly != nil ? "true" : "false",
+                "has_weekly": snapshot.usage.weekly != nil ? "true" : "false"
+            ])
             await apply(refresh: snapshot)
         } catch is CancellationError {
             return
         } catch {
             refreshEngagementStore.recordRefreshFailure()
+            DiagnosticLog.error("refresh", "failed", error: error)
             visibleError = error.localizedDescription
             if let cached = try? await cache.load() {
                 apply(cache: cached, preservingVisibleError: true)
@@ -275,6 +299,7 @@ final class AppModel {
     func enterDemo() async {
         mode = .demo
         defaults.set(AppMode.demo.rawValue, forKey: Self.modeDefaultsKey)
+        DiagnosticLog.info("process", "enter_demo")
         visibleError = nil
         accountEmail = "demo@local"
         accountPlan = "Plus (Demo)"
@@ -285,15 +310,20 @@ final class AppModel {
         await demoService.signOut()
         await notificationCoordinator.clearAll()
         backgroundRefreshCoordinator.cancel()
+        try? await usageHistoryStore.clear()
+        apply(history: .empty)
         clearSessionState()
     }
 
     func signOut() async {
         signInTask?.cancel()
         signInTask = nil
+        DiagnosticLog.info("process", "sign_out")
         await activeService.signOut()
         await notificationCoordinator.clearAll()
         backgroundRefreshCoordinator.cancel()
+        try? await usageHistoryStore.clear()
+        apply(history: .empty)
         clearSessionState()
     }
 
@@ -305,7 +335,9 @@ final class AppModel {
 
         do {
             authChallenge = try await liveService.deviceCodeAuth.requestChallenge()
+            DiagnosticLog.info("oauth", "challenge_started")
         } catch {
+            DiagnosticLog.error("oauth", "challenge_failed", error: error)
             authenticationError = error.localizedDescription
         }
     }
@@ -325,11 +357,13 @@ final class AppModel {
                 authChallenge = nil
                 isAuthenticating = false
                 signInTask = nil
+                DiagnosticLog.info("oauth", "signed_in")
                 await refresh()
             } catch is CancellationError {
                 isAuthenticating = false
                 signInTask = nil
             } catch {
+                DiagnosticLog.error("oauth", "sign_in_failed", error: error)
                 authenticationError = error.localizedDescription
                 authChallenge = nil
                 isAuthenticating = false
@@ -367,6 +401,9 @@ final class AppModel {
             }
             if let cached = try? await cache.load() {
                 apply(cache: cached)
+                if result.applied, let refreshedUsage = cached.usage {
+                    await recordUsageHistory(refreshedUsage)
+                }
                 if result.applied {
                     let advanced: Bool
                     if let refreshedAt = cached.usage?.fetchedAt {
@@ -525,6 +562,15 @@ final class AppModel {
         scheduleBackgroundRefresh()
     }
 
+    func clearUsageHistory() async {
+        do {
+            try await usageHistoryStore.clear()
+            apply(history: .empty)
+        } catch {
+            visibleError = "Local usage history could not be cleared."
+        }
+    }
+
     private var activeService: any CodexService {
         mode == .demo ? demoService : liveService
     }
@@ -536,12 +582,13 @@ final class AppModel {
         accountPlan = UsageFormat.planLabel(refresh.usage.planType)
         visibleError = nil
         isUsingCachedData = false
+        await recordUsageHistory(refresh.usage)
 
         if mode == .live, let tokens = try? await liveService.currentTokens() {
             apply(tokens: tokens)
         }
         if let cached = try? await cache.load() {
-            visibleError = cached.resetCreditsError ?? cached.widgetError
+            visibleError = cached.resetCreditsError
         }
         await notificationCoordinator.process(
             usage: refresh.usage,
@@ -567,7 +614,7 @@ final class AppModel {
                   snapshot.usage?.isStale(at: .now, maxAge: 15 * 60) == true {
             visibleError = error
         } else {
-            visibleError = snapshot.resetCreditsError ?? snapshot.widgetError
+            visibleError = snapshot.resetCreditsError
         }
     }
 
@@ -602,7 +649,7 @@ final class AppModel {
         let now = Date()
         try? backgroundRefreshCoordinator.schedule(
             preferredMinutes: effectiveRefreshMinutes(at: now),
-            nextReset: usage?.nextReset(after: .now)
+            nextReset: usage?.nextReset(after: now)
         )
     }
 
@@ -617,6 +664,22 @@ final class AppModel {
             consecutiveFailures: refreshEngagementStore.consecutiveFailures,
             now: date
         )
+    }
+
+    private func recordUsageHistory(_ usage: UsageSnapshot) async {
+        guard let snapshot = try? await usageHistoryStore.record(usage) else { return }
+        apply(history: snapshot)
+    }
+
+    private func apply(history: LocalUsageHistorySnapshot) {
+        fiveHourHistory = history.fiveHour
+        weeklyHistory = history.weekly
+        monthlyHistory = history.monthly
+    }
+
+    func unlockDiagnostics() {
+        diagnosticsUnlocked = true
+        DiagnosticLog.unlock(defaults: defaults)
     }
 
     private func applyNotificationSettings() async {

--- a/ios/CodexMeter/Infrastructure/AppCacheStore.swift
+++ b/ios/CodexMeter/Infrastructure/AppCacheStore.swift
@@ -6,8 +6,6 @@ nonisolated public struct AppCacheSnapshot: Codable, Sendable, Equatable {
     public var credits: ResetCreditsSnapshot?
     public var lastError: String?
     public var resetCreditsError: String?
-    /// Surfaced when widget App Group publishing fails while account data still refreshes.
-    public var widgetError: String?
     public var updatedAt: Date
 
     public init(
@@ -15,14 +13,12 @@ nonisolated public struct AppCacheSnapshot: Codable, Sendable, Equatable {
         credits: ResetCreditsSnapshot? = nil,
         lastError: String? = nil,
         resetCreditsError: String? = nil,
-        widgetError: String? = nil,
         updatedAt: Date = Date()
     ) {
         self.usage = usage
         self.credits = credits
         self.lastError = lastError
         self.resetCreditsError = resetCreditsError
-        self.widgetError = widgetError
         self.updatedAt = updatedAt
     }
 }
@@ -118,20 +114,6 @@ public actor AppCacheStore {
     public func recordCreditsError(_ message: String, at date: Date = Date()) async {
         var snapshot = (try? await load()) ?? AppCacheSnapshot(updatedAt: date)
         snapshot.resetCreditsError = String(message.prefix(240))
-        snapshot.updatedAt = date
-        try? await save(snapshot)
-    }
-
-    public func recordWidgetError(_ message: String, at date: Date = Date()) async {
-        var snapshot = (try? await load()) ?? AppCacheSnapshot(updatedAt: date)
-        snapshot.widgetError = String(message.prefix(240))
-        snapshot.updatedAt = date
-        try? await save(snapshot)
-    }
-
-    public func clearWidgetError(at date: Date = Date()) async {
-        guard var snapshot = try? await load(), snapshot.widgetError != nil else { return }
-        snapshot.widgetError = nil
         snapshot.updatedAt = date
         try? await save(snapshot)
     }

--- a/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
+++ b/ios/CodexMeter/Infrastructure/AppSettingsStore.swift
@@ -1,4 +1,5 @@
 import Combine
+import CodexMeterCore
 import Foundation
 
 nonisolated public enum AppAppearance: String, Codable, Sendable, CaseIterable, Identifiable {
@@ -15,21 +16,6 @@ nonisolated public enum AlertMetric: String, Codable, Sendable, CaseIterable, Id
     case weekly
 
     public var id: String { rawValue }
-
-    /// Whether low-usage / reset alerts should run for `metric`.
-    ///
-    /// The picker chooses which windows to monitor (Both / 5-hour / Weekly),
-    /// not which window to exclude.
-    public func includes(_ metric: AlertMetric) -> Bool {
-        switch self {
-        case .both:
-            return metric == .fiveHour || metric == .weekly
-        case .fiveHour:
-            return metric == .fiveHour
-        case .weekly:
-            return metric == .weekly
-        }
-    }
 }
 
 nonisolated public enum RefreshMode: String, Codable, Sendable, CaseIterable, Identifiable {
@@ -53,9 +39,15 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
     public var refreshMinutes: Int
     public var showFiveHour: Bool
     public var showWeekly: Bool
+    public var showMonthly: Bool
     public var showAdditionalLimits: Bool
     public var showUsageCredits: Bool
+    public var showUsageHistory: Bool
     public var showResetCredits: Bool
+    public var dashboardOrder: [String]
+    public var dashboardHiddenSections: [String]
+    /// CSV of usage-history highlight keys the user toggled away from their default.
+    public var historySectionOverrides: String
     public var notificationsEnabled: Bool
     public var alertMetric: AlertMetric
     /// Remaining allowance percentage. `100` corresponds to the “Always” UI option.
@@ -73,9 +65,14 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         refreshMinutes: Int = 30,
         showFiveHour: Bool = true,
         showWeekly: Bool = true,
+        showMonthly: Bool = true,
         showAdditionalLimits: Bool = true,
         showUsageCredits: Bool = true,
+        showUsageHistory: Bool = true,
         showResetCredits: Bool = true,
+        dashboardOrder: [String] = [],
+        dashboardHiddenSections: [String] = [],
+        historySectionOverrides: String = "",
         notificationsEnabled: Bool = false,
         alertMetric: AlertMetric = .both,
         alertThreshold: Int = 25,
@@ -90,9 +87,16 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         self.refreshMinutes = Self.allowedRefreshMinutes.contains(refreshMinutes) ? refreshMinutes : 30
         self.showFiveHour = showFiveHour
         self.showWeekly = showWeekly
+        self.showMonthly = showMonthly
         self.showAdditionalLimits = showAdditionalLimits
         self.showUsageCredits = showUsageCredits
+        self.showUsageHistory = showUsageHistory
         self.showResetCredits = showResetCredits
+        self.dashboardOrder = Self.sanitizedSectionKeys(dashboardOrder)
+        self.dashboardHiddenSections = Self.sanitizedSectionKeys(dashboardHiddenSections)
+        self.historySectionOverrides = HistorySections.serialize(
+            HistorySections.parseCSV(historySectionOverrides)
+        )
         self.notificationsEnabled = notificationsEnabled
         self.alertMetric = alertMetric
         self.alertThreshold = Self.allowedAlertThresholds.contains(alertThreshold) ? alertThreshold : 25
@@ -117,9 +121,79 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         creditExpiryLeadMinutes = Self.sanitizedLeadMinutes(Array(set))
     }
 
+    public func isDashboardSectionVisible(_ key: String) -> Bool {
+        switch key {
+        case DashboardSections.fiveHour:
+            showFiveHour
+        case DashboardSections.weekly:
+            showWeekly
+        case DashboardSections.monthly:
+            showMonthly
+        case DashboardSections.usageCredits:
+            showUsageCredits
+        case DashboardSections.usageHistory:
+            showUsageHistory
+        case DashboardSections.resetCredits:
+            showResetCredits
+        default:
+            showAdditionalLimits && !dashboardHiddenSections.contains(key)
+        }
+    }
+
+    public mutating func setDashboardSectionVisible(_ key: String, visible: Bool) {
+        switch key {
+        case DashboardSections.fiveHour:
+            showFiveHour = visible
+        case DashboardSections.weekly:
+            showWeekly = visible
+        case DashboardSections.monthly:
+            showMonthly = visible
+        case DashboardSections.usageCredits:
+            showUsageCredits = visible
+        case DashboardSections.usageHistory:
+            showUsageHistory = visible
+        case DashboardSections.resetCredits:
+            showResetCredits = visible
+        default:
+            if visible {
+                showAdditionalLimits = true
+                dashboardHiddenSections.removeAll { $0 == key }
+            } else if !dashboardHiddenSections.contains(key) {
+                dashboardHiddenSections.append(key)
+            }
+            dashboardHiddenSections = Self.sanitizedSectionKeys(dashboardHiddenSections)
+        }
+    }
+
+    public mutating func setDashboardOrder(_ keys: [String]) {
+        dashboardOrder = Self.sanitizedSectionKeys(keys)
+    }
+
+    public func isHistorySectionVisible(_ key: String) -> Bool {
+        HistorySections.isVisible(historySectionOverrides, key: key)
+    }
+
+    public mutating func setHistorySectionVisible(_ key: String, visible: Bool) {
+        historySectionOverrides = HistorySections.setVisible(
+            historySectionOverrides,
+            key: key,
+            visible: visible
+        )
+    }
+
     private static func sanitizedLeadMinutes(_ values: [Int]) -> [Int] {
         let filtered = Set(values).intersection(Set(allowedCreditExpiryLeadMinutes))
         return filtered.sorted()
+    }
+
+    private static func sanitizedSectionKeys(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.compactMap { raw in
+            let key = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingOccurrences(of: ",", with: "_")
+            guard !key.isEmpty, seen.insert(key).inserted else { return nil }
+            return key
+        }
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -129,9 +203,14 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
         case refreshMinutes
         case showFiveHour
         case showWeekly
+        case showMonthly
         case showAdditionalLimits
         case showUsageCredits
+        case showUsageHistory
         case showResetCredits
+        case dashboardOrder
+        case dashboardHiddenSections
+        case historySectionOverrides
         case notificationsEnabled
         case alertMetric
         case alertThreshold
@@ -150,9 +229,14 @@ nonisolated public struct AppSettings: Codable, Sendable, Equatable {
             refreshMinutes: try container.decodeIfPresent(Int.self, forKey: .refreshMinutes) ?? 30,
             showFiveHour: try container.decodeIfPresent(Bool.self, forKey: .showFiveHour) ?? true,
             showWeekly: try container.decodeIfPresent(Bool.self, forKey: .showWeekly) ?? true,
+            showMonthly: try container.decodeIfPresent(Bool.self, forKey: .showMonthly) ?? true,
             showAdditionalLimits: try container.decodeIfPresent(Bool.self, forKey: .showAdditionalLimits) ?? true,
             showUsageCredits: try container.decodeIfPresent(Bool.self, forKey: .showUsageCredits) ?? true,
+            showUsageHistory: try container.decodeIfPresent(Bool.self, forKey: .showUsageHistory) ?? true,
             showResetCredits: try container.decodeIfPresent(Bool.self, forKey: .showResetCredits) ?? true,
+            dashboardOrder: try container.decodeIfPresent([String].self, forKey: .dashboardOrder) ?? [],
+            dashboardHiddenSections: try container.decodeIfPresent([String].self, forKey: .dashboardHiddenSections) ?? [],
+            historySectionOverrides: try container.decodeIfPresent(String.self, forKey: .historySectionOverrides) ?? "",
             notificationsEnabled: try container.decodeIfPresent(Bool.self, forKey: .notificationsEnabled) ?? false,
             alertMetric: try container.decodeIfPresent(AlertMetric.self, forKey: .alertMetric) ?? .both,
             alertThreshold: try container.decodeIfPresent(Int.self, forKey: .alertThreshold) ?? 25,

--- a/ios/CodexMeter/Infrastructure/CelebrationDetector.swift
+++ b/ios/CodexMeter/Infrastructure/CelebrationDetector.swift
@@ -13,6 +13,7 @@ nonisolated public enum CelebrationDetector {
 
         public static let fiveHour = RefillMask(rawValue: 1 << 0)
         public static let weekly = RefillMask(rawValue: 1 << 1)
+        public static let monthly = RefillMask(rawValue: 1 << 2)
     }
 
     public static let unknownUserResetSuppression: TimeInterval = 15 * 60
@@ -40,6 +41,14 @@ nonisolated public enum CelebrationDetector {
         ) {
             mask.insert(.weekly)
         }
+        if isUnexpectedRefill(
+            previous: previous,
+            oldWindow: previous.monthly,
+            newWindow: current.monthly,
+            observedAt: current.fetchedAt
+        ) {
+            mask.insert(.monthly)
+        }
         return mask
     }
 
@@ -52,7 +61,8 @@ nonisolated public enum CelebrationDetector {
         _ refills: RefillMask,
         observedAt: Date,
         fiveHourSuppressUntil: Date?,
-        weeklySuppressUntil: Date?
+        weeklySuppressUntil: Date?,
+        monthlySuppressUntil: Date? = nil
     ) -> RefillMask {
         var result = refills
         if let fiveHourSuppressUntil, fiveHourSuppressUntil > observedAt {
@@ -60,6 +70,9 @@ nonisolated public enum CelebrationDetector {
         }
         if let weeklySuppressUntil, weeklySuppressUntil > observedAt {
             result.remove(.weekly)
+        }
+        if let monthlySuppressUntil, monthlySuppressUntil > observedAt {
+            result.remove(.monthly)
         }
         return result
     }

--- a/ios/CodexMeter/Infrastructure/DiagnosticLog.swift
+++ b/ios/CodexMeter/Infrastructure/DiagnosticLog.swift
@@ -1,0 +1,228 @@
+import CodexMeterCore
+import Foundation
+
+/// Opt-in, privacy-filtered, rotating JSONL diagnostics stored only in app-private storage.
+enum DiagnosticLog {
+    static let unlockKey = "codex-meter.diagnostics-unlocked-v1"
+    private static let enabledKey = "codex-meter.diagnostics-enabled-v1"
+    private static let sessionKey = "codex-meter.diagnostics-session-v1"
+    private static let directoryName = "diagnostic-logs"
+    private static let currentFileName = "events.jsonl"
+    private static let maxArchives = 2
+    private static let maxFileBytes = 1_024 * 1_024
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var sequence: Int64 = 0
+
+    struct Stats: Sendable, Equatable {
+        var bytes: Int64
+        var files: Int
+
+        var hasLogs: Bool { bytes > 0 }
+    }
+
+    static func isUnlocked(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: unlockKey)
+    }
+
+    static func unlock(defaults: UserDefaults = .standard) {
+        defaults.set(true, forKey: unlockKey)
+    }
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: enabledKey)
+    }
+
+    static func setEnabled(_ enabled: Bool) {
+        let wasEnabled = isEnabled
+        guard wasEnabled != enabled else { return }
+        if enabled {
+            UserDefaults.standard.set(UUID().uuidString, forKey: sessionKey)
+            UserDefaults.standard.set(true, forKey: enabledKey)
+            info("diagnostics", "tracing_enabled", details: [
+                "app_version": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "",
+                "ios": ProcessInfo.processInfo.operatingSystemVersionString
+            ])
+        } else {
+            info("diagnostics", "tracing_disabled")
+            UserDefaults.standard.set(false, forKey: enabledKey)
+        }
+    }
+
+    static func info(_ category: String, _ event: String, details: [String: String] = [:]) {
+        write(level: "info", category: category, event: event, error: nil, details: details)
+    }
+
+    static func warn(_ category: String, _ event: String, details: [String: String] = [:]) {
+        write(level: "warn", category: category, event: event, error: nil, details: details)
+    }
+
+    static func error(
+        _ category: String,
+        _ event: String,
+        error: Error? = nil,
+        details: [String: String] = [:]
+    ) {
+        write(level: "error", category: category, event: event, error: error, details: details)
+    }
+
+    static func stats() -> Stats {
+        lock.lock()
+        defer { lock.unlock() }
+        var bytes: Int64 = 0
+        var files = 0
+        for file in orderedFiles() where FileManager.default.fileExists(atPath: file.path) {
+            if let size = try? FileManager.default.attributesOfItem(atPath: file.path)[.size] as? NSNumber {
+                let length = size.int64Value
+                if length > 0 {
+                    bytes += length
+                    files += 1
+                }
+            }
+        }
+        return Stats(bytes: bytes, files: files)
+    }
+
+    static func clear() {
+        lock.lock()
+        defer { lock.unlock() }
+        for file in orderedFiles() where FileManager.default.fileExists(atPath: file.path) {
+            try? FileManager.default.removeItem(at: file)
+        }
+    }
+
+    static func exportURL() throws -> URL {
+        info("diagnostics", "export_started")
+        lock.lock()
+        defer { lock.unlock() }
+        let export = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-meter-diagnostics.jsonl")
+        if FileManager.default.fileExists(atPath: export.path) {
+            try FileManager.default.removeItem(at: export)
+        }
+        FileManager.default.createFile(atPath: export.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: export)
+        defer { try? handle.close() }
+        for file in orderedFiles() {
+            guard FileManager.default.fileExists(atPath: file.path),
+                  let data = try? Data(contentsOf: file),
+                  !data.isEmpty else {
+                continue
+            }
+            try handle.write(contentsOf: data)
+        }
+        return export
+    }
+
+    static func formatBytes(_ bytes: Int64) -> String {
+        if bytes < 1_024 {
+            return "\(bytes) B"
+        }
+        if bytes < 1_024 * 1_024 {
+            return "\(max(1, bytes / 1_024)) KB"
+        }
+        return String(format: "%.1f MB", Double(bytes) / (1_024.0 * 1_024.0))
+    }
+
+    private static func write(
+        level: String,
+        category: String,
+        event: String,
+        error: Error?,
+        details: [String: String]
+    ) {
+        guard isEnabled else { return }
+        do {
+            var record: [String: Any] = [
+                "timestamp": ISO8601DateFormatter().string(from: Date()),
+                "sequence": nextSequence(),
+                "session_id": UserDefaults.standard.string(forKey: sessionKey) ?? "",
+                "level": DiagnosticSanitizer.redact(level),
+                "category": DiagnosticSanitizer.redact(category),
+                "event": DiagnosticSanitizer.redact(event),
+                "thread": DiagnosticSanitizer.redact(Thread.current.name ?? "main")
+            ]
+            if !details.isEmpty {
+                record["details"] = details.reduce(into: [String: String]()) { result, item in
+                    result[DiagnosticSanitizer.redact(item.key)] = DiagnosticSanitizer.redact(item.value)
+                }
+            }
+            if let error {
+                record["error"] = [
+                    "type": String(describing: type(of: error)),
+                    "message": DiagnosticSanitizer.redact(error.localizedDescription)
+                ]
+            }
+            let data = try JSONSerialization.data(withJSONObject: record, options: [.sortedKeys])
+            var line = data
+            line.append(contentsOf: "\n".utf8)
+            append(line)
+        } catch {
+            // Diagnostics must never break the operation being diagnosed.
+        }
+    }
+
+    private static func nextSequence() -> Int64 {
+        lock.lock()
+        defer { lock.unlock() }
+        sequence += 1
+        return sequence
+    }
+
+    private static func append(_ line: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        let directory = directoryURL()
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let current = directory.appendingPathComponent(currentFileName)
+        let existing = (try? FileManager.default.attributesOfItem(atPath: current.path)[.size] as? NSNumber)?
+            .int64Value ?? 0
+        if existing + Int64(line.count) > maxFileBytes {
+            rotate(directory)
+        }
+        if !FileManager.default.fileExists(atPath: current.path) {
+            FileManager.default.createFile(atPath: current.path, contents: nil)
+        }
+        guard let handle = try? FileHandle(forWritingTo: current) else { return }
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        try? handle.write(contentsOf: line)
+    }
+
+    private static func rotate(_ directory: URL) {
+        let oldest = archive(directory, index: maxArchives)
+        if FileManager.default.fileExists(atPath: oldest.path) {
+            try? FileManager.default.removeItem(at: oldest)
+        }
+        for index in stride(from: maxArchives - 1, through: 1, by: -1) {
+            let source = archive(directory, index: index)
+            if FileManager.default.fileExists(atPath: source.path) {
+                try? FileManager.default.moveItem(at: source, to: archive(directory, index: index + 1))
+            }
+        }
+        let current = directory.appendingPathComponent(currentFileName)
+        if FileManager.default.fileExists(atPath: current.path) {
+            try? FileManager.default.moveItem(at: current, to: archive(directory, index: 1))
+        }
+    }
+
+    private static func orderedFiles() -> [URL] {
+        let directory = directoryURL()
+        return [
+            archive(directory, index: 2),
+            archive(directory, index: 1),
+            directory.appendingPathComponent(currentFileName)
+        ]
+    }
+
+    private static func archive(_ directory: URL, index: Int) -> URL {
+        directory.appendingPathComponent("events.\(index).jsonl")
+    }
+
+    private static func directoryURL() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return base
+            .appendingPathComponent("CodexMeter", isDirectory: true)
+            .appendingPathComponent(directoryName, isDirectory: true)
+    }
+}

--- a/ios/CodexMeter/Infrastructure/NotificationCoordinator.swift
+++ b/ios/CodexMeter/Infrastructure/NotificationCoordinator.swift
@@ -22,38 +22,22 @@ nonisolated public enum NotificationDeduplication {
         Int(resetDate.timeIntervalSince1970)
     }
 
-    /// OpenAI reset timestamps drift across refreshes; match Android's window tolerance.
-    public static func resetWindowToleranceSeconds(windowSeconds: Int64) -> Int {
-        if windowSeconds <= 0 { return 60 }
-        let proportional = Int(windowSeconds / 20)
-        return min(15 * 60, max(60, proportional))
-    }
-
-    public static func sameResetWindow(
-        leftToken: Int,
-        rightToken: Int,
-        windowSeconds: Int64
-    ) -> Bool {
-        abs(leftToken - rightToken) <= resetWindowToleranceSeconds(windowSeconds: windowSeconds)
-    }
-
     public static func shouldDeliverLowUsage(
         lastDeliveredWindowToken: Int?,
         resetDate: Date,
-        windowSeconds: Int64
+        windowSeconds: Int64 = 18_000
     ) -> Bool {
-        let current = windowToken(for: resetDate)
-        guard let lastDeliveredWindowToken else { return true }
-        return !sameResetWindow(
-            leftToken: lastDeliveredWindowToken,
-            rightToken: current,
+        UsageWindow.shouldAnnounceLowUsage(
+            lastAnnouncedReset: lastDeliveredWindowToken.map {
+                Date(timeIntervalSince1970: TimeInterval($0))
+            },
+            currentReset: resetDate,
             windowSeconds: windowSeconds
         )
     }
 
-    /// Stable per-metric id so refresh drift cannot create a second low-usage alert.
-    public static func lowUsageIdentifier(metric: AlertMetric) -> String {
-        "\(identifierPrefix)low.\(metric.rawValue)"
+    public static func lowUsageIdentifier(metric: AlertMetric, resetDate: Date) -> String {
+        "\(identifierPrefix)low.\(metric.rawValue).\(windowToken(for: resetDate))"
     }
 
     public static func resetIdentifier(metric: AlertMetric, resetDate: Date) -> String {
@@ -108,6 +92,7 @@ public actor NotificationCoordinator {
     private static let creditExpiryAnnouncedKey = "codex-meter.notification.credit-expiry-announced"
     private static let userResetFiveHourUntilKey = "codex-meter.notification.user-reset-five-hour-until"
     private static let userResetWeeklyUntilKey = "codex-meter.notification.user-reset-weekly-until"
+    private static let userResetMonthlyUntilKey = "codex-meter.notification.user-reset-monthly-until"
     private static let categoriesRegisteredKey = "codex-meter.notification.categories-registered"
 
     private let center: UNUserNotificationCenter
@@ -156,7 +141,7 @@ public actor NotificationCoordinator {
 
         var currentLowIdentifiers: Set<String> = []
         var currentResetIdentifiers: Set<String> = []
-        if settings.alertMetric.includes(.fiveHour), let window = usage.fiveHour {
+        if settings.alertMetric != .weekly, let window = usage.fiveHour {
             await processWindow(
                 window,
                 metric: .fiveHour,
@@ -168,11 +153,11 @@ public actor NotificationCoordinator {
                 currentResetIdentifiers: &currentResetIdentifiers
             )
         }
-        if settings.alertMetric.includes(.weekly), let window = usage.weekly {
+        if settings.alertMetric != .fiveHour, let window = usage.longWindow {
             await processWindow(
                 window,
                 metric: .weekly,
-                label: "Weekly",
+                label: usage.longWindowIsMonthly ? "Monthly" : "Weekly",
                 fetchedAt: usage.fetchedAt,
                 threshold: settings.alertThreshold,
                 now: now,
@@ -220,6 +205,15 @@ public actor NotificationCoordinator {
         } else {
             defaults.removeObject(forKey: Self.userResetWeeklyUntilKey)
         }
+        if let deadline = CelebrationDetector.userResetSuppressionDeadline(
+            snapshot: usage,
+            window: usage.monthly,
+            now: now
+        ) {
+            defaults.set(deadline.timeIntervalSince1970, forKey: Self.userResetMonthlyUntilKey)
+        } else {
+            defaults.removeObject(forKey: Self.userResetMonthlyUntilKey)
+        }
     }
 
     @discardableResult
@@ -250,6 +244,7 @@ public actor NotificationCoordinator {
         defaults.removeObject(forKey: Self.creditExpiryAnnouncedKey)
         defaults.removeObject(forKey: Self.userResetFiveHourUntilKey)
         defaults.removeObject(forKey: Self.userResetWeeklyUntilKey)
+        defaults.removeObject(forKey: Self.userResetMonthlyUntilKey)
     }
 
     private func processWindow(
@@ -287,21 +282,20 @@ public actor NotificationCoordinator {
             )
         )
         guard window.hasRemainingAllowance(atOrBelow: threshold) else { return }
-        let identifier = NotificationDeduplication.lowUsageIdentifier(metric: metric)
+        let identifier = NotificationDeduplication.lowUsageIdentifier(
+            metric: metric,
+            resetDate: resetDate
+        )
         currentLowIdentifiers.insert(identifier)
         let stateKey = Self.lowUsageStatePrefix + metric.rawValue
         let previousWindowToken = defaults.object(forKey: stateKey) == nil
             ? nil
             : defaults.integer(forKey: stateKey)
-        let currentToken = NotificationDeduplication.windowToken(for: resetDate)
         guard NotificationDeduplication.shouldDeliverLowUsage(
             lastDeliveredWindowToken: previousWindowToken,
             resetDate: resetDate,
             windowSeconds: window.windowSeconds
         ) else {
-            if previousWindowToken != currentToken {
-                defaults.set(currentToken, forKey: stateKey)
-            }
             return
         }
         let lowContent = UNMutableNotificationContent()
@@ -312,7 +306,7 @@ public actor NotificationCoordinator {
             try await center.add(
                 UNNotificationRequest(identifier: identifier, content: lowContent, trigger: nil)
             )
-            defaults.set(currentToken, forKey: stateKey)
+            defaults.set(NotificationDeduplication.windowToken(for: resetDate), forKey: stateKey)
         } catch {
             // Leave the state unset so a later refresh can retry delivery.
         }
@@ -327,14 +321,16 @@ public actor NotificationCoordinator {
 
         let fiveHourUntil = date(forKey: Self.userResetFiveHourUntilKey)
         let weeklyUntil = date(forKey: Self.userResetWeeklyUntilKey)
+        let monthlyUntil = date(forKey: Self.userResetMonthlyUntilKey)
         let filtered = CelebrationDetector.withoutUserResetRefills(
             raw,
             observedAt: current.fetchedAt,
             fiveHourSuppressUntil: fiveHourUntil,
-            weeklySuppressUntil: weeklyUntil
+            weeklySuppressUntil: weeklyUntil,
+            monthlySuppressUntil: monthlyUntil
         )
 
-        if fiveHourUntil != nil || weeklyUntil != nil {
+        if fiveHourUntil != nil || weeklyUntil != nil || monthlyUntil != nil {
             clearSuppressionIfNeeded(
                 window: .fiveHour,
                 before: raw,
@@ -351,18 +347,34 @@ public actor NotificationCoordinator {
                 suppressUntil: weeklyUntil,
                 key: Self.userResetWeeklyUntilKey
             )
+            clearSuppressionIfNeeded(
+                window: .monthly,
+                before: raw,
+                after: filtered,
+                observedAt: current.fetchedAt,
+                suppressUntil: monthlyUntil,
+                key: Self.userResetMonthlyUntilKey
+            )
         }
 
         guard !filtered.isEmpty else { return }
 
         let title: String
         let body: String
-        if filtered.contains(.fiveHour) && filtered.contains(.weekly) {
+        let windows = [
+            filtered.contains(.fiveHour) ? "five-hour" : nil,
+            filtered.contains(.weekly) ? "weekly" : nil,
+            filtered.contains(.monthly) ? "monthly" : nil
+        ].compactMap { $0 }
+        if windows.count > 1 {
             title = "Codex allowance refilled"
-            body = "Your five-hour and weekly windows refilled before their scheduled reset."
+            body = "Your \(windows.joined(separator: " and ")) windows refilled before their scheduled reset."
         } else if filtered.contains(.fiveHour) {
             title = "5-hour Codex allowance refilled"
             body = "Your five-hour window refilled before its scheduled reset."
+        } else if filtered.contains(.monthly) {
+            title = "Monthly Codex allowance refilled"
+            body = "Your monthly window refilled before its scheduled reset."
         } else {
             title = "Weekly Codex allowance refilled"
             body = "Your weekly window refilled before its scheduled reset."

--- a/ios/CodexMeter/Infrastructure/SettingsTransferDocument.swift
+++ b/ios/CodexMeter/Infrastructure/SettingsTransferDocument.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct SettingsTransferDocument: FileDocument {
+    static let readableContentTypes: [UTType] = [.json]
+
+    let settings: AppSettings
+
+    init(settings: AppSettings) {
+        self.settings = settings
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        settings = try Self.decode(data)
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        let envelope = SettingsTransferEnvelope(
+            formatVersion: 1,
+            exportedAt: .now,
+            settings: settings
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return FileWrapper(regularFileWithContents: try encoder.encode(envelope))
+    }
+
+    static func decode(_ data: Data) throws -> AppSettings {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        if let envelope = try? decoder.decode(SettingsTransferEnvelope.self, from: data),
+           envelope.formatVersion == 1 {
+            return envelope.settings
+        }
+        return try decoder.decode(AppSettings.self, from: data)
+    }
+}
+
+private struct SettingsTransferEnvelope: Codable {
+    let formatVersion: Int
+    let exportedAt: Date
+    let settings: AppSettings
+}

--- a/ios/CodexMeter/Infrastructure/UsageHistoryStore.swift
+++ b/ios/CodexMeter/Infrastructure/UsageHistoryStore.swift
@@ -1,0 +1,136 @@
+import CodexMeterCore
+import Foundation
+
+nonisolated struct LocalUsageHistorySnapshot: Codable, Sendable, Equatable {
+    var fiveHour: UsageHistory
+    var weekly: UsageHistory
+    var monthly: UsageHistory
+
+    static let empty = LocalUsageHistorySnapshot(
+        fiveHour: .empty(.fiveHour),
+        weekly: .empty(.weekly),
+        monthly: .empty(.monthly)
+    )
+
+    private enum CodingKeys: String, CodingKey {
+        case fiveHour
+        case weekly
+        case monthly
+    }
+
+    init(fiveHour: UsageHistory, weekly: UsageHistory, monthly: UsageHistory) {
+        self.fiveHour = fiveHour
+        self.weekly = weekly
+        self.monthly = monthly
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        fiveHour = try container.decodeIfPresent(UsageHistory.self, forKey: .fiveHour)
+            ?? .empty(.fiveHour)
+        weekly = try container.decodeIfPresent(UsageHistory.self, forKey: .weekly)
+            ?? .empty(.weekly)
+        monthly = try container.decodeIfPresent(UsageHistory.self, forKey: .monthly)
+            ?? .empty(.monthly)
+    }
+}
+
+/// Stores only bounded allowance samples used for on-device charts and pace estimates.
+/// No account identifiers, tokens, or raw API responses are written here.
+actor UsageHistoryStore {
+    static let defaultFileName = "usage-history-v1.json"
+    static let shared = UsageHistoryStore()
+
+    private let fileURL: URL
+    private let fileManager: FileManager
+    private var memorySnapshot: LocalUsageHistorySnapshot?
+
+    init(fileURL: URL? = nil, fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        if let fileURL {
+            self.fileURL = fileURL
+        } else {
+            let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+                ?? fileManager.temporaryDirectory
+            self.fileURL = base
+                .appendingPathComponent("CodexMeter", isDirectory: true)
+                .appendingPathComponent(Self.defaultFileName)
+        }
+    }
+
+    func load() -> LocalUsageHistorySnapshot {
+        if let memorySnapshot {
+            return memorySnapshot
+        }
+        guard fileManager.fileExists(atPath: fileURL.path),
+              let data = try? Data(contentsOf: fileURL, options: [.mappedIfSafe, .uncached]),
+              data.count <= 512 * 1_024,
+              let decoded = try? Self.decoder.decode(LocalUsageHistorySnapshot.self, from: data)
+        else {
+            memorySnapshot = .empty
+            return .empty
+        }
+        memorySnapshot = decoded
+        return decoded
+    }
+
+    @discardableResult
+    func record(_ usage: UsageSnapshot) throws -> LocalUsageHistorySnapshot {
+        var snapshot = load()
+        if let fiveHour = usage.fiveHour {
+            snapshot.fiveHour = snapshot.fiveHour.appending(
+                window: fiveHour,
+                observedAt: usage.fetchedAt
+            )
+        }
+        if let weekly = usage.weekly {
+            snapshot.weekly = snapshot.weekly.appending(
+                window: weekly,
+                observedAt: usage.fetchedAt
+            )
+        }
+        if let monthly = usage.monthly {
+            snapshot.monthly = snapshot.monthly.appending(
+                window: monthly,
+                observedAt: usage.fetchedAt
+            )
+        }
+        try save(snapshot)
+        return snapshot
+    }
+
+    func clear() throws {
+        memorySnapshot = .empty
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        try fileManager.removeItem(at: fileURL)
+    }
+
+    private func save(_ snapshot: LocalUsageHistorySnapshot) throws {
+        let data = try Self.encoder.encode(snapshot)
+        let directory = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+        )
+        try data.write(to: fileURL, options: [.atomic])
+        try? fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: fileURL.path
+        )
+        memorySnapshot = snapshot
+    }
+
+    private static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/ios/CodexMeter/Infrastructure/WidgetSnapshotCache.swift
+++ b/ios/CodexMeter/Infrastructure/WidgetSnapshotCache.swift
@@ -6,11 +6,6 @@ import Foundation
 public actor WidgetSnapshotCache {
     public nonisolated static let appGroupIdentifier = "group.com.bukovinafilip.CodexMeter"
     public nonisolated static let shared = WidgetSnapshotCache()
-    public nonisolated static let unavailableMessage =
-        "Home Screen widgets need an App Group. Configure signing and the group.com.bukovinafilip.CodexMeter entitlement in Xcode."
-
-    /// `false` when the App Group container is missing (unsigned / misconfigured builds).
-    public nonisolated let isAvailable: Bool
 
     private let fileURL: URL?
     private let fileManager: FileManager
@@ -20,22 +15,19 @@ public actor WidgetSnapshotCache {
         fileManager: FileManager = .default
     ) {
         self.fileManager = fileManager
-        let resolved = fileManager
+        self.fileURL = fileManager
             .containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)?
             .appendingPathComponent(SharedWidgetSnapshot.defaultFileName)
-        self.fileURL = resolved
-        self.isAvailable = resolved != nil
     }
 
     public init(fileURL: URL, fileManager: FileManager = .default) {
         self.fileManager = fileManager
         self.fileURL = fileURL
-        self.isAvailable = true
     }
 
     public func save(_ snapshot: SharedWidgetSnapshot) async throws {
         guard let fileURL else {
-            throw CodexServiceError.storage(Self.unavailableMessage)
+            throw CodexServiceError.storage("The App Group container is unavailable.")
         }
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -62,21 +54,20 @@ public actor WidgetSnapshotCache {
             planType: usage?.planType ?? "",
             fiveHour: usage?.fiveHour,
             weekly: usage?.weekly,
+            monthly: usage?.monthly,
             resetCreditsAvailable: credits?.availableCount ?? usage?.resetCreditsAvailable,
             freshness: freshness
         )
         try await save(snapshot)
+        DiagnosticLog.info("widgets", "snapshot_published", details: [
+            "mode": mode.rawValue,
+            "freshness": freshness.rawValue,
+            "monthly": usage?.monthly != nil ? "true" : "false"
+        ])
     }
 
     public func publishSignedOut() async throws {
-        do {
-            try await save(.signedOut)
-        } catch {
-            // Never leave an authenticated-looking snapshot behind if the
-            // signed-out write fails (disk/App Group issues, etc.).
-            try? await clear()
-            throw error
-        }
+        try await save(.signedOut)
     }
 
     public func load() async throws -> SharedWidgetSnapshot? {

--- a/ios/CodexMeter/Localizable.xcstrings
+++ b/ios/CodexMeter/Localizable.xcstrings
@@ -10,9 +10,6 @@
     "%lld minutes" : {
 
     },
-    "%lld percent remaining" : {
-
-    },
     "%lld reset %@ available" : {
       "localizations" : {
         "en" : {
@@ -24,6 +21,9 @@
       }
     },
     "%lld%% or lower" : {
+
+    },
+    "%lld%% used" : {
 
     },
     "2 hours" : {
@@ -41,13 +41,16 @@
     "Account" : {
 
     },
+    "After signing in on the OpenAI page, return here. This screen updates automatically." : {
+
+    },
     "Allow notifications" : {
 
     },
     "Always" : {
 
     },
-    "An unofficial native client for viewing Codex allowance and earned reset credits." : {
+    "An unofficial native iPhone and iPad client for checking and monitoring Codex usage." : {
 
     },
     "Appearance" : {
@@ -68,6 +71,9 @@
     "Close" : {
 
     },
+    "Code copied" : {
+
+    },
     "Codex Meter" : {
 
     },
@@ -83,10 +89,16 @@
     "Codex reset" : {
 
     },
+    "Codex usage is not currently available for this account." : {
+
+    },
     "Connect account" : {
 
     },
     "Connect your ChatGPT account to see the current five-hour and weekly windows, reset times, and earned reset credits." : {
+
+    },
+    "Copied" : {
 
     },
     "Copy code" : {
@@ -96,9 +108,6 @@
 
     },
     "Credentials and cached account data will be removed from this device and its widgets." : {
-
-    },
-    "Demo data — no OpenAI requests" : {
 
     },
     "Demo mode" : {
@@ -116,7 +125,13 @@
     "Enter this one-time code" : {
 
     },
+    "Expiry details are unavailable for the current inventory." : {
+
+    },
     "Expiry details are unavailable; OpenAI will choose an eligible credit." : {
+
+    },
+    "Expiry reminders fire at each selected lead time before an available credit expires. Choose at least one lead time." : {
 
     },
     "Explore demo" : {
@@ -128,7 +143,13 @@
     "Important" : {
 
     },
+    "Includes low usage, scheduled resets, optional surprise refills, and reset-credit inventory changes." : {
+
+    },
     "iOS decides when background work runs. This interval is an earliest preference, not a guaranteed schedule." : {
+
+    },
+    "iOS development — Filip Bukovina" : {
 
     },
     "Last updated July 12, 2026" : {
@@ -138,9 +159,6 @@
 
     },
     "License" : {
-
-    },
-    "Local data and privacy" : {
 
     },
     "Local storage" : {
@@ -153,6 +171,12 @@
 
     },
     "Mode" : {
+
+    },
+    "New reset-credit alerts" : {
+
+    },
+    "Next credit expires %@" : {
 
     },
     "Next credit expires %@ (%@)." : {
@@ -177,9 +201,6 @@
     "OAuth tokens are stored in Apple Keychain on this device. Widgets never receive tokens or account identifiers." : {
 
     },
-    "OAuth tokens stay in Apple Keychain. Requests go directly to OpenAI for authentication and Codex account data. Widgets receive only a sanitized usage snapshot." : {
-
-    },
     "One-time code %@" : {
 
     },
@@ -201,7 +222,13 @@
     "Plan" : {
 
     },
+    "Plan %@" : {
+
+    },
     "Preferred interval" : {
+
+    },
+    "Preparing secure sign-in…" : {
 
     },
     "Privacy" : {
@@ -225,6 +252,12 @@
     "Reset available" : {
 
     },
+    "Reset time unavailable" : {
+
+    },
+    "Reset-credit expiry reminders" : {
+
+    },
     "Resets available" : {
 
     },
@@ -235,6 +268,9 @@
 
     },
     "Settings" : {
+
+    },
+    "Sign in or open demo mode to configure usage alerts." : {
 
     },
     "Sign in with ChatGPT" : {
@@ -258,7 +294,13 @@
     "This action consumes one available reset credit and cannot be undone." : {
 
     },
-    "Unavailable" : {
+    "Tokens stay in Keychain. Requests go directly to OpenAI; widgets only get a sanitized usage snapshot." : {
+
+    },
+    "Unexpected refill alerts" : {
+
+    },
+    "Usage limit reached for the current window." : {
 
     },
     "Use 1 reset" : {

--- a/ios/CodexMeter/Services/DemoCodexService.swift
+++ b/ios/CodexMeter/Services/DemoCodexService.swift
@@ -63,15 +63,8 @@ public actor DemoCodexService: CodexService {
         weeklyUsed = 64
         availableCredits = 2
         try? await appCache.clear()
-        do {
-            try await widgetCache.publishSignedOut()
-            WidgetCenter.shared.reloadAllTimelines()
-            await appCache.clearWidgetError(at: referenceDate)
-        } catch {
-            // publishSignedOut already best-effort clears any prior snapshot.
-            WidgetCenter.shared.reloadAllTimelines()
-            await appCache.recordWidgetError(error.localizedDescription, at: referenceDate)
-        }
+        try? await widgetCache.publishSignedOut()
+        WidgetCenter.shared.reloadAllTimelines()
     }
 
     private func persistCurrentState() async throws -> CodexRefreshSnapshot {
@@ -119,18 +112,13 @@ public actor DemoCodexService: CodexService {
         try await appCache.save(
             AppCacheSnapshot(usage: usage, credits: credits, updatedAt: fetchedAt)
         )
-        do {
-            try await widgetCache.publish(
-                mode: .demo,
-                usage: usage,
-                credits: credits,
-                now: fetchedAt
-            )
-            WidgetCenter.shared.reloadAllTimelines()
-            await appCache.clearWidgetError(at: fetchedAt)
-        } catch {
-            await appCache.recordWidgetError(error.localizedDescription, at: fetchedAt)
-        }
+        try? await widgetCache.publish(
+            mode: .demo,
+            usage: usage,
+            credits: credits,
+            now: fetchedAt
+        )
+        WidgetCenter.shared.reloadAllTimelines()
         return (usage, credits)
     }
 

--- a/ios/CodexMeter/Services/HTTPClientSupport.swift
+++ b/ios/CodexMeter/Services/HTTPClientSupport.swift
@@ -18,7 +18,7 @@ nonisolated enum HTTPClientSupport {
         configuration.httpShouldSetCookies = true
         configuration.httpAdditionalHeaders = [
             "Accept": "application/json",
-            "User-Agent": "codex-meter-ios/1.0"
+            "User-Agent": "codex-meter-ios/2.8.0"
         ]
         return URLSession(configuration: configuration)
     }

--- a/ios/CodexMeter/Services/LiveCodexService.swift
+++ b/ios/CodexMeter/Services/LiveCodexService.swift
@@ -293,6 +293,7 @@ public actor LiveCodexService: CodexService {
             limitReached: parsed.limitReached,
             fiveHour: resolvingResetDate(in: parsed.fiveHour, relativeTo: fetchedAt),
             weekly: resolvingResetDate(in: parsed.weekly, relativeTo: fetchedAt),
+            monthly: resolvingResetDate(in: parsed.monthly, relativeTo: fetchedAt),
             resetCreditsAvailable: parsed.resetCreditsAvailable,
             additionalLimits: parsed.additionalLimits.map {
                 UsageLimit(
@@ -334,6 +335,7 @@ public actor LiveCodexService: CodexService {
             limitReached: usage.limitReached,
             fiveHour: usage.fiveHour,
             weekly: usage.weekly,
+            monthly: usage.monthly,
             resetCreditsAvailable: count,
             additionalLimits: usage.additionalLimits,
             usageCredits: usage.usageCredits,

--- a/ios/CodexMeter/Services/LiveCodexService.swift
+++ b/ios/CodexMeter/Services/LiveCodexService.swift
@@ -80,11 +80,13 @@ public actor LiveCodexService: CodexService {
         do {
             let usage = try await fetchUsage()
             let cached = try await appCache.updateUsage(usage, at: now())
-            await publishWidgets(
+            try? await widgetCache.publish(
                 mode: .live,
                 usage: usage,
-                credits: cached.credits
+                credits: cached.credits,
+                now: now()
             )
+            WidgetCenter.shared.reloadAllTimelines()
             return usage
         } catch {
             await appCache.recordUsageError(error.localizedDescription, at: now())
@@ -99,11 +101,13 @@ public actor LiveCodexService: CodexService {
         do {
             let credits = try await fetchCredits()
             let cached = try await appCache.updateCredits(credits, at: now())
-            await publishWidgets(
+            try? await widgetCache.publish(
                 mode: .live,
                 usage: cached.usage,
-                credits: credits
+                credits: credits,
+                now: now()
             )
+            WidgetCenter.shared.reloadAllTimelines()
             return credits
         } catch {
             await appCache.recordCreditsError(error.localizedDescription, at: now())
@@ -127,11 +131,13 @@ public actor LiveCodexService: CodexService {
             do {
                 let refreshed = try await fetchCredits()
                 let updated = try await appCache.updateCredits(refreshed, at: now())
-                await publishWidgets(
+                try? await widgetCache.publish(
                     mode: .live,
                     usage: updated.usage,
-                    credits: refreshed
+                    credits: refreshed,
+                    now: now()
                 )
+                WidgetCenter.shared.reloadAllTimelines()
                 credits = refreshed
             } catch {
                 await appCache.recordCreditsError(error.localizedDescription, at: now())
@@ -184,10 +190,11 @@ public actor LiveCodexService: CodexService {
             let refreshed = try await fetchCredits()
             _ = try await appCache.updateCredits(refreshed, at: now())
             let cached = try? await appCache.load()
-            await publishWidgets(
+            try? await widgetCache.publish(
                 mode: .live,
                 usage: cached?.usage,
-                credits: refreshed
+                credits: refreshed,
+                now: now()
             )
         } catch {
             await appCache.recordCreditsError(error.localizedDescription, at: now())
@@ -209,22 +216,24 @@ public actor LiveCodexService: CodexService {
         activeRefresh = nil
         await authSession.signOut()
         try? await appCache.clear()
-        await publishSignedOutWidgets()
+        try? await widgetCache.publishSignedOut()
 
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.removeAllPendingNotificationRequests()
         notificationCenter.removeAllDeliveredNotifications()
         BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: "com.bukovinafilip.CodexMeter.refresh")
+        WidgetCenter.shared.reloadAllTimelines()
     }
 
     private func performRefresh() async throws -> CodexRefreshSnapshot {
         do {
             let usage = try await fetchUsage()
             let cachedAfterUsage = try await appCache.updateUsage(usage, at: now())
-            await publishWidgets(
+            try? await widgetCache.publish(
                 mode: .live,
                 usage: usage,
-                credits: cachedAfterUsage.credits
+                credits: cachedAfterUsage.credits,
+                now: now()
             )
 
             do {
@@ -237,11 +246,13 @@ public actor LiveCodexService: CodexService {
                 combined.resetCreditsError = nil
                 combined.updatedAt = now()
                 try await appCache.save(combined)
-                await publishWidgets(
+                try? await widgetCache.publish(
                     mode: .live,
                     usage: enrichedUsage,
-                    credits: credits
+                    credits: credits,
+                    now: now()
                 )
+                WidgetCenter.shared.reloadAllTimelines()
                 return (enrichedUsage, credits)
             } catch {
                 await appCache.recordCreditsError(error.localizedDescription, at: now())
@@ -256,11 +267,13 @@ public actor LiveCodexService: CodexService {
                 retained.lastError = nil
                 retained.updatedAt = now()
                 try await appCache.save(retained)
-                await publishWidgets(
+                try? await widgetCache.publish(
                     mode: .live,
                     usage: enrichedUsage,
-                    credits: fallbackCredits
+                    credits: fallbackCredits,
+                    now: now()
                 )
+                WidgetCenter.shared.reloadAllTimelines()
                 return (enrichedUsage, fallbackCredits)
             }
         } catch {
@@ -372,7 +385,7 @@ public actor LiveCodexService: CodexService {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("Bearer \(tokens.accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue(backend.originator, forHTTPHeaderField: "originator")
-        request.setValue("codex-meter-ios/1.0", forHTTPHeaderField: "User-Agent")
+        request.setValue("codex-meter-ios/2.8.0", forHTTPHeaderField: "User-Agent")
         if !tokens.accountID.isEmpty {
             request.setValue(tokens.accountID, forHTTPHeaderField: "ChatGPT-Account-Id")
         }
@@ -393,36 +406,5 @@ public actor LiveCodexService: CodexService {
             fallback = "\(operation) (HTTP \(payload.statusCode))."
         }
         return try HTTPClientSupport.requireSuccess(payload, fallback: fallback)
-    }
-
-    private func publishWidgets(
-        mode: WidgetSnapshotMode,
-        usage: UsageSnapshot?,
-        credits: ResetCreditsSnapshot?
-    ) async {
-        do {
-            try await widgetCache.publish(
-                mode: mode,
-                usage: usage,
-                credits: credits,
-                now: now()
-            )
-            WidgetCenter.shared.reloadAllTimelines()
-            await appCache.clearWidgetError(at: now())
-        } catch {
-            await appCache.recordWidgetError(error.localizedDescription, at: now())
-        }
-    }
-
-    private func publishSignedOutWidgets() async {
-        do {
-            try await widgetCache.publishSignedOut()
-            WidgetCenter.shared.reloadAllTimelines()
-            await appCache.clearWidgetError(at: now())
-        } catch {
-            // publishSignedOut already best-effort clears any prior snapshot.
-            WidgetCenter.shared.reloadAllTimelines()
-            await appCache.recordWidgetError(error.localizedDescription, at: now())
-        }
     }
 }

--- a/ios/CodexMeter/Views/AboutView.swift
+++ b/ios/CodexMeter/Views/AboutView.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 
 struct AboutView: View {
+    @Environment(AppModel.self) private var model
+    @State private var versionTaps = 0
+    @State private var unlockHint: String?
+    @State private var showingDiagnostics = false
+
+    private static let diagnosticTaps = 7
+
     private var version: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
     }
@@ -18,18 +25,28 @@ struct AboutView: View {
                         .font(.title2.bold())
                     Text("Version \(version)")
                         .foregroundStyle(.secondary)
-                    Text("An unofficial native client for viewing Codex allowance and earned reset credits.")
+                    Text("An unofficial native iPhone and iPad client for checking and monitoring Codex usage.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
+                    if let unlockHint {
+                        Text(unlockHint)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 18)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: handleVersionTap)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityHint("Tap repeatedly to unlock diagnostics.")
             }
 
             Section("Source and credits") {
                 Link("BenItBuhner/Codex-Meter", destination: URL(string: "https://github.com/BenItBuhner/Codex-Meter")!)
                 LabeledContent("Original project", value: "Bennett")
+                Link("iOS development — Filip Bukovina", destination: URL(string: "https://github.com/FBukovina")!)
                 LabeledContent("License", value: "MIT")
                 NavigationLink("Open-source notices") {
                     OpenSourceNoticesView()
@@ -44,6 +61,24 @@ struct AboutView: View {
             }
         }
         .navigationTitle("About")
+        .navigationDestination(isPresented: $showingDiagnostics) {
+            DiagnosticsView()
+        }
+    }
+
+    private func handleVersionTap() {
+        versionTaps += 1
+        let remaining = Self.diagnosticTaps - versionTaps
+        if remaining <= 0 {
+            unlockHint = "Diagnostics unlocked."
+            model.unlockDiagnostics()
+            showingDiagnostics = true
+            versionTaps = 0
+        } else if remaining <= 3 {
+            unlockHint = remaining == 1
+                ? "1 more tap for diagnostics."
+                : "\(remaining) more taps for diagnostics."
+        }
     }
 }
 
@@ -85,11 +120,12 @@ struct PrivacyPolicyView: View {
                 Text("OAuth tokens are stored in Apple Keychain on this device. Widgets never receive tokens or account identifiers.")
                 Text("Local storage")
                     .font(.title3.bold())
-                Text("The last successful usage response is cached for offline display. Signing out removes credentials, cached account data, background requests, and scheduled notifications.")
+                Text("The last successful usage response and bounded allowance samples are stored locally for offline display, burn charts, and pace estimates. You can clear history separately; signing out removes credentials, cached account data, history, background requests, and scheduled notifications.")
+                Text("Settings exports contain preferences and dashboard choices, never credentials or usage samples.")
                 Text("Demo mode")
                     .font(.title3.bold())
                 Text("Demo mode is entirely local and does not contact OpenAI.")
-                Text("Last updated July 12, 2026")
+                Text("Last updated August 14, 2026")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }

--- a/ios/CodexMeter/Views/DashboardEditView.swift
+++ b/ios/CodexMeter/Views/DashboardEditView.swift
@@ -1,0 +1,137 @@
+import CodexMeterCore
+import SwiftUI
+
+struct DashboardEditView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+    @State private var items: [DashboardEditItem] = []
+    @State private var editMode: EditMode = .active
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(items) { item in
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(item.title)
+                                .foregroundStyle(
+                                    model.settings.isDashboardSectionVisible(item.key)
+                                        ? .primary : .secondary
+                                )
+                            Text(item.summary)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 8)
+                        Toggle(
+                            "Show \(item.title)",
+                            isOn: visibilityBinding(for: item.key)
+                        )
+                        .labelsHidden()
+                    }
+                    .accessibilityElement(children: .contain)
+                }
+                .onMove(perform: move)
+            } header: {
+                Text("Dashboard cards")
+            } footer: {
+                Text("Drag the handles to arrange cards and use the switches to hide cards you do not need. Model-specific limits appear automatically when OpenAI reports them.")
+            }
+
+            Section {
+                Label(
+                    "Changes save immediately. Usage-credit and reset-credit cards still hide automatically when their inventory is empty or unknown. Usage history stays off the dashboard until OpenAI reports a usage window.",
+                    systemImage: "info.circle"
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .environment(\.editMode, $editMode)
+        .navigationTitle("Edit dashboard")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+        .task {
+            rebuildItems()
+        }
+    }
+
+    private func visibilityBinding(for key: String) -> Binding<Bool> {
+        Binding(
+            get: { model.settings.isDashboardSectionVisible(key) },
+            set: { visible in
+                var settings = model.settings
+                settings.setDashboardSectionVisible(key, visible: visible)
+                model.save(settings: settings)
+            }
+        )
+    }
+
+    private func move(from source: IndexSet, to destination: Int) {
+        items.move(fromOffsets: source, toOffset: destination)
+        var settings = model.settings
+        settings.setDashboardOrder(items.map(\.key))
+        model.save(settings: settings)
+    }
+
+    private func rebuildItems() {
+        let limits = model.usage?.additionalLimits ?? []
+        var availableItems: [String: DashboardEditItem] = [
+            DashboardSections.fiveHour: DashboardEditItem(
+                key: DashboardSections.fiveHour,
+                title: "5-hour limit",
+                summary: "Rolling 5-hour Codex window"
+            ),
+            DashboardSections.weekly: DashboardEditItem(
+                key: DashboardSections.weekly,
+                title: "Weekly limit",
+                summary: "Rolling 7-day Codex window"
+            ),
+            DashboardSections.monthly: DashboardEditItem(
+                key: DashboardSections.monthly,
+                title: "Monthly limit",
+                summary: "Free-tier ~30-day Codex window"
+            ),
+            DashboardSections.usageCredits: DashboardEditItem(
+                key: DashboardSections.usageCredits,
+                title: "Usage-credit balance",
+                summary: "Hidden automatically at a zero or negative balance"
+            ),
+            DashboardSections.usageHistory: DashboardEditItem(
+                key: DashboardSections.usageHistory,
+                title: "Usage history",
+                summary: "Local burn charts for your usage windows"
+            ),
+            DashboardSections.resetCredits: DashboardEditItem(
+                key: DashboardSections.resetCredits,
+                title: "Reset credits",
+                summary: "Hidden automatically when none are available"
+            )
+        ]
+        for limit in limits {
+            let key = DashboardSections.limitKey(limit)
+            availableItems[key] = DashboardEditItem(
+                key: key,
+                title: limit.displayName,
+                summary: "Model-specific limit · detected automatically"
+            )
+        }
+        let defaults = DashboardSections.defaultOrder(additionalLimits: limits)
+        items = DashboardSections.resolveOrder(
+            saved: model.settings.dashboardOrder,
+            available: defaults
+        ).compactMap { availableItems[$0] }
+    }
+}
+
+private struct DashboardEditItem: Identifiable {
+    let key: String
+    let title: String
+    let summary: String
+
+    var id: String { key }
+}

--- a/ios/CodexMeter/Views/DashboardSectionsView.swift
+++ b/ios/CodexMeter/Views/DashboardSectionsView.swift
@@ -1,0 +1,375 @@
+import CodexMeterCore
+import SwiftUI
+
+struct DashboardSectionsView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    private var sections: [DashboardSectionItem] {
+        var available: [String: DashboardSectionItem] = [:]
+        let usage = model.usage
+
+        if model.settings.showFiveHour, let window = usage?.fiveHour {
+            available[DashboardSections.fiveHour] = DashboardSectionItem(
+                key: DashboardSections.fiveHour,
+                kind: .meter(
+                    title: "5-hour",
+                    systemImage: "clock",
+                    window: window,
+                    accent: .mint
+                )
+            )
+        }
+        if model.settings.showWeekly, let window = usage?.weekly {
+            available[DashboardSections.weekly] = DashboardSectionItem(
+                key: DashboardSections.weekly,
+                kind: .meter(
+                    title: "Weekly",
+                    systemImage: "calendar",
+                    window: window,
+                    accent: .indigo
+                )
+            )
+        }
+        if model.settings.showMonthly, let window = usage?.monthly {
+            available[DashboardSections.monthly] = DashboardSectionItem(
+                key: DashboardSections.monthly,
+                kind: .meter(
+                    title: "Monthly",
+                    systemImage: "calendar.badge.clock",
+                    window: window,
+                    accent: .orange
+                )
+            )
+        }
+        if model.settings.showAdditionalLimits {
+            for limit in usage?.additionalLimits ?? [] {
+                let key = DashboardSections.limitKey(limit)
+                guard !model.settings.dashboardHiddenSections.contains(key),
+                      limit.primary != nil || limit.secondary != nil else {
+                    continue
+                }
+                available[key] = DashboardSectionItem(key: key, kind: .additional(limit))
+            }
+        }
+        if model.settings.showUsageCredits,
+           let credits = usage?.usageCredits,
+           credits.shouldDisplay {
+            available[DashboardSections.usageCredits] = DashboardSectionItem(
+                key: DashboardSections.usageCredits,
+                kind: .usageCredits(credits)
+            )
+        }
+        if model.settings.showUsageHistory,
+           usage?.fiveHour != nil || usage?.weekly != nil || usage?.monthly != nil {
+            available[DashboardSections.usageHistory] = DashboardSectionItem(
+                key: DashboardSections.usageHistory,
+                kind: .usageHistory
+            )
+        }
+        let resetCount = model.credits?.availableCount ?? usage?.resetCreditsAvailable ?? 0
+        if model.settings.showResetCredits, resetCount > 0 {
+            available[DashboardSections.resetCredits] = DashboardSectionItem(
+                key: DashboardSections.resetCredits,
+                kind: .resetCredits
+            )
+        }
+
+        let defaultOrder = DashboardSections.defaultOrder(
+            additionalLimits: usage?.additionalLimits ?? []
+        )
+        let availableKeys = defaultOrder.filter { available[$0] != nil }
+        return DashboardSections.resolveOrder(
+            saved: model.settings.dashboardOrder,
+            available: availableKeys
+        ).compactMap { available[$0] }
+    }
+
+    private var rows: [DashboardSectionRow] {
+        guard horizontalSizeClass == .regular else {
+            return sections.map { DashboardSectionRow(items: [$0]) }
+        }
+        var result: [DashboardSectionRow] = []
+        var index = 0
+        while index < sections.count {
+            let current = sections[index]
+            if current.isSingleMeter,
+               sections.indices.contains(index + 1),
+               sections[index + 1].isSingleMeter {
+                result.append(
+                    DashboardSectionRow(items: [current, sections[index + 1]])
+                )
+                index += 2
+            } else {
+                result.append(DashboardSectionRow(items: [current]))
+                index += 1
+            }
+        }
+        return result
+    }
+
+    var body: some View {
+        if rows.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Label("No dashboard items are available", systemImage: "rectangle.slash")
+                    .font(.headline)
+                Text("Refresh usage or choose cards in Edit dashboard.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                NavigationLink("Edit dashboard") {
+                    DashboardEditView()
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(AppChrome.cardPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .cardSurface()
+        } else {
+            LazyVStack(spacing: AppChrome.sectionSpacing) {
+                ForEach(rows) { row in
+                    HStack(alignment: .top, spacing: AppChrome.sectionSpacing) {
+                        ForEach(row.items) { section in
+                            sectionView(section)
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func sectionView(_ section: DashboardSectionItem) -> some View {
+        switch section.kind {
+        case let .meter(title, systemImage, window, accent):
+            UsageMeterCard(
+                title: LocalizedStringKey(title),
+                systemImage: systemImage,
+                window: window,
+                accent: accent,
+                fetchedAt: model.usage?.fetchedAt ?? .now
+            )
+        case let .additional(limit):
+            AdditionalLimitCards(
+                limit: limit,
+                fetchedAt: model.usage?.fetchedAt ?? .now
+            )
+        case let .usageCredits(credits):
+            UsageCreditsCard(credits: credits)
+        case .usageHistory:
+            UsageHistoryDashboardCard()
+        case .resetCredits:
+            ResetCreditsDashboardCard()
+        }
+    }
+}
+
+private struct DashboardSectionRow: Identifiable {
+    let items: [DashboardSectionItem]
+
+    var id: String {
+        items.map(\.key).joined(separator: "|")
+    }
+}
+
+private struct DashboardSectionItem: Identifiable {
+    enum Kind {
+        case meter(title: String, systemImage: String, window: UsageWindow, accent: Color)
+        case additional(UsageLimit)
+        case usageCredits(UsageCredits)
+        case usageHistory
+        case resetCredits
+    }
+
+    let key: String
+    let kind: Kind
+
+    var id: String { key }
+
+    var isSingleMeter: Bool {
+        if case .meter = kind {
+            return true
+        }
+        return false
+    }
+}
+
+private struct AdditionalLimitCards: View {
+    let limit: UsageLimit
+    let fetchedAt: Date
+
+    var body: some View {
+        VStack(spacing: AppChrome.sectionSpacing) {
+            if let primary = limit.primary {
+                card(for: primary, accent: .teal)
+            }
+            if let secondary = limit.secondary {
+                card(for: secondary, accent: .purple)
+            }
+        }
+    }
+
+    private func card(for window: UsageWindow, accent: Color) -> some View {
+        UsageMeterCard(
+            title: LocalizedStringKey(
+                "\(Self.limitTitle(limit)) · \(Self.cadenceLabel(window))"
+            ),
+            systemImage: window.windowSeconds >= 86_400
+                ? "calendar.badge.clock" : "clock.badge",
+            window: window,
+            accent: accent,
+            fetchedAt: fetchedAt
+        )
+    }
+
+    private static func cadenceLabel(_ window: UsageWindow) -> String {
+        let seconds = window.windowSeconds
+        if (432_000 ... 777_600).contains(seconds) {
+            return "Weekly"
+        }
+        if (864_000 ... 3_888_000).contains(seconds) {
+            return "Monthly"
+        }
+        if (10_800 ... 28_800).contains(seconds) {
+            return "\(max(1, Int((Double(seconds) / 3_600).rounded())))-hour"
+        }
+        if seconds.isMultiple(of: 86_400) {
+            return "\(seconds / 86_400)-day"
+        }
+        if seconds.isMultiple(of: 3_600) {
+            return "\(seconds / 3_600)-hour"
+        }
+        return "Usage"
+    }
+
+    private static func limitTitle(_ limit: UsageLimit) -> String {
+        if limit.limitReached {
+            return "\(limit.displayName) (limit reached)"
+        }
+        if !limit.allowed {
+            return "\(limit.displayName) (unavailable)"
+        }
+        return limit.displayName
+    }
+}
+
+private struct UsageCreditsCard: View {
+    let credits: UsageCredits
+
+    private var balance: String {
+        if credits.unlimited {
+            return "Unlimited"
+        }
+        guard let raw = credits.balance else {
+            return credits.hasCredits ? "Credits available" : "No purchased credits"
+        }
+        if let number = Double(raw.replacingOccurrences(of: ",", with: "")),
+           number.isFinite {
+            return number.formatted(
+                .number.precision(.fractionLength(0 ... 2))
+            ) + " credits"
+        }
+        return raw
+    }
+
+    private var summary: String {
+        if credits.unlimited {
+            return "Usage-credit balance is not capped"
+        }
+        return "Purchased Codex usage-credit balance"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Usage credits")
+                .font(.headline.bold())
+
+            HStack(spacing: 16) {
+                Image(systemName: "creditcard.fill")
+                    .font(.system(size: 30))
+                    .foregroundStyle(.tint)
+                    .symbolRenderingMode(.hierarchical)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(balance)
+                        .font(.title3.bold())
+                        .contentTransition(.numericText())
+                    Text(summary)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(AppChrome.cardPadding)
+        .frame(maxWidth: .infinity, minHeight: 138, alignment: .leading)
+        .cardSurface()
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct ResetCreditsDashboardCard: View {
+    @Environment(AppModel.self) private var model
+
+    private var count: Int {
+        model.credits?.availableCount ?? model.usage?.resetCreditsAvailable ?? 0
+    }
+
+    private var nextExpiry: Date? {
+        model.credits?.credits
+            .filter(\.isAvailable)
+            .compactMap(\.expiresAt)
+            .filter { $0 > .now }
+            .min()
+    }
+
+    private var summary: String {
+        if nextExpiry != nil {
+            return "Next credit expiry"
+        }
+        if count > 0 {
+            return "Expiration details unavailable"
+        }
+        return "Earn credits from ChatGPT Codex"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Reset credits")
+                .font(.headline.bold())
+
+            HStack(spacing: 16) {
+                Image(systemName: "arrow.counterclockwise.circle.fill")
+                    .font(.system(size: 30))
+                    .foregroundStyle(.tint)
+                    .symbolRenderingMode(.hierarchical)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(count == 1 ? "1 reset available" : "\(count) resets available")
+                        .font(.title3.bold())
+                        .contentTransition(.numericText())
+                    if let nextExpiry {
+                        Text("Next expires \(nextExpiry, style: .relative)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(summary)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+
+            Button(count > 0 ? "Use 1 reset" : "No resets available") {
+                model.isShowingReset = true
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .frame(maxWidth: .infinity)
+            .disabled(count == 0)
+        }
+        .padding(AppChrome.cardPadding)
+        .cardSurface()
+    }
+}

--- a/ios/CodexMeter/Views/DashboardView.swift
+++ b/ios/CodexMeter/Views/DashboardView.swift
@@ -5,57 +5,6 @@ struct DashboardView: View {
     @Environment(AppModel.self) private var model
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    private var columns: [GridItem] {
-        horizontalSizeClass == .regular
-            ? [GridItem(.flexible(), spacing: AppChrome.sectionSpacing), GridItem(.flexible(), spacing: AppChrome.sectionSpacing)]
-            : [GridItem(.flexible())]
-    }
-
-    private var additionalWindows: [AdditionalWindowPresentation] {
-        guard model.settings.showAdditionalLimits else { return [] }
-        return (model.usage?.additionalLimits ?? []).flatMap { limit in
-            var windows: [AdditionalWindowPresentation] = []
-            if let primary = limit.primary {
-                windows.append(
-                    AdditionalWindowPresentation(
-                        id: "\(limit.id)-primary",
-                        title: "\(Self.limitTitle(limit)) · \(Self.cadenceLabel(primary))",
-                        window: primary,
-                        accent: .teal
-                    )
-                )
-            }
-            if let secondary = limit.secondary {
-                windows.append(
-                    AdditionalWindowPresentation(
-                        id: "\(limit.id)-secondary",
-                        title: "\(Self.limitTitle(limit)) · \(Self.cadenceLabel(secondary))",
-                        window: secondary,
-                        accent: .purple
-                    )
-                )
-            }
-            return windows
-        }
-    }
-
-    private var hasVisibleUsageWindows: Bool {
-        (model.settings.showFiveHour && model.usage?.fiveHour != nil)
-            || (model.settings.showWeekly && model.usage?.weekly != nil)
-            || !additionalWindows.isEmpty
-    }
-
-    /// Prefer the detailed credits snapshot; fall back to the usage-endpoint summary count.
-    private var shouldShowResetCredits: Bool {
-        if let credits = model.credits {
-            return credits.shouldDisplay
-        }
-        guard let count = model.usage?.resetCreditsAvailable else {
-            return false
-        }
-        return count > 0
-    }
-
     var body: some View {
         ScrollView {
             LazyVStack(spacing: AppChrome.sectionSpacing) {
@@ -86,49 +35,7 @@ struct DashboardView: View {
                         )
                     }
 
-                    if hasVisibleUsageWindows {
-                        LazyVGrid(columns: columns, spacing: AppChrome.sectionSpacing) {
-                            if model.settings.showFiveHour,
-                               let window = model.usage?.fiveHour {
-                                UsageMeterCard(
-                                    title: "5-hour",
-                                    systemImage: "clock",
-                                    window: window,
-                                    accent: .mint,
-                                    fetchedAt: model.usage?.fetchedAt ?? .now
-                                )
-                            }
-                            if model.settings.showWeekly,
-                               let window = model.usage?.weekly {
-                                UsageMeterCard(
-                                    title: "Weekly",
-                                    systemImage: "calendar",
-                                    window: window,
-                                    accent: .indigo,
-                                    fetchedAt: model.usage?.fetchedAt ?? .now
-                                )
-                            }
-                            ForEach(additionalWindows) { item in
-                                UsageMeterCard(
-                                    title: LocalizedStringKey(item.title),
-                                    systemImage: item.window.windowSeconds >= 86_400
-                                        ? "calendar.badge.clock" : "clock.badge",
-                                    window: item.window,
-                                    accent: item.accent,
-                                    fetchedAt: model.usage?.fetchedAt ?? .now
-                                )
-                            }
-                        }
-                    }
-
-                    if model.settings.showUsageCredits,
-                       let usageCredits = model.usage?.usageCredits,
-                       usageCredits.shouldDisplay {
-                        UsageCreditsCard(credits: usageCredits)
-                    }
-                    if model.settings.showResetCredits, shouldShowResetCredits {
-                        ResetCreditsCard()
-                    }
+                    DashboardSectionsView()
                     PrivacyFootnote()
                 }
             }
@@ -141,6 +48,12 @@ struct DashboardView: View {
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 if model.mode != .signedOut {
+                    NavigationLink {
+                        DashboardEditView()
+                    } label: {
+                        Label("Edit dashboard", systemImage: "slider.horizontal.3")
+                    }
+
                     Button {
                         Task { await model.refresh() }
                     } label: {
@@ -169,40 +82,6 @@ struct DashboardView: View {
             await model.startIfNeeded()
         }
     }
-
-    private static func cadenceLabel(_ window: UsageWindow) -> String {
-        let seconds = window.windowSeconds
-        if (432_000 ... 777_600).contains(seconds) {
-            return "Weekly"
-        }
-        if (10_800 ... 28_800).contains(seconds) {
-            return "\(max(1, Int((Double(seconds) / 3_600).rounded())))-hour"
-        }
-        if seconds.isMultiple(of: 86_400) {
-            return "\(seconds / 86_400)-day"
-        }
-        if seconds.isMultiple(of: 3_600) {
-            return "\(seconds / 3_600)-hour"
-        }
-        return "Usage"
-    }
-
-    private static func limitTitle(_ limit: UsageLimit) -> String {
-        if limit.limitReached {
-            return "\(limit.displayName) (limit reached)"
-        }
-        if !limit.allowed {
-            return "\(limit.displayName) (unavailable)"
-        }
-        return limit.displayName
-    }
-}
-
-private struct AdditionalWindowPresentation: Identifiable {
-    let id: String
-    let title: String
-    let window: UsageWindow
-    let accent: Color
 }
 
 private struct DashboardStatusStrip: View {
@@ -293,108 +172,6 @@ private struct SignedOutView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(28)
-        .cardSurface()
-    }
-}
-
-private struct UsageCreditsCard: View {
-    let credits: UsageCredits
-
-    private var balance: String {
-        if credits.unlimited {
-            return "Unlimited"
-        }
-        guard let raw = credits.balance else {
-            return credits.hasCredits ? "Available" : "No purchased credits"
-        }
-        if let number = Double(raw.replacingOccurrences(of: ",", with: "")),
-           number.isFinite {
-            return number.formatted(
-                .number.precision(.fractionLength(0 ... 2))
-            ) + " credits"
-        }
-        return raw
-    }
-
-    var body: some View {
-        HStack(spacing: 16) {
-            Image(systemName: "creditcard.fill")
-                .font(.system(size: 34))
-                .foregroundStyle(.tint)
-                .symbolRenderingMode(.hierarchical)
-                .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(balance)
-                    .font(.title2.bold())
-                    .contentTransition(.numericText())
-                Text("Usage-credit balance")
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(AppChrome.cardPadding)
-        .cardSurface()
-        .accessibilityElement(children: .combine)
-    }
-}
-
-private struct ResetCreditsCard: View {
-    @Environment(AppModel.self) private var model
-
-    private var count: Int {
-        model.credits?.availableCount ?? model.usage?.resetCreditsAvailable ?? 0
-    }
-
-    private var nextExpiry: Date? {
-        model.credits?.credits
-            .filter(\.isAvailable)
-            .compactMap(\.expiresAt)
-            .filter { $0 > .now }
-            .min()
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 14) {
-                Image(systemName: "arrow.counterclockwise.circle.fill")
-                    .font(.system(size: 34))
-                    .foregroundStyle(.tint)
-                    .symbolRenderingMode(.hierarchical)
-                    .accessibilityHidden(true)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("\(count)")
-                        .font(.largeTitle.bold())
-                        .contentTransition(.numericText())
-                    Text(count == 1 ? "Reset available" : "Resets available")
-                        .font(.headline)
-                }
-                Spacer(minLength: 0)
-            }
-
-            if let nextExpiry {
-                Label {
-                    Text("Next credit expires \(nextExpiry, style: .relative)")
-                } icon: {
-                    Image(systemName: "calendar.badge.clock")
-                }
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            } else if count > 0, model.credits != nil {
-                Text("Expiry details are unavailable for the current inventory.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-
-            Button(count > 0 ? "Use 1 reset" : "No resets available") {
-                model.isShowingReset = true
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .frame(maxWidth: .infinity)
-            .disabled(count == 0)
-        }
-        .padding(AppChrome.cardPadding)
         .cardSurface()
     }
 }

--- a/ios/CodexMeter/Views/DiagnosticsView.swift
+++ b/ios/CodexMeter/Views/DiagnosticsView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import UIKit
+
+struct DiagnosticsView: View {
+    @State private var enabled = DiagnosticLog.isEnabled
+    @State private var stats = DiagnosticLog.stats()
+    @State private var exportURL: URL?
+    @State private var isExporting = false
+    @State private var confirmingClear = false
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("Write diagnostic logs", isOn: $enabled)
+                    .onChange(of: enabled) { _, isOn in
+                        DiagnosticLog.setEnabled(isOn)
+                        refreshStats()
+                    }
+            } footer: {
+                Text("Logs stay on this device as sanitized JSONL. Credentials, emails, JWTs, and OAuth query parameters are redacted. Nothing is uploaded.")
+            }
+
+            Section("Stored logs") {
+                LabeledContent("Size", value: DiagnosticLog.formatBytes(stats.bytes))
+                LabeledContent("Files", value: "\(stats.files)")
+                Button("Export logs") {
+                    exportLogs()
+                }
+                .disabled(!stats.hasLogs)
+                Button("Clear logs", role: .destructive) {
+                    confirmingClear = true
+                }
+                .disabled(!stats.hasLogs)
+            }
+        }
+        .navigationTitle("Diagnostics")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear(perform: refreshStats)
+        .sheet(isPresented: $isExporting) {
+            if let exportURL {
+                ShareSheet(items: [exportURL])
+            }
+        }
+        .confirmationDialog(
+            "Clear diagnostic logs?",
+            isPresented: $confirmingClear,
+            titleVisibility: .visible
+        ) {
+            Button("Clear", role: .destructive) {
+                DiagnosticLog.clear()
+                refreshStats()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This deletes every locally stored diagnostic log file.")
+        }
+    }
+
+    private func refreshStats() {
+        stats = DiagnosticLog.stats()
+    }
+
+    private func exportLogs() {
+        do {
+            exportURL = try DiagnosticLog.exportURL()
+            isExporting = exportURL != nil
+            refreshStats()
+        } catch {
+            exportURL = nil
+        }
+    }
+}
+
+private struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}
+}

--- a/ios/CodexMeter/Views/SettingsView.swift
+++ b/ios/CodexMeter/Views/SettingsView.swift
@@ -1,10 +1,14 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @Environment(AppModel.self) private var model
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
     @State private var confirmingSignOut = false
+    @State private var isExportingSettings = false
+    @State private var isImportingSettings = false
+    @State private var transferMessage: String?
 
     var body: some View {
         @Bindable var model = model
@@ -45,15 +49,22 @@ struct SettingsView: View {
             }
 
             Section {
+                NavigationLink {
+                    DashboardEditView()
+                } label: {
+                    Label("Edit dashboard", systemImage: "slider.horizontal.3")
+                }
                 Toggle("5-hour limit", isOn: $model.settings.showFiveHour)
                 Toggle("Weekly limit", isOn: $model.settings.showWeekly)
-                Toggle("Additional limits", isOn: $model.settings.showAdditionalLimits)
+                Toggle("Monthly limit", isOn: $model.settings.showMonthly)
+                Toggle("Additional model limits", isOn: $model.settings.showAdditionalLimits)
                 Toggle("Usage-credit balance", isOn: $model.settings.showUsageCredits)
+                Toggle("Usage history", isOn: $model.settings.showUsageHistory)
                 Toggle("Reset credits", isOn: $model.settings.showResetCredits)
             } header: {
                 Text("Dashboard")
             } footer: {
-                Text("Enabled items still appear only when OpenAI returns data for them. Usage-credit balance and reset credits also stay hidden when the inventory is zero. Additional limits include temporary model-specific allowances.")
+                Text("Enabled cards still appear only when data is available. Edit dashboard also controls order and individual model-specific limits.")
             }
 
             Section {
@@ -73,7 +84,7 @@ struct SettingsView: View {
                 Text("Refresh")
             } footer: {
                 Text(model.settings.refreshMode == .automatic
-                    ? "Automatic adapts on device to remaining usage, app attention, reset timing, quiet hours, and recent failures. iOS still decides when background work runs."
+                    ? "Automatic adapts on device to remaining usage, reset timing, recent attention, quiet hours, accelerated usage, and failures. iOS still decides when background work runs."
                     : "iOS decides when background work runs. This interval is an earliest preference, not a guaranteed schedule.")
             }
 
@@ -130,6 +141,38 @@ struct SettingsView: View {
             .disabled(model.mode == .signedOut)
 
             Section {
+                NavigationLink {
+                    UsageHistoryView()
+                } label: {
+                    Label("View usage history", systemImage: "chart.xyaxis.line")
+                }
+                Button {
+                    isExportingSettings = true
+                } label: {
+                    Label("Export settings", systemImage: "square.and.arrow.up")
+                }
+                Button {
+                    isImportingSettings = true
+                } label: {
+                    Label("Import settings", systemImage: "square.and.arrow.down")
+                }
+            } header: {
+                Text("Data")
+            } footer: {
+                Text("Usage samples stay on this device. Settings exports include dashboard order, visibility, and hidden model-specific sections, but never credentials or usage data.")
+            }
+
+            if model.diagnosticsUnlocked {
+                Section {
+                    NavigationLink("Diagnostics") {
+                        DiagnosticsView()
+                    }
+                } footer: {
+                    Text("Opt-in tracing writes sanitized JSONL logs on this device. Credentials, emails, JWTs, and OAuth query parameters are redacted.")
+                }
+            }
+
+            Section {
                 NavigationLink("About Codex Meter") {
                     AboutView()
                 }
@@ -165,6 +208,55 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Credentials and cached account data will be removed from this device and its widgets.")
+        }
+        .fileExporter(
+            isPresented: $isExportingSettings,
+            document: SettingsTransferDocument(settings: model.settings),
+            contentType: .json,
+            defaultFilename: "CodexMeter-Settings"
+        ) { result in
+            switch result {
+            case .success:
+                transferMessage = "Settings exported."
+            case let .failure(error):
+                transferMessage = "Settings could not be exported: \(error.localizedDescription)"
+            }
+        }
+        .fileImporter(
+            isPresented: $isImportingSettings,
+            allowedContentTypes: [.json],
+            allowsMultipleSelection: false
+        ) { result in
+            do {
+                let urls = try result.get()
+                guard let url = urls.first else {
+                    throw CocoaError(.fileReadNoSuchFile)
+                }
+                let isScoped = url.startAccessingSecurityScopedResource()
+                defer {
+                    if isScoped {
+                        url.stopAccessingSecurityScopedResource()
+                    }
+                }
+                let imported = try SettingsTransferDocument.decode(
+                    Data(contentsOf: url, options: [.mappedIfSafe, .uncached])
+                )
+                model.save(settings: imported)
+                transferMessage = "Settings imported."
+            } catch {
+                transferMessage = "Settings could not be imported: \(error.localizedDescription)"
+            }
+        }
+        .alert(
+            "Settings transfer",
+            isPresented: Binding(
+                get: { transferMessage != nil },
+                set: { if !$0 { transferMessage = nil } }
+            )
+        ) {
+            Button("OK") { transferMessage = nil }
+        } message: {
+            Text(transferMessage ?? "")
         }
     }
 

--- a/ios/CodexMeter/Views/UsageHistoryView.swift
+++ b/ios/CodexMeter/Views/UsageHistoryView.swift
@@ -1,0 +1,791 @@
+import Charts
+import CodexMeterCore
+import SwiftUI
+
+struct UsageHistoryDashboardCard: View {
+    @Environment(AppModel.self) private var model
+
+    private var hasCharts: Bool {
+        model.usage?.fiveHour != nil || model.usage?.weekly != nil || model.usage?.monthly != nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Usage history")
+                .font(.headline.bold())
+            Text("On-device burn trends improve pace estimates as samples accumulate.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            if let usage = model.usage {
+                if let fiveHour = usage.fiveHour {
+                    UsageBurnChart(
+                        title: "5-hour",
+                        kind: .fiveHour,
+                        window: fiveHour,
+                        history: model.fiveHourHistory,
+                        observedAt: usage.fetchedAt,
+                        compact: true
+                    )
+                }
+                if let weekly = usage.weekly {
+                    UsageBurnChart(
+                        title: "Weekly",
+                        kind: .weekly,
+                        window: weekly,
+                        history: model.weeklyHistory,
+                        observedAt: usage.fetchedAt,
+                        compact: true
+                    )
+                }
+                if let monthly = usage.monthly {
+                    UsageBurnChart(
+                        title: "Monthly",
+                        kind: .monthly,
+                        window: monthly,
+                        history: model.monthlyHistory,
+                        observedAt: usage.fetchedAt,
+                        compact: true
+                    )
+                }
+            }
+
+            if !hasCharts {
+                Label(
+                    "Charts appear once OpenAI reports your 5-hour, weekly, or monthly usage windows.",
+                    systemImage: "chart.xyaxis.line"
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .padding(.vertical, 8)
+            }
+
+            NavigationLink {
+                UsageHistoryView()
+            } label: {
+                Text("View history")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+        }
+        .padding(AppChrome.cardPadding)
+        .cardSurface()
+    }
+}
+
+struct UsageHistoryView: View {
+    @Environment(AppModel.self) private var model
+    @State private var confirmingClear = false
+    @State private var showingCustomize = false
+
+    private var hasCharts: Bool {
+        model.usage?.fiveHour != nil || model.usage?.weekly != nil || model.usage?.monthly != nil
+    }
+
+    private var hasSamples: Bool {
+        !model.fiveHourHistory.samples.isEmpty
+            || !model.weeklyHistory.samples.isEmpty
+            || !model.monthlyHistory.samples.isEmpty
+    }
+
+    private var pricing: PlanPricing? {
+        guard model.settings.isHistorySectionVisible(HistorySections.valueEstimates) else {
+            return nil
+        }
+        return PlanPricing.forPlan(model.usage?.planType)
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: AppChrome.sectionSpacing) {
+                if model.settings.isHistorySectionVisible(HistorySections.guide) {
+                    VStack(alignment: .leading, spacing: 9) {
+                        Text("How to read the charts")
+                            .font(.title3.bold())
+                        Text("The solid line is this window's usage, faint lines are previous windows, the dotted diagonal is a sustainable pace, and the dashed line is the projection. Drag a chart to inspect any moment. Samples are recorded after each successful refresh and stay on this device.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(AppChrome.cardPadding)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .cardSurface()
+                }
+
+                if let usage = model.usage {
+                    if let fiveHour = usage.fiveHour {
+                        windowSection(
+                            title: "5-hour",
+                            kind: .fiveHour,
+                            window: fiveHour,
+                            history: model.fiveHourHistory,
+                            observedAt: usage.fetchedAt
+                        )
+                    }
+                    if let weekly = usage.weekly {
+                        windowSection(
+                            title: "Weekly",
+                            kind: .weekly,
+                            window: weekly,
+                            history: model.weeklyHistory,
+                            observedAt: usage.fetchedAt
+                        )
+                    }
+                    if let monthly = usage.monthly {
+                        windowSection(
+                            title: "Monthly",
+                            kind: .monthly,
+                            window: monthly,
+                            history: model.monthlyHistory,
+                            observedAt: usage.fetchedAt
+                        )
+                    }
+                }
+
+                if !hasCharts {
+                    Label(
+                        "Charts appear once OpenAI reports your 5-hour, weekly, or monthly usage windows. Refresh usage from the dashboard to check again.",
+                        systemImage: "clock.badge.questionmark"
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(AppChrome.cardPadding)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .cardSurface()
+                }
+
+                if let pricing, hasCharts {
+                    ValueEstimatesCard(usage: model.usage, pricing: pricing)
+                }
+
+                Button("Clear local history", role: .destructive) {
+                    confirmingClear = true
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .frame(maxWidth: .infinity)
+                .disabled(!hasSamples)
+            }
+            .frame(maxWidth: AppChrome.contentMaxWidth)
+            .padding(16)
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("Usage history")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Customize") {
+                    showingCustomize = true
+                }
+            }
+        }
+        .sheet(isPresented: $showingCustomize) {
+            HistoryCustomizeView()
+        }
+        .confirmationDialog(
+            "Clear usage history?",
+            isPresented: $confirmingClear,
+            titleVisibility: .visible
+        ) {
+            Button("Clear", role: .destructive) {
+                Task { await model.clearUsageHistory() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes every locally stored usage sample. Your latest allowance and account sign-in stay intact.")
+        }
+    }
+
+    @ViewBuilder
+    private func windowSection(
+        title: String,
+        kind: UsageHistoryKind,
+        window: UsageWindow,
+        history: UsageHistory,
+        observedAt: Date
+    ) -> some View {
+        HistoryDetailCard(
+            title: title,
+            kind: kind,
+            window: window,
+            history: history,
+            observedAt: observedAt,
+            pricing: pricing,
+            showWindowList: model.settings.isHistorySectionVisible(HistorySections.windowList)
+        )
+        if let insights = HistoryInsightsCard.model(
+            window: window,
+            history: history,
+            observedAt: observedAt,
+            pricing: pricing,
+            settings: model.settings
+        ) {
+            HistoryInsightsCard(model: insights)
+        }
+    }
+}
+
+private struct HistoryCustomizeView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(HistorySections.all, id: \.self) { key in
+                        Toggle(HistorySections.label(key), isOn: binding(for: key))
+                    }
+                } header: {
+                    Text("Highlights to show")
+                } footer: {
+                    Text("The charts and clear-history action always stay available. Turning a highlight off declutters this page without deleting samples.")
+                }
+            }
+            .navigationTitle("Customize")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private func binding(for key: String) -> Binding<Bool> {
+        Binding(
+            get: { model.settings.isHistorySectionVisible(key) },
+            set: { visible in
+                var settings = model.settings
+                settings.setHistorySectionVisible(key, visible: visible)
+                model.save(settings: settings)
+            }
+        )
+    }
+}
+
+private struct HistoryDetailCard: View {
+    let title: String
+    let kind: UsageHistoryKind
+    let window: UsageWindow
+    let history: UsageHistory
+    let observedAt: Date
+    let pricing: PlanPricing?
+    let showWindowList: Bool
+
+    @State private var selectedWindowIndex: Int?
+    @State private var scrubText: String?
+
+    private var breakdown: [UsageStats.WindowStats] {
+        UsageStats.windowBreakdown(history, maximumWindows: 5)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            UsageBurnChart(
+                title: title,
+                kind: kind,
+                window: window,
+                history: history,
+                observedAt: observedAt,
+                compact: false,
+                selectedWindowIndex: selectedWindowIndex,
+                onScrub: handleScrub,
+                onScrubEnd: { scrubText = nil }
+            )
+
+            Text(scrubText ?? defaultDetail)
+                .font(.caption)
+                .foregroundStyle(scrubText == nil ? .secondary : .primary)
+
+            Text(
+                "\(history.samples.count) samples · \(history.completedWindowCount) completed \(history.completedWindowCount == 1 ? "window" : "windows")"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if showWindowList, breakdown.count > 1 {
+                Divider()
+                ForEach(Array(breakdown.enumerated().reversed()), id: \.offset) { index, stats in
+                    Button {
+                        selectedWindowIndex = stats.complete ? index : nil
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(stats.complete ? windowRangeLabel(stats) : "Current window")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(
+                                    selectedWindowIndex == index || (!stats.complete && selectedWindowIndex == nil)
+                                        ? Color.accentColor : .primary
+                                )
+                            Text(windowSubtitle(stats))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(AppChrome.cardPadding)
+        .cardSurface()
+    }
+
+    private var defaultDetail: String {
+        showWindowList && breakdown.count > 1
+            ? "Drag to inspect · tap a window to compare"
+            : "Drag to inspect"
+    }
+
+    private func handleScrub(date: Date, usedPercent: Double, historical: Bool) {
+        var text = "\(UsageFormat.absolute(date, relativeTo: .now)) — \(Int(usedPercent.rounded()))% used"
+        if let pricing {
+            text += " · ≈ \(PlanPricing.formatUsd(pricing.estimatedValueUsd(for: kind, usedPercent: usedPercent)))"
+        }
+        if historical {
+            text += " · previous window"
+        }
+        scrubText = text
+    }
+
+    private func windowSubtitle(_ stats: UsageStats.WindowStats) -> String {
+        var parts = ["\(stats.finalPercent)% used"]
+        if stats.averageBurnPercentPerHour > 0 {
+            parts.append("avg \(UsageStats.formatRate(stats.averageBurnPercentPerHour))")
+        }
+        if let pricing {
+            parts.append("≈ \(PlanPricing.formatUsd(pricing.estimatedValueUsd(for: kind, usedPercent: Double(stats.finalPercent))))")
+        }
+        if stats.exhausted {
+            parts.append("hit limit")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private func windowRangeLabel(_ stats: UsageStats.WindowStats) -> String {
+        let day = DateFormatter()
+        day.dateFormat = "MMM d"
+        if kind == .weekly || kind == .monthly {
+            return "\(day.string(from: stats.windowStart)) – \(day.string(from: stats.resetAt))"
+        }
+        let time = DateFormatter()
+        time.dateFormat = DateFormatter.dateFormat(
+            fromTemplate: "jm",
+            options: 0,
+            locale: .current
+        )
+        return "\(day.string(from: stats.windowStart)) · \(time.string(from: stats.windowStart)) – \(time.string(from: stats.resetAt))"
+    }
+}
+
+private struct HistoryInsightsModel {
+    var rows: [(label: String, value: String)]
+}
+
+private struct HistoryInsightsCard: View {
+    let model: HistoryInsightsModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Insights")
+                .font(.headline.bold())
+            ForEach(Array(model.rows.enumerated()), id: \.offset) { _, row in
+                HStack {
+                    Text(row.label)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 12)
+                    Text(row.value)
+                        .multilineTextAlignment(.trailing)
+                }
+                .font(.subheadline)
+            }
+        }
+        .padding(AppChrome.cardPadding)
+        .cardSurface()
+    }
+
+    static func model(
+        window: UsageWindow,
+        history: UsageHistory,
+        observedAt: Date,
+        pricing: PlanPricing?,
+        settings: AppSettings
+    ) -> HistoryInsightsModel? {
+        var rows: [(label: String, value: String)] = []
+        let now = Date()
+
+        if settings.isHistorySectionVisible(HistorySections.insightPace),
+           let resetAt = window.effectiveResetDate(relativeTo: observedAt),
+           window.windowSeconds > 0 {
+            let remaining = max(0, resetAt.timeIntervalSince(now))
+            let elapsedFraction = 1 - min(1, remaining / TimeInterval(window.windowSeconds))
+            if let typical = UsageStats.typicalUsedPercent(in: history, atElapsedFraction: elapsedFraction) {
+                let delta = Int((Double(window.usedPercent) - typical).rounded())
+                let value: String
+                if delta >= 2 {
+                    value = "\(delta) pts ahead of typical"
+                } else if delta <= -2 {
+                    value = "\(-delta) pts behind typical"
+                } else {
+                    value = "On par with typical"
+                }
+                rows.append(("Pace vs. previous windows", value))
+            }
+        }
+
+        if settings.isHistorySectionVisible(HistorySections.insightExhaustion) {
+            let pace = UsagePace.assess(
+                window: window,
+                history: history,
+                observedAt: observedAt,
+                now: now,
+                sensitivity: .balanced
+            )
+            if pace.isAvailable, let exhaustion = pace.estimatedExhaustionAt {
+                rows.append(("Projected exhaustion", UsageFormat.relative(until: exhaustion, from: now)))
+            }
+        }
+
+        if settings.isHistorySectionVisible(HistorySections.insightAverage),
+           let average = UsageStats.averageFinalPercent(history) {
+            rows.append(("Avg. completed window", "\(Int(average.rounded()))% used"))
+        }
+
+        if settings.isHistorySectionVisible(HistorySections.insightPeak) {
+            let peak = UsageStats.peakBurnPercentPerHour(history)
+            if peak > 0 {
+                var value = UsageStats.formatRate(peak)
+                if let pricing {
+                    value += " · ≈ \(PlanPricing.formatUsd(pricing.windowValueUsd(for: history.kind) * peak / 100))/h"
+                }
+                rows.append(("Peak burn observed", value))
+            }
+        }
+
+        if let pricing {
+            rows.append((
+                "Est. value used this window",
+                "≈ \(PlanPricing.formatUsd(pricing.estimatedValueUsd(for: history.kind, usedPercent: Double(window.usedPercent)))) of \(PlanPricing.formatUsd(pricing.windowValueUsd(for: history.kind)))"
+            ))
+        }
+
+        return rows.isEmpty ? nil : HistoryInsightsModel(rows: rows)
+    }
+}
+
+private struct ValueEstimatesCard: View {
+    let usage: UsageSnapshot?
+    let pricing: PlanPricing
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("\(pricing.planLabel) · \(PlanPricing.formatUsd(pricing.monthlyPriceUsd))/month")
+                .font(.headline.bold())
+            estimateRow("Est. included usage", PlanPricing.formatUsd(pricing.monthlyValueUsd) + "/month")
+            estimateRow("Weekly allowance", PlanPricing.formatUsd(pricing.weeklyValueUsd))
+            estimateRow("5-hour allowance", PlanPricing.formatUsd(pricing.fiveHourValueUsd))
+            estimateRow("Vs. subscription price", "≈ \(Int(pricing.valueMultiplier.rounded()))x the monthly cost")
+            if let weekly = usage?.weekly {
+                estimateRow(
+                    "Weekly value remaining",
+                    PlanPricing.formatUsd(
+                        pricing.estimatedValueUsd(for: .weekly, usedPercent: Double(weekly.remainingPercent))
+                    )
+                )
+            }
+            if let monthly = usage?.monthly, usage?.weekly == nil {
+                estimateRow(
+                    "Monthly value remaining",
+                    PlanPricing.formatUsd(
+                        pricing.estimatedValueUsd(for: .monthly, usedPercent: Double(monthly.remainingPercent))
+                    )
+                )
+            }
+            Text("Rough community estimates comparing plan allowances with API pricing; not a billing statement.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.top, 4)
+        }
+        .padding(AppChrome.cardPadding)
+        .cardSurface()
+    }
+
+    private func estimateRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 12)
+            Text("≈ \(value)")
+        }
+        .font(.subheadline)
+    }
+}
+
+private struct UsageBurnChart: View {
+    let title: String
+    let kind: UsageHistoryKind
+    let window: UsageWindow
+    let history: UsageHistory
+    let observedAt: Date
+    let compact: Bool
+    var selectedWindowIndex: Int?
+    var onScrub: ((Date, Double, Bool) -> Void)?
+    var onScrubEnd: (() -> Void)?
+
+    private var windows: [[UsageSample]] {
+        history.recentWindows(maximum: 5)
+    }
+
+    private var currentPoints: [UsageChartPoint] {
+        Self.points(for: history.currentWindowSamples, series: "Current", prefix: "current")
+    }
+
+    private var historicalPoints: [UsageChartPoint] {
+        guard windows.count > 1 else { return [] }
+        return windows.dropLast().enumerated().flatMap { index, samples in
+            Self.points(
+                for: samples,
+                series: "History \(index)",
+                prefix: "history-\(index)"
+            )
+        }
+    }
+
+    private var pace: UsagePaceAssessment {
+        UsagePace.assess(
+            window: window,
+            history: history,
+            observedAt: observedAt,
+            now: .now,
+            sensitivity: .balanced
+        )
+    }
+
+    private var projectionPoints: [UsageChartPoint] {
+        guard pace.isAvailable,
+              let latest = history.currentWindowSamples.last,
+              let resetAt = window.effectiveResetDate(relativeTo: observedAt),
+              let exhaustionAt = pace.estimatedExhaustionAt
+        else {
+            return []
+        }
+        let startAt = resetAt.addingTimeInterval(-TimeInterval(window.windowSeconds))
+        guard resetAt > startAt else { return [] }
+        let from = Self.progress(for: latest.observedAt, start: startAt, reset: resetAt)
+        let projectedDate = min(resetAt, exhaustionAt)
+        let to = Self.progress(for: projectedDate, start: startAt, reset: resetAt)
+        let projectedUsed = exhaustionAt <= resetAt
+            ? 100 : latest.usedPercent
+        return [
+            UsageChartPoint(
+                id: "projection-start",
+                progress: from,
+                usedPercent: Double(latest.usedPercent),
+                series: "Projection"
+            ),
+            UsageChartPoint(
+                id: "projection-end",
+                progress: to,
+                usedPercent: Double(projectedUsed),
+                series: "Projection"
+            )
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                Text(title)
+                    .font(.subheadline.bold())
+                Spacer(minLength: 8)
+                Text(currentPoints.count < 2 ? "Building history" : "\(currentPoints.count) samples")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Chart {
+                LineMark(
+                    x: .value("Window", 0.0),
+                    y: .value("Used", 0.0),
+                    series: .value("Series", "Budget")
+                )
+                .foregroundStyle(.secondary.opacity(0.5))
+                .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 5]))
+                LineMark(
+                    x: .value("Window", 1.0),
+                    y: .value("Used", 100.0),
+                    series: .value("Series", "Budget")
+                )
+                .foregroundStyle(.secondary.opacity(0.5))
+                .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 5]))
+
+                ForEach(historicalPoints) { point in
+                    LineMark(
+                        x: .value("Window", point.progress),
+                        y: .value("Used", point.usedPercent),
+                        series: .value("Series", point.series)
+                    )
+                    .foregroundStyle(.secondary.opacity(selectedOpacity(for: point.series)))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5))
+                }
+
+                ForEach(currentPoints) { point in
+                    LineMark(
+                        x: .value("Window", point.progress),
+                        y: .value("Used", point.usedPercent),
+                        series: .value("Series", point.series)
+                    )
+                    .foregroundStyle(Color.accentColor)
+                    .lineStyle(StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+                }
+
+                ForEach(projectionPoints) { point in
+                    LineMark(
+                        x: .value("Window", point.progress),
+                        y: .value("Used", point.usedPercent),
+                        series: .value("Series", point.series)
+                    )
+                    .foregroundStyle(pace.isAccelerated ? Color.orange : Color.accentColor.opacity(0.7))
+                    .lineStyle(StrokeStyle(lineWidth: 2, dash: [7, 5]))
+                }
+            }
+            .chartXScale(domain: 0.0 ... 1.0)
+            .chartYScale(domain: 0.0 ... 100.0)
+            .chartXAxis(.hidden)
+            .chartYAxis {
+                AxisMarks(values: [0, 50, 100]) {
+                    AxisGridLine()
+                    AxisValueLabel()
+                }
+            }
+            .chartLegend(.hidden)
+            .frame(height: compact ? 112 : 190)
+            .chartOverlay { proxy in
+                GeometryReader { geometry in
+                    Rectangle()
+                        .fill(.clear)
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { value in
+                                    handleDrag(at: value.location, proxy: proxy, geometry: geometry)
+                                }
+                                .onEnded { _ in
+                                    onScrubEnd?()
+                                }
+                        )
+                }
+            }
+            .accessibilityLabel("\(title) usage burn chart")
+            .accessibilityValue(chartAccessibilityValue)
+
+            HStack {
+                Text("0%")
+                Spacer()
+                Text("reset")
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+
+            if pace.isAvailable, let exhaustionAt = pace.estimatedExhaustionAt {
+                Label {
+                    if pace.isAccelerated {
+                        Text("Current pace may exhaust allowance \(exhaustionAt, style: .relative).")
+                    } else {
+                        Text("Estimated exhaustion \(exhaustionAt, style: .relative).")
+                    }
+                } icon: {
+                    Image(systemName: pace.isAccelerated
+                        ? "exclamationmark.triangle.fill" : "speedometer")
+                }
+                .font(.caption)
+                .foregroundStyle(pace.isAccelerated ? .orange : .secondary)
+            }
+        }
+    }
+
+    private var chartAccessibilityValue: String {
+        var value = currentPoints.count < 2
+            ? "Building local history"
+            : "\(currentPoints.count) local samples"
+        if pace.isAvailable {
+            value += pace.isAccelerated
+                ? ", accelerated pace detected"
+                : ", pace estimate available"
+        }
+        return value
+    }
+
+    private func selectedOpacity(for series: String) -> Double {
+        guard let selectedWindowIndex else { return 0.25 }
+        return series == "History \(selectedWindowIndex)" ? 0.7 : 0.12
+    }
+
+    private func handleDrag(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) {
+        guard let onScrub,
+              let plotFrame = proxy.plotFrame else { return }
+        let frame = geometry[plotFrame]
+        let x = location.x - frame.origin.x
+        guard let progress: Double = proxy.value(atX: x) else { return }
+        let clamped = min(1, max(0, progress))
+
+        let samples: [UsageSample]
+        let historical: Bool
+        if let selectedWindowIndex, windows.indices.contains(selectedWindowIndex) {
+            samples = windows[selectedWindowIndex]
+            historical = selectedWindowIndex < windows.count - 1
+        } else {
+            samples = history.currentWindowSamples
+            historical = false
+        }
+        guard let first = samples.first ?? history.currentWindowSamples.first else { return }
+        let start = first.resetAt.addingTimeInterval(-TimeInterval(first.windowSeconds))
+        let date = start.addingTimeInterval(clamped * TimeInterval(first.windowSeconds))
+        let used = UsageStats.usedPercent(at: date, in: samples)
+            ?? interpolateOutside(date: date, samples: samples, start: start)
+        onScrub(date, used, historical)
+    }
+
+    private func interpolateOutside(date: Date, samples: [UsageSample], start: Date) -> Double {
+        guard let first = samples.first, let last = samples.last else {
+            return Double(window.usedPercent)
+        }
+        if date <= first.observedAt { return Double(first.usedPercent) }
+        if date >= last.observedAt { return Double(last.usedPercent) }
+        return Double(window.usedPercent)
+    }
+
+    private static func points(
+        for samples: [UsageSample],
+        series: String,
+        prefix: String
+    ) -> [UsageChartPoint] {
+        samples.enumerated().compactMap { index, sample in
+            let startAt = sample.resetAt.addingTimeInterval(-TimeInterval(sample.windowSeconds))
+            guard sample.resetAt > startAt else { return nil }
+            return UsageChartPoint(
+                id: "\(prefix)-\(index)-\(sample.observedAt.timeIntervalSince1970)",
+                progress: progress(
+                    for: sample.observedAt,
+                    start: startAt,
+                    reset: sample.resetAt
+                ),
+                usedPercent: Double(sample.usedPercent),
+                series: series
+            )
+        }
+    }
+
+    private static func progress(for date: Date, start: Date, reset: Date) -> Double {
+        guard reset > start else { return 0 }
+        return min(1, max(0, date.timeIntervalSince(start) / reset.timeIntervalSince(start)))
+    }
+}
+
+private struct UsageChartPoint: Identifiable {
+    let id: String
+    let progress: Double
+    let usedPercent: Double
+    let series: String
+}

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/AdaptiveRefreshPolicy.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/AdaptiveRefreshPolicy.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Pure, low-cost policy for selecting the next automatic usage refresh.
 public enum AdaptiveRefreshPolicy {
     private static let intervals = [5, 10, 15, 30, 60, 120]
 
@@ -10,7 +11,7 @@ public enum AdaptiveRefreshPolicy {
         consecutiveFailures: Int,
         now: Date = Date()
     ) -> Int {
-        let windows = [snapshot?.fiveHour, snapshot?.weekly]
+        let windows = [snapshot?.fiveHour, snapshot?.weekly, snapshot?.monthly]
             .compactMap { $0 }
             .filter {
                 guard let reset = $0.effectiveResetDate(relativeTo: snapshot?.fetchedAt ?? now) else {
@@ -49,6 +50,10 @@ public enum AdaptiveRefreshPolicy {
         if untilReset <= 15 * 60 {
             minutes = min(minutes, 5)
         } else if untilReset <= 60 * 60 {
+            minutes = min(minutes, 10)
+        }
+
+        if UsagePace.mostAcceleratedWindow(in: snapshot, now: now) != nil {
             minutes = min(minutes, 10)
         }
 

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/DashboardSections.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/DashboardSections.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Stable keys and merge rules for movable dashboard sections.
+public enum DashboardSections {
+    public static let fiveHour = "five_hour"
+    public static let weekly = "weekly"
+    public static let monthly = "monthly"
+    public static let usageCredits = "usage_credits"
+    public static let usageHistory = "usage_history"
+    public static let resetCredits = "reset_credits"
+
+    private static let limitPrefix = "limit:"
+
+    /// A stable key for an additional limit, preferring the API id over display names.
+    public static func limitKey(_ limit: UsageLimit) -> String {
+        let identity = [limit.id, limit.name, limit.meteredFeature, "additional"]
+            .first { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }!
+        let normalized = identity
+            .lowercased(with: Locale(identifier: "en_US_POSIX"))
+            .replacingOccurrences(of: ",", with: "_")
+        return limitPrefix + normalized
+    }
+
+    public static func isLimitKey(_ key: String) -> Bool {
+        key.hasPrefix(limitPrefix)
+    }
+
+    /// Default order: standard windows, monthly, detected additional limits, credits, history, resets.
+    public static func defaultOrder(additionalLimits: [UsageLimit]) -> [String] {
+        var result = [fiveHour, weekly, monthly]
+        for limit in additionalLimits {
+            let key = limitKey(limit)
+            if !result.contains(key) {
+                result.append(key)
+            }
+        }
+        result.append(contentsOf: [usageCredits, usageHistory, resetCredits])
+        return result
+    }
+
+    /// Applies a saved order to the currently available section keys.
+    ///
+    /// Unavailable saved keys are removed. Newly available keys are inserted after the nearest
+    /// preceding key in the natural `available` order instead of being dumped at the end.
+    public static func resolveOrder(saved: [String], available: [String]) -> [String] {
+        let availableKeys = deduplicating(available)
+        var result = deduplicating(saved).filter(availableKeys.contains)
+
+        for (index, key) in availableKeys.enumerated() where !result.contains(key) {
+            var insertionIndex = 0
+            for precedingKey in availableKeys.prefix(index) {
+                if let position = result.firstIndex(of: precedingKey) {
+                    insertionIndex = max(insertionIndex, result.index(after: position))
+                }
+            }
+            result.insert(key, at: insertionIndex)
+        }
+        return result
+    }
+
+    public static func resolveOrder(savedCSV: String, available: [String]) -> [String] {
+        resolveOrder(saved: parseCSV(savedCSV), available: available)
+    }
+
+    public static func isHidden(_ hiddenCSV: String, key: String) -> Bool {
+        parseCSV(hiddenCSV).contains(key)
+    }
+
+    /// Adds or removes a key from a comma-separated hidden-section setting.
+    public static func settingHidden(_ hiddenCSV: String, key: String, hidden: Bool) -> String {
+        let key = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        var keys = deduplicating(parseCSV(hiddenCSV))
+        guard !key.isEmpty else {
+            return serialize(keys)
+        }
+        if hidden {
+            if !keys.contains(key) {
+                keys.append(key)
+            }
+        } else {
+            keys.removeAll { $0 == key }
+        }
+        return serialize(keys)
+    }
+
+    public static func parseCSV(_ csv: String) -> [String] {
+        csv.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    public static func serialize(_ keys: [String]) -> String {
+        keys
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ",")
+    }
+
+    private static func deduplicating(_ keys: [String]) -> [String] {
+        var seen = Set<String>()
+        return keys.filter { seen.insert($0).inserted }
+    }
+}

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/DiagnosticSanitizer.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/DiagnosticSanitizer.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Privacy filters shared by diagnostic logging and its tests.
+public enum DiagnosticSanitizer {
+    public static let redacted = "[REDACTED]"
+    public static let redactedEmail = "[REDACTED_EMAIL]"
+
+    private static let authScheme = try! NSRegularExpression(
+        pattern: #"(?i)\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+"#
+    )
+    private static let email = try! NSRegularExpression(
+        pattern: #"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"#
+    )
+    private static let jwt = try! NSRegularExpression(
+        pattern: #"\b[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{8,}\b"#
+    )
+    private static let sensitiveAssignment = try! NSRegularExpression(
+        pattern: #"(?i)\b(authorization|proxy-authorization|cookie|set-cookie|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|code[_-]?verifier|password|passwd|session(?:id)?|api[_-]?key)\b\s*["']?\s*[:=]\s*["']?([^\s,;&}\]]+)"#
+    )
+    private static let sensitiveQuery = try! NSRegularExpression(
+        pattern: #"(?i)([?&](?:code|state|token|access_token|refresh_token|id_token|code_verifier|client_secret|password|session)=)[^&#\s]+"#
+    )
+
+    public static func redact(_ value: String?) -> String {
+        guard let value, !value.isEmpty else { return value ?? "" }
+        var result = replace(authScheme, in: value, with: redacted)
+        result = replace(jwt, in: result, with: redacted)
+        result = replace(email, in: result, with: redactedEmail)
+        result = replaceAssignments(result)
+        return replace(sensitiveQuery, in: result, template: "$1\(redacted)")
+    }
+
+    /// Returns scheme, host, optional port, and path only. Query strings and fragments are dropped.
+    public static func safeURL(_ value: String?) -> String {
+        guard let value, !value.isEmpty else { return "" }
+        guard let url = URL(string: value),
+              let scheme = url.scheme,
+              let host = url.host else {
+            return redact(value)
+        }
+        var safe = "\(scheme.lowercased())://\(host.lowercased())"
+        if let port = url.port {
+            safe += ":\(port)"
+        }
+        let path = url.path
+        if !path.isEmpty {
+            safe += path
+        }
+        return safe
+    }
+
+    private static func replaceAssignments(_ value: String) -> String {
+        let range = NSRange(value.startIndex..., in: value)
+        var result = value
+        let matches = sensitiveAssignment.matches(in: value, range: range).reversed()
+        for match in matches {
+            guard match.numberOfRanges >= 2,
+                  let nameRange = Range(match.range(at: 1), in: result),
+                  let fullRange = Range(match.range, in: result) else {
+                continue
+            }
+            let name = String(result[nameRange])
+            result.replaceSubrange(fullRange, with: "\(name)=\(redacted)")
+        }
+        return result
+    }
+
+    private static func replace(
+        _ expression: NSRegularExpression,
+        in value: String,
+        with replacement: String
+    ) -> String {
+        replace(expression, in: value, template: NSRegularExpression.escapedTemplate(for: replacement))
+    }
+
+    private static func replace(
+        _ expression: NSRegularExpression,
+        in value: String,
+        template: String
+    ) -> String {
+        let range = NSRange(value.startIndex..., in: value)
+        return expression.stringByReplacingMatches(in: value, range: range, withTemplate: template)
+    }
+}

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/HistorySections.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/HistorySections.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Stable keys for optional Usage history highlights: the chart guide, the previous-window
+/// list, each insight row, and dollar value estimates. Visibility is stored as a
+/// comma-separated list of keys the user toggled away from their default, so changing a
+/// default later never overrides an explicit user choice. The chart itself and the
+/// clear-history action are always shown and have no key here.
+public enum HistorySections {
+    public static let guide = "guide"
+    public static let windowList = "window_list"
+    public static let insightPace = "insight_pace"
+    public static let insightExhaustion = "insight_exhaustion"
+    public static let insightAverage = "insight_average"
+    public static let insightPeak = "insight_peak"
+    public static let valueEstimates = "value_estimates"
+
+    /// Every customizable highlight, in the order the customize sheet lists them.
+    public static let all = [
+        guide,
+        windowList,
+        insightPace,
+        insightExhaustion,
+        insightAverage,
+        insightPeak,
+        valueEstimates
+    ]
+
+    /// The guide is opt-in extra reading; every other highlight starts visible.
+    public static func defaultVisible(_ key: String) -> Bool {
+        key != guide
+    }
+
+    /// User-facing label for a highlight key.
+    public static func label(_ key: String) -> String {
+        switch key {
+        case guide: "How to read the charts"
+        case windowList: "Previous window list"
+        case insightPace: "Pace vs. typical"
+        case insightExhaustion: "Projected exhaustion"
+        case insightAverage: "Average completed window"
+        case insightPeak: "Peak burn rate"
+        case valueEstimates: "Value estimates ($)"
+        default: key
+        }
+    }
+
+    /// Whether a highlight is visible given the saved override CSV.
+    public static func isVisible(_ overridesCSV: String?, key: String) -> Bool {
+        defaultVisible(key) != parseCSV(overridesCSV).contains(key)
+    }
+
+    /// Returns the override CSV updated so the key resolves to the requested visibility.
+    public static func setVisible(_ overridesCSV: String?, key: String, visible: Bool) -> String {
+        let key = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        var keys = deduplicating(parseCSV(overridesCSV))
+        guard !key.isEmpty else {
+            return serialize(keys)
+        }
+        if visible == defaultVisible(key) {
+            keys.removeAll { $0 == key }
+        } else if !keys.contains(key) {
+            keys.append(key)
+        }
+        return serialize(keys)
+    }
+
+    public static func parseCSV(_ csv: String?) -> [String] {
+        guard let csv else { return [] }
+        return csv.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    public static func serialize(_ keys: [String]) -> String {
+        keys
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ",")
+    }
+
+    private static func deduplicating(_ keys: [String]) -> [String] {
+        var seen = Set<String>()
+        return keys.filter { seen.insert($0).inserted }
+    }
+}

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
@@ -39,6 +39,47 @@ public struct UsageWindow: Codable, Sendable, Equatable {
         remainingPercent <= min(100, max(0, threshold))
     }
 
+    /// OpenAI reset timestamps drift slightly across refreshes. Nearby reset times for the
+    /// same window length are treated as one window so alerts stay one-shot until the real reset.
+    public static func resetWindowTolerance(windowSeconds: Int64) -> TimeInterval {
+        guard windowSeconds > 0 else { return 60 }
+        return min(15 * 60, max(60, TimeInterval(windowSeconds) / 20))
+    }
+
+    public static func sameResetWindow(
+        leftReset: Date,
+        leftWindowSeconds: Int64,
+        rightReset: Date,
+        rightWindowSeconds: Int64
+    ) -> Bool {
+        guard leftReset.timeIntervalSince1970 > 0,
+              rightReset.timeIntervalSince1970 > 0,
+              leftWindowSeconds == rightWindowSeconds else {
+            return false
+        }
+        return abs(leftReset.timeIntervalSince(rightReset))
+            <= resetWindowTolerance(windowSeconds: leftWindowSeconds)
+    }
+
+    /// Whether a low-usage alert should fire for `currentReset`. Returns false when
+    /// `lastAnnouncedReset` already covers the same usage window.
+    public static func shouldAnnounceLowUsage(
+        lastAnnouncedReset: Date?,
+        currentReset: Date,
+        windowSeconds: Int64
+    ) -> Bool {
+        guard currentReset.timeIntervalSince1970 > 0 else { return false }
+        guard let lastAnnouncedReset, lastAnnouncedReset.timeIntervalSince1970 > 0 else {
+            return true
+        }
+        return !sameResetWindow(
+            leftReset: lastAnnouncedReset,
+            leftWindowSeconds: windowSeconds,
+            rightReset: currentReset,
+            rightWindowSeconds: windowSeconds
+        )
+    }
+
     private enum CodingKeys: String, CodingKey {
         case usedPercent
         case windowSeconds
@@ -122,8 +163,6 @@ public struct UsageLimit: Codable, Sendable, Equatable, Identifiable {
 }
 
 public struct UsageCredits: Codable, Sendable, Equatable {
-    /// Balances below this render as "0" with the two fraction digits used across the app,
-    /// so they are treated as exhausted and never displayed.
     private static let nearZeroBalance = Decimal(string: "0.005")!
 
     public let hasCredits: Bool
@@ -138,24 +177,34 @@ public struct UsageCredits: Codable, Sendable, Equatable {
             ? cleanBalance : nil
     }
 
-    /// Whether the balance is worth surfacing anywhere in the UI. Zero, effectively-zero,
-    /// and negative balances always hide the card, as does an account without purchased
-    /// credits. Unlimited plans and unparseable non-empty balances remain visible.
+    /// The parsed purchased-credit balance, or `nil` when it is absent or not numeric.
+    public var numericBalance: Decimal? {
+        guard let balance else { return nil }
+        return Decimal(
+            string: balance.replacingOccurrences(of: ",", with: ""),
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+    }
+
+    /// Whether the balance is useful enough to surface in the UI.
+    ///
+    /// Unlimited plans and unparseable non-empty balances remain visible. Accounts without
+    /// purchased credits and numeric balances below half of the smallest displayed hundredth
+    /// (including zero and negative values) stay hidden.
     public var shouldDisplay: Bool {
         if unlimited {
             return true
         }
-        if !hasCredits {
+        guard hasCredits else {
             return false
         }
-        guard let balance, !balance.isEmpty else {
+        guard balance != nil else {
             return true
         }
-        let normalized = balance.replacingOccurrences(of: ",", with: "")
-        guard let amount = Decimal(string: normalized) else {
+        guard let numericBalance else {
             return true
         }
-        return amount >= Self.nearZeroBalance
+        return numericBalance >= Self.nearZeroBalance
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -180,6 +229,8 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
     public let limitReached: Bool
     public let fiveHour: UsageWindow?
     public let weekly: UsageWindow?
+    /// Monthly Codex window (~30 days); reported instead of 5-hour/weekly on the Free tier.
+    public let monthly: UsageWindow?
     public let resetCreditsAvailable: Int?
     public let additionalLimits: [UsageLimit]
     public let usageCredits: UsageCredits?
@@ -191,6 +242,7 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
         limitReached: Bool,
         fiveHour: UsageWindow?,
         weekly: UsageWindow?,
+        monthly: UsageWindow? = nil,
         resetCreditsAvailable: Int? = nil,
         additionalLimits: [UsageLimit] = [],
         usageCredits: UsageCredits? = nil,
@@ -201,6 +253,7 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
         self.limitReached = limitReached
         self.fiveHour = fiveHour
         self.weekly = weekly
+        self.monthly = monthly
         self.resetCreditsAvailable = resetCreditsAvailable.map { max(0, $0) }
         self.additionalLimits = additionalLimits.filter {
             $0.primary != nil || $0.secondary != nil
@@ -209,17 +262,28 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
         self.fetchedAt = fetchedAt
     }
 
+    /// The longer-cadence Codex window: weekly when present, otherwise the monthly window that
+    /// free-tier accounts report. Surfaces that used to hardcode weekly adapt through this so a
+    /// subscription change swaps windows automatically.
+    public var longWindow: UsageWindow? {
+        weekly ?? monthly
+    }
+
+    /// Whether `longWindow` is the monthly window rather than the weekly one.
+    public var longWindowIsMonthly: Bool {
+        weekly == nil && monthly != nil
+    }
+
     public func nextReset(after date: Date) -> Date? {
-        ([fiveHour, weekly] + additionalLimits.flatMap { [$0.primary, $0.secondary] })
+        ([fiveHour, weekly, monthly] + additionalLimits.flatMap { [$0.primary, $0.secondary] })
             .compactMap { $0?.effectiveResetDate(relativeTo: fetchedAt) }
             .filter { $0 > date }
             .min()
     }
 
     public var hasDisplayableData: Bool {
-        fiveHour != nil || weekly != nil || !additionalLimits.isEmpty
-            || usageCredits?.shouldDisplay == true
-            || (resetCreditsAvailable ?? 0) > 0
+        fiveHour != nil || weekly != nil || monthly != nil || !additionalLimits.isEmpty
+            || usageCredits?.shouldDisplay == true || resetCreditsAvailable != nil
     }
 
     public func isStale(at date: Date = Date(), maxAge: TimeInterval) -> Bool {
@@ -232,6 +296,7 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
         case limitReached
         case fiveHour
         case weekly
+        case monthly
         case resetCreditsAvailable
         case additionalLimits
         case usageCredits
@@ -246,6 +311,7 @@ public struct UsageSnapshot: Codable, Sendable, Equatable {
             limitReached: try container.decodeIfPresent(Bool.self, forKey: .limitReached) ?? false,
             fiveHour: try container.decodeIfPresent(UsageWindow.self, forKey: .fiveHour),
             weekly: try container.decodeIfPresent(UsageWindow.self, forKey: .weekly),
+            monthly: try container.decodeIfPresent(UsageWindow.self, forKey: .monthly),
             resetCreditsAvailable: try container.decodeIfPresent(Int.self, forKey: .resetCreditsAvailable),
             additionalLimits: try container.decodeIfPresent([UsageLimit].self, forKey: .additionalLimits) ?? [],
             usageCredits: try container.decodeIfPresent(UsageCredits.self, forKey: .usageCredits),
@@ -329,12 +395,6 @@ public struct ResetCreditsSnapshot: Codable, Sendable, Equatable {
         self.availableCount = max(0, availableCount)
         self.credits = credits
         self.fetchedAt = fetchedAt
-    }
-
-    /// Whether inventory is worth surfacing on the dashboard. Zero available resets always
-    /// hide the card, even when the Settings toggle is on.
-    public var shouldDisplay: Bool {
-        availableCount > 0
     }
 
     public static func summary(availableCount: Int, fetchedAt: Date) -> Self {
@@ -527,8 +587,17 @@ public struct SharedWidgetSnapshot: Codable, Sendable, Equatable {
     public let planType: String
     public let fiveHour: UsageWindow?
     public let weekly: UsageWindow?
+    public let monthly: UsageWindow?
     public let resetCreditsAvailable: Int?
     public let freshness: WidgetSnapshotFreshness
+
+    public var longWindow: UsageWindow? {
+        weekly ?? monthly
+    }
+
+    public var longWindowIsMonthly: Bool {
+        weekly == nil && monthly != nil
+    }
 
     public init(
         version: Int = Self.currentVersion,
@@ -537,6 +606,7 @@ public struct SharedWidgetSnapshot: Codable, Sendable, Equatable {
         planType: String,
         fiveHour: UsageWindow?,
         weekly: UsageWindow?,
+        monthly: UsageWindow? = nil,
         resetCreditsAvailable: Int?,
         freshness: WidgetSnapshotFreshness
     ) {
@@ -546,6 +616,7 @@ public struct SharedWidgetSnapshot: Codable, Sendable, Equatable {
         self.planType = planType
         self.fiveHour = fiveHour
         self.weekly = weekly
+        self.monthly = monthly
         self.resetCreditsAvailable = resetCreditsAvailable.map { max(0, $0) }
         self.freshness = freshness
     }
@@ -561,6 +632,7 @@ public struct SharedWidgetSnapshot: Codable, Sendable, Equatable {
             planType: usage?.planType ?? "",
             fiveHour: usage?.fiveHour,
             weekly: usage?.weekly,
+            monthly: usage?.monthly,
             resetCreditsAvailable: usage?.resetCreditsAvailable,
             freshness: freshness
         )
@@ -572,6 +644,7 @@ public struct SharedWidgetSnapshot: Codable, Sendable, Equatable {
         planType: "",
         fiveHour: nil,
         weekly: nil,
+        monthly: nil,
         resetCreditsAvailable: nil,
         freshness: .unavailable
     )
@@ -583,6 +656,7 @@ public struct SharedWidgetSnapshot: Codable, Sendable, Equatable {
         case planType
         case fiveHour
         case weekly
+        case monthly
         case resetCreditsAvailable
         case freshness
     }
@@ -596,6 +670,7 @@ public struct SharedWidgetSnapshot: Codable, Sendable, Equatable {
             planType: try container.decodeIfPresent(String.self, forKey: .planType) ?? "",
             fiveHour: try container.decodeIfPresent(UsageWindow.self, forKey: .fiveHour),
             weekly: try container.decodeIfPresent(UsageWindow.self, forKey: .weekly),
+            monthly: try container.decodeIfPresent(UsageWindow.self, forKey: .monthly),
             resetCreditsAvailable: try container.decodeIfPresent(Int.self, forKey: .resetCreditsAvailable),
             freshness: try container.decodeIfPresent(WidgetSnapshotFreshness.self, forKey: .freshness) ?? .unavailable
         )

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/PlanPricing.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/PlanPricing.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Rough, community-researched value estimates for Codex subscription allowances.
+///
+/// Anchors: Pro 20x ($200/month) is commonly measured at roughly $14,000 of
+/// equivalent API usage per month and Pro 5x ($100/month) at roughly $3,500.
+/// Because OpenAI documents Pro 5x as 5x Plus usage and Pro 20x as 20x Plus,
+/// Plus ($20/month) back-solves to roughly $700 of monthly usage value. Weekly
+/// figures divide the month into four allowance windows, and the 5-hour figure
+/// uses a rough one-sixth-of-weekly burst heuristic. Every number here is an
+/// estimate, not a billing statement.
+public struct PlanPricing: Sendable, Equatable {
+    /// Rough share of a weekly allowance available inside one 5-hour burst window.
+    private static let fiveHourShareOfWeekly = 1.0 / 6.0
+
+    public let planKey: String
+    public let planLabel: String
+    public let monthlyPriceUsd: Double
+    public let monthlyValueUsd: Double
+
+    private init(
+        planKey: String,
+        planLabel: String,
+        monthlyPriceUsd: Double,
+        monthlyValueUsd: Double
+    ) {
+        self.planKey = planKey
+        self.planLabel = planLabel
+        self.monthlyPriceUsd = monthlyPriceUsd
+        self.monthlyValueUsd = monthlyValueUsd
+    }
+
+    /// Returns pricing for a raw plan type, or `nil` when no researched estimate exists.
+    public static func forPlan(_ planType: String?) -> PlanPricing? {
+        guard let planType else { return nil }
+        let normalized = planType
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+        switch normalized {
+        case "plus":
+            return PlanPricing(planKey: "plus", planLabel: "Plus", monthlyPriceUsd: 20, monthlyValueUsd: 700)
+        case "prolite", "pro5x":
+            return PlanPricing(planKey: "pro5x", planLabel: "Pro 5x", monthlyPriceUsd: 100, monthlyValueUsd: 3_500)
+        case "pro", "pro20x":
+            return PlanPricing(planKey: "pro20x", planLabel: "Pro 20x", monthlyPriceUsd: 200, monthlyValueUsd: 14_000)
+        default:
+            return nil
+        }
+    }
+
+    /// Estimated usage value covered by one week of the allowance (month / 4).
+    public var weeklyValueUsd: Double {
+        monthlyValueUsd / 4
+    }
+
+    /// Rough usage value available inside a single 5-hour burst window.
+    public var fiveHourValueUsd: Double {
+        weeklyValueUsd * Self.fiveHourShareOfWeekly
+    }
+
+    /// Estimated allowance value for a usage-history window kind.
+    public func windowValueUsd(for kind: UsageHistoryKind) -> Double {
+        switch kind {
+        case .monthly: monthlyValueUsd
+        case .weekly: weeklyValueUsd
+        case .fiveHour: fiveHourValueUsd
+        }
+    }
+
+    /// Estimated dollars burned for a used percentage of the given window kind.
+    public func estimatedValueUsd(for kind: UsageHistoryKind, usedPercent: Double) -> Double {
+        let clamped = min(100, max(0, usedPercent))
+        return windowValueUsd(for: kind) * clamped / 100
+    }
+
+    /// How many times the subscription price the estimated monthly value represents.
+    public var valueMultiplier: Double {
+        guard monthlyPriceUsd > 0 else { return 0 }
+        return monthlyValueUsd / monthlyPriceUsd
+    }
+
+    /// Compact USD formatting: $3,500 · $29 · $4.20 · $0.35.
+    public static func formatUsd(_ value: Double) -> String {
+        let amount = max(0, value)
+        if amount >= 10 {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .currency
+            formatter.currencyCode = "USD"
+            formatter.locale = Locale(identifier: "en_US")
+            formatter.maximumFractionDigits = 0
+            formatter.minimumFractionDigits = 0
+            return formatter.string(from: NSNumber(value: amount.rounded())) ?? "$\(Int(amount.rounded()))"
+        }
+        return String(format: "$%.2f", amount)
+    }
+}

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsageHistory.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsageHistory.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+public enum UsageHistoryKind: String, Codable, Sendable, CaseIterable {
+    case fiveHour = "five_hour"
+    case weekly
+    case monthly
+}
+
+/// One locally observed allowance value. It contains no account or credential data.
+public struct UsageSample: Codable, Sendable, Equatable, Identifiable {
+    public var id: Date { observedAt }
+
+    public let observedAt: Date
+    public let usedPercent: Int
+    public let resetAt: Date
+    public let windowSeconds: Int64
+
+    public init(
+        observedAt: Date,
+        usedPercent: Int,
+        resetAt: Date,
+        windowSeconds: Int64
+    ) {
+        self.observedAt = observedAt
+        self.usedPercent = min(100, max(0, usedPercent))
+        self.resetAt = resetAt
+        self.windowSeconds = max(0, windowSeconds)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case observedAt
+        case usedPercent
+        case resetAt
+        case windowSeconds
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            observedAt: try container.decodeIfPresent(Date.self, forKey: .observedAt)
+                ?? Date(timeIntervalSince1970: 0),
+            usedPercent: try container.decodeIfPresent(Int.self, forKey: .usedPercent) ?? 0,
+            resetAt: try container.decodeIfPresent(Date.self, forKey: .resetAt)
+                ?? Date(timeIntervalSince1970: 0),
+            windowSeconds: try container.decodeIfPresent(Int64.self, forKey: .windowSeconds) ?? 0
+        )
+    }
+
+    fileprivate var isValid: Bool {
+        observedAt.timeIntervalSince1970.isFinite
+            && observedAt.timeIntervalSince1970 > 0
+            && resetAt.timeIntervalSince1970.isFinite
+            && resetAt > observedAt
+            && windowSeconds > 0
+    }
+}
+
+/// Bounded, local-only samples used by usage charts and trend-aware pace estimates.
+public struct UsageHistory: Codable, Sendable, Equatable {
+    public let kind: UsageHistoryKind
+    public let samples: [UsageSample]
+
+    public init(kind: UsageHistoryKind, samples: [UsageSample]) {
+        self.kind = kind
+        let maximum = Self.maximumSamples(for: kind)
+        let normalized = samples
+            .filter(\.isValid)
+            .sorted { $0.observedAt < $1.observedAt }
+        self.samples = Array(normalized.suffix(maximum))
+    }
+
+    public static func empty(_ kind: UsageHistoryKind) -> Self {
+        Self(kind: kind, samples: [])
+    }
+
+    public func appending(window: UsageWindow, observedAt: Date) -> Self {
+        guard observedAt.timeIntervalSince1970.isFinite,
+              observedAt.timeIntervalSince1970 > 0,
+              window.windowSeconds > 0,
+              let resetAt = window.effectiveResetDate(relativeTo: observedAt),
+              resetAt > observedAt else {
+            return self
+        }
+
+        let next = UsageSample(
+            observedAt: observedAt,
+            usedPercent: window.usedPercent,
+            resetAt: resetAt,
+            windowSeconds: window.windowSeconds
+        )
+        var updated = samples
+        if let last = updated.last {
+            guard observedAt > last.observedAt else {
+                return self
+            }
+            let minimumSpacing: TimeInterval = switch kind {
+            case .fiveHour: 5 * 60
+            case .weekly: 30 * 60
+            case .monthly: 2 * 60 * 60
+            }
+            if Self.sameWindow(last, next),
+               last.usedPercent == next.usedPercent,
+               observedAt.timeIntervalSince(last.observedAt) < minimumSpacing {
+                updated[updated.count - 1] = next
+                return Self(kind: kind, samples: updated)
+            }
+        }
+
+        updated.append(next)
+        return Self(kind: kind, samples: updated)
+    }
+
+    /// Samples from the latest reset window, oldest first.
+    public var currentWindowSamples: [UsageSample] {
+        guard let latest = samples.last else { return [] }
+        return samples.filter { Self.sameWindow($0, latest) }
+    }
+
+    /// The most recent reset windows, oldest window first and oldest sample first.
+    public func recentWindows(maximum: Int) -> [[UsageSample]] {
+        guard maximum > 0, !samples.isEmpty else { return [] }
+        var windows: [[UsageSample]] = []
+        var current: [UsageSample] = []
+        var previous: UsageSample?
+
+        for sample in samples {
+            if let previous, !Self.sameWindow(previous, sample) {
+                windows.append(current)
+                current = []
+            }
+            current.append(sample)
+            previous = sample
+        }
+        if !current.isEmpty {
+            windows.append(current)
+        }
+        return Array(windows.suffix(maximum))
+    }
+
+    public var completedWindowCount: Int {
+        guard var previous = samples.first else { return 0 }
+        var count = 0
+        for sample in samples.dropFirst() {
+            if !Self.sameWindow(previous, sample) {
+                count += 1
+            }
+            previous = sample
+        }
+        return count
+    }
+
+    /// Recent observed burn in percentage points per second.
+    public var observedBurnRate: Double {
+        let current = currentWindowSamples
+        guard let latest = current.last, current.count >= 2 else { return 0 }
+        let minimumSpan: TimeInterval = switch kind {
+        case .fiveHour: 10 * 60
+        case .weekly: 2 * 60 * 60
+        case .monthly: 6 * 60 * 60
+        }
+        guard let first = current.first(where: {
+            latest.observedAt.timeIntervalSince($0.observedAt) >= minimumSpan
+                && latest.usedPercent - $0.usedPercent >= 2
+        }) else {
+            return 0
+        }
+        let elapsed = latest.observedAt.timeIntervalSince(first.observedAt)
+        guard elapsed > 0 else { return 0 }
+        return Double(latest.usedPercent - first.usedPercent) / elapsed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case samples
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            kind: try container.decodeIfPresent(UsageHistoryKind.self, forKey: .kind) ?? .fiveHour,
+            samples: try container.decodeIfPresent([UsageSample].self, forKey: .samples) ?? []
+        )
+    }
+
+    private static func maximumSamples(for kind: UsageHistoryKind) -> Int {
+        switch kind {
+        case .fiveHour: 288
+        case .weekly: 336
+        case .monthly: 372
+        }
+    }
+
+    private static func sameWindow(_ left: UsageSample, _ right: UsageSample) -> Bool {
+        UsageWindow.sameResetWindow(
+            leftReset: left.resetAt,
+            leftWindowSeconds: left.windowSeconds,
+            rightReset: right.resetAt,
+            rightWindowSeconds: right.windowSeconds
+        )
+    }
+}

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsagePace.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsagePace.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+public enum UsagePaceSensitivity: String, Codable, Sendable, CaseIterable {
+    case off
+    case sensitive
+    case balanced
+    case relaxed
+}
+
+public enum UsagePaceWindow: String, Codable, Sendable {
+    case fiveHour
+    case weekly
+    case monthly
+}
+
+public struct UsagePaceAssessment: Sendable, Equatable {
+    public let isAvailable: Bool
+    public let isAccelerated: Bool
+    public let estimatedRemaining: TimeInterval
+    public let estimatedTotal: TimeInterval
+    public let actualRemaining: TimeInterval
+    public let estimatedExhaustionAt: Date?
+    public let resetAt: Date?
+    public let observedDuration: TimeInterval
+    public let usedPercent: Int
+
+    public var coverageRatio: Double {
+        guard isAvailable, actualRemaining > 0 else { return .infinity }
+        return estimatedRemaining / actualRemaining
+    }
+
+    public static let unavailable = UsagePaceAssessment(
+        isAvailable: false,
+        isAccelerated: false,
+        estimatedRemaining: 0,
+        estimatedTotal: 0,
+        actualRemaining: 0,
+        estimatedExhaustionAt: nil,
+        resetAt: nil,
+        observedDuration: 0,
+        usedPercent: 0
+    )
+}
+
+/// Estimates quota exhaustion from full-window usage and optional recent local history.
+public enum UsagePace {
+    public static func assess(
+        window: UsageWindow?,
+        history: UsageHistory? = nil,
+        observedAt: Date,
+        now: Date = Date(),
+        sensitivity: UsagePaceSensitivity = .balanced
+    ) -> UsagePaceAssessment {
+        let baseline = baselineAssessment(
+            window: window,
+            observedAt: observedAt,
+            now: now,
+            sensitivity: sensitivity
+        )
+        guard baseline.isAvailable,
+              let window,
+              let history,
+              history.observedBurnRate > 0 else {
+            return baseline
+        }
+
+        let averageRate = Double(window.usedPercent) / baseline.observedDuration
+        guard averageRate.isFinite, averageRate > 0 else {
+            return baseline
+        }
+        let observedRate = min(
+            averageRate * 4,
+            max(averageRate * 0.25, history.observedBurnRate)
+        )
+        let blendedRate = averageRate * 0.4 + observedRate * 0.6
+        guard blendedRate.isFinite, blendedRate > 0,
+              let resetAt = baseline.resetAt else {
+            return baseline
+        }
+
+        let remainingAtObservation = max(
+            0,
+            Double(100 - window.usedPercent) / blendedRate
+        )
+        let exhaustionAt = observedAt.addingTimeInterval(remainingAtObservation)
+        let estimatedRemaining = max(0, exhaustionAt.timeIntervalSince(now))
+        let estimatedTotal = baseline.observedDuration + remainingAtObservation
+        let policy = policy(for: sensitivity, windowDuration: TimeInterval(window.windowSeconds))
+        let accelerated = sensitivity != .off
+            && remainingAtObservation * 100
+                <= resetAt.timeIntervalSince(observedAt) * Double(policy.maximumCoveragePercent)
+
+        return UsagePaceAssessment(
+            isAvailable: true,
+            isAccelerated: accelerated,
+            estimatedRemaining: estimatedRemaining,
+            estimatedTotal: estimatedTotal,
+            actualRemaining: baseline.actualRemaining,
+            estimatedExhaustionAt: exhaustionAt,
+            resetAt: resetAt,
+            observedDuration: baseline.observedDuration,
+            usedPercent: window.usedPercent
+        )
+    }
+
+    public static func mostAcceleratedWindow(
+        in snapshot: UsageSnapshot?,
+        histories: [UsageHistoryKind: UsageHistory] = [:],
+        now: Date = Date(),
+        sensitivity: UsagePaceSensitivity = .balanced
+    ) -> UsagePaceWindow? {
+        guard sensitivity != .off, let snapshot else { return nil }
+        let fiveHour = assess(
+            window: snapshot.fiveHour,
+            history: histories[.fiveHour],
+            observedAt: snapshot.fetchedAt,
+            now: now,
+            sensitivity: sensitivity
+        )
+        let weekly = assess(
+            window: snapshot.weekly,
+            history: histories[.weekly],
+            observedAt: snapshot.fetchedAt,
+            now: now,
+            sensitivity: sensitivity
+        )
+        let monthly = assess(
+            window: snapshot.monthly,
+            history: histories[.monthly],
+            observedAt: snapshot.fetchedAt,
+            now: now,
+            sensitivity: sensitivity
+        )
+
+        let assessments: [(UsagePaceWindow, UsagePaceAssessment)] = [
+            (.fiveHour, fiveHour),
+            (.weekly, weekly),
+            (.monthly, monthly)
+        ]
+        return assessments
+            .filter(\.1.isAccelerated)
+            .min { $0.1.coverageRatio < $1.1.coverageRatio }?
+            .0
+    }
+
+    private static func baselineAssessment(
+        window: UsageWindow?,
+        observedAt: Date,
+        now: Date,
+        sensitivity: UsagePaceSensitivity
+    ) -> UsagePaceAssessment {
+        guard let window,
+              window.windowSeconds > 0,
+              observedAt.timeIntervalSince1970.isFinite,
+              observedAt.timeIntervalSince1970 > 0,
+              now.timeIntervalSince1970.isFinite,
+              let resetAt = window.effectiveResetDate(relativeTo: observedAt),
+              resetAt > observedAt,
+              resetAt > now else {
+            return .unavailable
+        }
+
+        let windowDuration = TimeInterval(window.windowSeconds)
+        let windowStart = resetAt.addingTimeInterval(-windowDuration)
+        let elapsed = observedAt.timeIntervalSince(windowStart)
+        guard elapsed.isFinite,
+              elapsed > 0,
+              elapsed <= windowDuration,
+              window.usedPercent > 0 else {
+            return .unavailable
+        }
+
+        let policy = policy(for: sensitivity, windowDuration: windowDuration)
+        guard elapsed >= policy.minimumElapsed,
+              window.usedPercent >= policy.minimumUsedPercent else {
+            return .unavailable
+        }
+
+        let estimatedRemainingAtObservation =
+            elapsed * Double(100 - window.usedPercent) / Double(window.usedPercent)
+        let estimatedTotal = elapsed * 100 / Double(window.usedPercent)
+        guard estimatedRemainingAtObservation.isFinite, estimatedTotal.isFinite else {
+            return .unavailable
+        }
+        let exhaustionAt = observedAt.addingTimeInterval(estimatedRemainingAtObservation)
+        let actualRemainingAtObservation = resetAt.timeIntervalSince(observedAt)
+        let accelerated = sensitivity != .off
+            && estimatedRemainingAtObservation * 100
+                <= actualRemainingAtObservation * Double(policy.maximumCoveragePercent)
+
+        return UsagePaceAssessment(
+            isAvailable: true,
+            isAccelerated: accelerated,
+            estimatedRemaining: max(0, exhaustionAt.timeIntervalSince(now)),
+            estimatedTotal: estimatedTotal,
+            actualRemaining: max(0, resetAt.timeIntervalSince(now)),
+            estimatedExhaustionAt: exhaustionAt,
+            resetAt: resetAt,
+            observedDuration: elapsed,
+            usedPercent: window.usedPercent
+        )
+    }
+
+    private static func policy(
+        for sensitivity: UsagePaceSensitivity,
+        windowDuration: TimeInterval
+    ) -> (
+        minimumUsedPercent: Int,
+        minimumElapsed: TimeInterval,
+        maximumCoveragePercent: Int
+    ) {
+        switch sensitivity {
+        case .sensitive:
+            (2, max(2 * 60, windowDuration / 400), 100)
+        case .relaxed:
+            (10, max(10 * 60, windowDuration / 100), 50)
+        case .off, .balanced:
+            (5, max(5 * 60, windowDuration / 200), 75)
+        }
+    }
+}

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsageParser.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsageParser.swift
@@ -3,6 +3,11 @@ import Foundation
 public enum UsageParser {
     private static let fiveHours: Int64 = 18_000
     private static let week: Int64 = 604_800
+    private static let month: Int64 = 2_592_000
+    /// Free-tier accounts report a single ~30-day Codex window; accept 10–45 days so calendar
+    /// months and drifting billing periods still classify while staying clear of the weekly
+    /// window's 9-day ceiling.
+    private static let monthRange: ClosedRange<Int64> = 864_000 ... 3_888_000
 
     public static func parse(_ string: String, fetchedAt: Date = Date()) throws -> UsageSnapshot {
         try parse(Data(string.utf8), fetchedAt: fetchedAt)
@@ -54,15 +59,15 @@ public enum UsageParser {
                 if additionalPrimary != nil || additionalSecondary != nil {
                     let name = JSONSupport.string(item["limit_name"])
                     let feature = JSONSupport.string(item["metered_feature"])
-                    let id = [
+                    let identity = [
                         JSONSupport.string(item["limit_id"]),
                         name,
                         feature,
-                        "additional-\(index)"
+                        "additional"
                     ].first { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }!
                     additionalLimits.append(
                         UsageLimit(
-                            id: "\(id)-\(index)",
+                            id: "\(identity)-\(index)",
                             name: name,
                             meteredFeature: feature,
                             allowed: JSONSupport.bool(nested["allowed"], default: true),
@@ -79,20 +84,26 @@ public enum UsageParser {
             in: primaryCandidates,
             target: fiveHours,
             range: 10_800 ... 28_800,
-            excluding: nil
+            excluding: []
         )
         let weekly = nearest(
             in: primaryCandidates,
             target: week,
             range: 432_000 ... 777_600,
-            excluding: fiveHour?.id
+            excluding: fiveHour.map { [$0.id] } ?? []
+        )
+        let monthly = nearest(
+            in: primaryCandidates,
+            target: month,
+            range: monthRange,
+            excluding: [fiveHour?.id, weekly?.id].compactMap { $0 }
         )
 
         let resetCredits = JSONSupport.object(root["rate_limit_reset_credits"])
         let rawAvailableCount = resetCredits.map {
             JSONSupport.int($0["available_count"], default: -1)
         } ?? -1
-        let usageCredits = JSONSupport.object(root["credits"]).flatMap { credits in
+        let usageCredits: UsageCredits? = JSONSupport.object(root["credits"]).flatMap { credits in
             guard credits.keys.contains("has_credits")
                     || credits.keys.contains("unlimited")
                     || credits.keys.contains("balance") else {
@@ -117,6 +128,7 @@ public enum UsageParser {
             limitReached: limitReached,
             fiveHour: fiveHour?.window,
             weekly: weekly?.window,
+            monthly: monthly?.window,
             resetCreditsAvailable: rawAvailableCount >= 0 ? rawAvailableCount : nil,
             additionalLimits: additionalLimits,
             usageCredits: usageCredits,
@@ -172,13 +184,13 @@ public enum UsageParser {
         in candidates: [Candidate],
         target: Int64,
         range: ClosedRange<Int64>,
-        excluding excludedID: Int?
+        excluding excludedIDs: [Int]
     ) -> Candidate? {
         var best: Candidate?
         var bestDistance = Int64.max
 
         for candidate in candidates
-        where candidate.id != excludedID && range.contains(candidate.window.windowSeconds) {
+        where !excludedIDs.contains(candidate.id) && range.contains(candidate.window.windowSeconds) {
             let distance = absoluteDifference(candidate.window.windowSeconds, target)
             if distance < bestDistance {
                 best = candidate

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsageParser.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsageParser.swift
@@ -80,24 +80,37 @@ public enum UsageParser {
             }
         }
 
-        let fiveHour = nearest(
+        var fiveHour = nearest(
             in: primaryCandidates,
             target: fiveHours,
             range: 10_800 ... 28_800,
             excluding: []
         )
-        let weekly = nearest(
+        var weekly = nearest(
             in: primaryCandidates,
             target: week,
             range: 432_000 ... 777_600,
             excluding: fiveHour.map { [$0.id] } ?? []
         )
-        let monthly = nearest(
+        var monthly = nearest(
             in: primaryCandidates,
             target: month,
             range: monthRange,
             excluding: [fiveHour?.id, weekly?.id].compactMap { $0 }
         )
+
+        // Go and similar plans sometimes report a single window just outside the
+        // standard 5-hour / weekly / 10–45-day buckets. Keep that window visible.
+        if fiveHour == nil, weekly == nil, monthly == nil,
+           let leftover = longest(in: primaryCandidates, excluding: []) {
+            if leftover.window.windowSeconds >= monthRange.lowerBound {
+                monthly = leftover
+            } else if leftover.window.windowSeconds >= 86_400 {
+                weekly = leftover
+            } else {
+                fiveHour = leftover
+            }
+        }
 
         let resetCredits = JSONSupport.object(root["rate_limit_reset_credits"])
         let rawAvailableCount = resetCredits.map {
@@ -198,6 +211,15 @@ public enum UsageParser {
             }
         }
         return best
+    }
+
+    private static func longest(
+        in candidates: [Candidate],
+        excluding excludedIDs: [Int]
+    ) -> Candidate? {
+        candidates
+            .filter { !excludedIDs.contains($0.id) }
+            .max { $0.window.windowSeconds < $1.window.windowSeconds }
     }
 
     private static func absoluteDifference(_ lhs: Int64, _ rhs: Int64) -> Int64 {

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsageStats.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsageStats.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// Pure aggregation over locally recorded usage samples: per-window statistics,
+/// cross-window typical pace, and time interpolation for chart scrubbing.
+public enum UsageStats {
+    /// Consecutive samples closer than this are too jittery for a burn-rate reading.
+    private static let minimumRateSpacing: TimeInterval = 60
+
+    /// Statistics for one reset window's recorded samples.
+    public struct WindowStats: Sendable, Equatable {
+        public let windowStart: Date
+        public let resetAt: Date
+        public let firstSampleAt: Date
+        public let lastSampleAt: Date
+        public let firstPercent: Int
+        public let finalPercent: Int
+        public let sampleCount: Int
+        /// Average burn in percent per hour across the observed sample span.
+        public let averageBurnPercentPerHour: Double
+        /// Steepest observed burn in percent per hour between adjacent samples.
+        public let peakBurnPercentPerHour: Double
+        public let exhausted: Bool
+        public let complete: Bool
+    }
+
+    /// Builds statistics for one window's samples, or `nil` when samples are unusable.
+    public static func windowStats(samples: [UsageSample], complete: Bool) -> WindowStats? {
+        guard let first = samples.first, let last = samples.last else { return nil }
+        let windowStart = last.resetAt.addingTimeInterval(-TimeInterval(last.windowSeconds))
+        var averageRate = 0.0
+        let span = last.observedAt.timeIntervalSince(first.observedAt)
+        let burned = last.usedPercent - first.usedPercent
+        if span > 0, burned > 0 {
+            averageRate = Double(burned) / hours(span)
+        }
+        var peakRate = 0.0
+        if samples.count > 1 {
+            for index in 1..<samples.count {
+                let previous = samples[index - 1]
+                let current = samples[index]
+                let gap = current.observedAt.timeIntervalSince(previous.observedAt)
+                let delta = current.usedPercent - previous.usedPercent
+                guard gap >= minimumRateSpacing, delta > 0 else { continue }
+                peakRate = max(peakRate, Double(delta) / hours(gap))
+            }
+        }
+        return WindowStats(
+            windowStart: windowStart,
+            resetAt: last.resetAt,
+            firstSampleAt: first.observedAt,
+            lastSampleAt: last.observedAt,
+            firstPercent: first.usedPercent,
+            finalPercent: last.usedPercent,
+            sampleCount: samples.count,
+            averageBurnPercentPerHour: averageRate,
+            peakBurnPercentPerHour: peakRate,
+            exhausted: last.usedPercent >= 100,
+            complete: complete
+        )
+    }
+
+    /// Per-window statistics, oldest to newest; the final entry is the current window.
+    public static func windowBreakdown(_ history: UsageHistory?, maximumWindows: Int) -> [WindowStats] {
+        guard let history else { return [] }
+        let windows = history.recentWindows(maximum: maximumWindows)
+        return windows.enumerated().compactMap { index, samples in
+            windowStats(samples: samples, complete: index < windows.count - 1)
+        }
+    }
+
+    /// Linearly interpolated used percent at a moment in time, or `nil` when the moment
+    /// falls outside the observed sample span.
+    public static func usedPercent(at date: Date, in samples: [UsageSample]) -> Double? {
+        guard let first = samples.first, let last = samples.last else { return nil }
+        guard date >= first.observedAt, date <= last.observedAt else { return nil }
+        if samples.count == 1 {
+            return Double(first.usedPercent)
+        }
+        for index in 1..<samples.count {
+            let left = samples[index - 1]
+            let right = samples[index]
+            guard date <= right.observedAt else { continue }
+            let span = right.observedAt.timeIntervalSince(left.observedAt)
+            if span <= 0 {
+                return Double(right.usedPercent)
+            }
+            let ratio = date.timeIntervalSince(left.observedAt) / span
+            return Double(left.usedPercent)
+                + Double(right.usedPercent - left.usedPercent) * ratio
+        }
+        return Double(last.usedPercent)
+    }
+
+    /// Typical used percent at an elapsed fraction of the window (0...1), averaged across
+    /// completed windows. Returns `nil` when no completed window covers that fraction.
+    public static func typicalUsedPercent(in history: UsageHistory?, atElapsedFraction fraction: Double) -> Double? {
+        guard let history else { return nil }
+        let clamped = min(1, max(0, fraction))
+        let windows = history.recentWindows(maximum: .max)
+        guard windows.count > 1 else { return nil }
+        var total = 0.0
+        var counted = 0
+        for window in windows.dropLast() {
+            guard window.count >= 2, let reference = window.last, let first = window.first else {
+                continue
+            }
+            let windowStart = reference.resetAt.addingTimeInterval(-TimeInterval(reference.windowSeconds))
+            let moment = windowStart.addingTimeInterval(clamped * TimeInterval(reference.windowSeconds))
+            let value: Double
+            if let interpolated = usedPercent(at: moment, in: window) {
+                value = interpolated
+            } else {
+                value = moment < first.observedAt
+                    ? Double(first.usedPercent)
+                    : Double(reference.usedPercent)
+            }
+            total += value
+            counted += 1
+        }
+        return counted == 0 ? nil : total / Double(counted)
+    }
+
+    /// Average final used percent across completed windows, or `nil` when none exist.
+    public static func averageFinalPercent(_ history: UsageHistory?) -> Double? {
+        guard let history else { return nil }
+        let windows = history.recentWindows(maximum: .max)
+        let completed = windows.dropLast().compactMap(\.last)
+        guard !completed.isEmpty else { return nil }
+        let total = completed.reduce(0) { $0 + $1.usedPercent }
+        return Double(total) / Double(completed.count)
+    }
+
+    /// Steepest burn observed across every recorded window, or 0 when unavailable.
+    public static func peakBurnPercentPerHour(_ history: UsageHistory?) -> Double {
+        windowBreakdown(history, maximumWindows: .max)
+            .map(\.peakBurnPercentPerHour)
+            .max() ?? 0
+    }
+
+    public static func formatRate(_ percentPerHour: Double) -> String {
+        if percentPerHour >= 10 {
+            return "\(Int(percentPerHour.rounded()))%/h"
+        }
+        return String(format: "%.1f%%/h", percentPerHour)
+    }
+
+    private static func hours(_ interval: TimeInterval) -> Double {
+        interval / 3_600
+    }
+}

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/AdaptiveRefreshPolicyTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/AdaptiveRefreshPolicyTests.swift
@@ -3,14 +3,14 @@ import XCTest
 @testable import CodexMeterCore
 
 final class AdaptiveRefreshPolicyTests: XCTestCase {
-    func testQuotaAttentionResetQuietHoursAndFailureBackoff() {
+    func testQuotaPaceAttentionResetQuietHoursAndFailureBackoff() {
         let now = Date(timeIntervalSince1970: 2_000_000_000)
         let healthy = UsageWindow(
             usedPercent: 5,
             windowSeconds: 18_000,
             resetAt: now.addingTimeInterval(4 * 60 * 60)
         )
-        let medium = UsageWindow(
+        let accelerated = UsageWindow(
             usedPercent: 60,
             windowSeconds: 18_000,
             resetAt: now.addingTimeInterval(3 * 60 * 60)
@@ -28,7 +28,7 @@ final class AdaptiveRefreshPolicyTests: XCTestCase {
 
         XCTAssertEqual(choose(nil), 30)
         XCTAssertEqual(choose(snapshot(healthy), hour: 12), 60)
-        XCTAssertEqual(choose(snapshot(medium), hour: 12), 15)
+        XCTAssertEqual(choose(snapshot(accelerated), hour: 12), 10)
         XCTAssertEqual(choose(snapshot(low), hour: 12), 5)
         XCTAssertEqual(choose(snapshot(healthy), attention: 3, hour: 12), 10)
         XCTAssertEqual(choose(snapshot(healthy), hour: 3), 120)
@@ -68,5 +68,33 @@ final class AdaptiveRefreshPolicyTests: XCTestCase {
                 fetchedAt: now
             )
         }
+    }
+
+    func testExpiredWindowsAndNonFiniteAttentionAreIgnored() {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let expired = UsageWindow(
+            usedPercent: 99,
+            windowSeconds: 18_000,
+            resetAt: now.addingTimeInterval(-1)
+        )
+        let snapshot = UsageSnapshot(
+            planType: "plus",
+            allowed: true,
+            limitReached: false,
+            fiveHour: expired,
+            weekly: nil,
+            fetchedAt: now.addingTimeInterval(-60)
+        )
+
+        XCTAssertEqual(
+            AdaptiveRefreshPolicy.chooseMinutes(
+                snapshot: snapshot,
+                attentionScore: .nan,
+                localHour: 12,
+                consecutiveFailures: -10,
+                now: now
+            ),
+            30
+        )
     }
 }

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/DashboardSectionsTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/DashboardSectionsTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import CodexMeterCore
+
+final class DashboardSectionsTests: XCTestCase {
+    func testStableLimitKeysAndDefaultOrder() {
+        let first = UsageLimit(
+            id: "Model,One",
+            name: "First",
+            primary: UsageWindow(usedPercent: 1, windowSeconds: 18_000),
+            secondary: nil
+        )
+        let duplicate = UsageLimit(
+            id: "model,one",
+            name: "Duplicate",
+            primary: UsageWindow(usedPercent: 2, windowSeconds: 18_000),
+            secondary: nil
+        )
+        let fallback = UsageLimit(
+            id: "",
+            meteredFeature: "codex_spark",
+            primary: nil,
+            secondary: UsageWindow(usedPercent: 3, windowSeconds: 604_800)
+        )
+
+        XCTAssertEqual(DashboardSections.limitKey(first), "limit:model_one")
+        XCTAssertEqual(DashboardSections.limitKey(fallback), "limit:codex_spark")
+        XCTAssertTrue(DashboardSections.isLimitKey("limit:anything"))
+        XCTAssertFalse(DashboardSections.isLimitKey(DashboardSections.fiveHour))
+        XCTAssertEqual(
+            DashboardSections.defaultOrder(additionalLimits: [first, duplicate, fallback]),
+            [
+                DashboardSections.fiveHour,
+                DashboardSections.weekly,
+                DashboardSections.monthly,
+                "limit:model_one",
+                "limit:codex_spark",
+                DashboardSections.usageCredits,
+                DashboardSections.usageHistory,
+                DashboardSections.resetCredits
+            ]
+        )
+    }
+
+    func testSavedOrderMergesNewKeysAndDropsUnavailableKeys() {
+        let available = [
+            DashboardSections.fiveHour,
+            DashboardSections.weekly,
+            DashboardSections.monthly,
+            "limit:spark",
+            DashboardSections.usageCredits,
+            DashboardSections.usageHistory,
+            DashboardSections.resetCredits
+        ]
+        XCTAssertEqual(
+            DashboardSections.resolveOrder(
+                saved: [
+                    DashboardSections.usageHistory,
+                    DashboardSections.fiveHour,
+                    "missing",
+                    DashboardSections.usageHistory
+                ],
+                available: available
+            ),
+            [
+                DashboardSections.usageHistory,
+                DashboardSections.fiveHour,
+                DashboardSections.weekly,
+                DashboardSections.monthly,
+                "limit:spark",
+                DashboardSections.usageCredits,
+                DashboardSections.resetCredits
+            ]
+        )
+        XCTAssertEqual(
+            DashboardSections.resolveOrder(saved: [], available: available),
+            available
+        )
+    }
+
+    func testHiddenSectionCSVRoundTrip() {
+        var hidden = DashboardSections.settingHidden(
+            " limit:one,limit:one ",
+            key: "limit:two",
+            hidden: true
+        )
+        XCTAssertEqual(hidden, "limit:one,limit:two")
+        XCTAssertTrue(DashboardSections.isHidden(hidden, key: "limit:two"))
+
+        hidden = DashboardSections.settingHidden(hidden, key: "limit:one", hidden: false)
+        XCTAssertEqual(hidden, "limit:two")
+        XCTAssertEqual(
+            DashboardSections.resolveOrder(
+                savedCSV: "weekly,five_hour",
+                available: ["five_hour", "weekly"]
+            ),
+            ["weekly", "five_hour"]
+        )
+    }
+}

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/HistoryAnalyticsAndDiagnosticsTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/HistoryAnalyticsAndDiagnosticsTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import XCTest
+@testable import CodexMeterCore
+
+final class HistoryAnalyticsAndDiagnosticsTests: XCTestCase {
+    func testHistorySectionsDefaultsAndOverrideCSV() {
+        XCTAssertEqual(HistorySections.all.count, 7)
+        XCTAssertFalse(HistorySections.defaultVisible(HistorySections.guide))
+        XCTAssertTrue(HistorySections.defaultVisible(HistorySections.windowList))
+        XCTAssertTrue(HistorySections.defaultVisible(HistorySections.valueEstimates))
+        XCTAssertTrue(HistorySections.isVisible("", key: HistorySections.insightPace))
+        XCTAssertFalse(HistorySections.isVisible(nil, key: HistorySections.guide))
+
+        var overrides = HistorySections.setVisible("", key: HistorySections.guide, visible: true)
+        XCTAssertTrue(HistorySections.isVisible(overrides, key: HistorySections.guide))
+        overrides = HistorySections.setVisible(
+            overrides,
+            key: HistorySections.valueEstimates,
+            visible: false
+        )
+        XCTAssertFalse(HistorySections.isVisible(overrides, key: HistorySections.valueEstimates))
+        XCTAssertTrue(HistorySections.isVisible(overrides, key: HistorySections.insightPeak))
+
+        overrides = HistorySections.setVisible(overrides, key: HistorySections.guide, visible: false)
+        overrides = HistorySections.setVisible(
+            overrides,
+            key: HistorySections.valueEstimates,
+            visible: true
+        )
+        XCTAssertEqual(
+            HistorySections.setVisible("guide, guide ,", key: HistorySections.windowList, visible: true),
+            "guide"
+        )
+
+        var minimal = ""
+        for key in HistorySections.all {
+            minimal = HistorySections.setVisible(minimal, key: key, visible: false)
+            XCTAssertFalse(HistorySections.label(key).isEmpty)
+        }
+        for key in HistorySections.all {
+            XCTAssertFalse(HistorySections.isVisible(minimal, key: key))
+        }
+    }
+
+    func testPlanPricingAnchorsAndFormatting() {
+        XCTAssertNil(PlanPricing.forPlan(nil))
+        XCTAssertNil(PlanPricing.forPlan("free"))
+        XCTAssertNil(PlanPricing.forPlan("go"))
+        XCTAssertNil(PlanPricing.forPlan("enterprise"))
+
+        let plus = try! XCTUnwrap(PlanPricing.forPlan("plus"))
+        XCTAssertEqual(plus.monthlyPriceUsd, 20)
+        XCTAssertEqual(plus.monthlyValueUsd, 700)
+        XCTAssertEqual(plus.weeklyValueUsd, 175)
+        XCTAssertEqual(plus.fiveHourValueUsd, 175.0 / 6.0, accuracy: 0.000_000_1)
+
+        let pro5x = try! XCTUnwrap(PlanPricing.forPlan("pro_5x"))
+        XCTAssertEqual(pro5x.monthlyValueUsd, 3_500)
+        XCTAssertEqual(PlanPricing.forPlan("prolite")?.monthlyValueUsd, 3_500)
+
+        let pro20x = try! XCTUnwrap(PlanPricing.forPlan("pro"))
+        XCTAssertEqual(pro20x.monthlyPriceUsd, 200)
+        XCTAssertEqual(pro20x.monthlyValueUsd, 14_000)
+        XCTAssertEqual(pro20x.windowValueUsd(for: .monthly), 14_000)
+        XCTAssertEqual(pro20x.estimatedValueUsd(for: .weekly, usedPercent: 50), 1_750)
+
+        XCTAssertEqual(PlanPricing.formatUsd(3_500), "$3,500")
+        XCTAssertEqual(PlanPricing.formatUsd(29.2), "$29")
+        XCTAssertEqual(PlanPricing.formatUsd(4.2), "$4.20")
+        XCTAssertEqual(PlanPricing.formatUsd(-3), "$0.00")
+    }
+
+    func testUsageStatsWindowBreakdownTypicalAndPeak() {
+        let base = Date(timeIntervalSince1970: 2_000_000_000)
+        var history = UsageHistory.empty(.fiveHour)
+        let firstReset = base.addingTimeInterval(5 * 60 * 60)
+        history = history.appending(
+            window: UsageWindow(usedPercent: 10, windowSeconds: 18_000, resetAt: firstReset),
+            observedAt: base
+        )
+        history = history.appending(
+            window: UsageWindow(usedPercent: 70, windowSeconds: 18_000, resetAt: firstReset),
+            observedAt: base.addingTimeInterval(30 * 60)
+        )
+        history = history.appending(
+            window: UsageWindow(usedPercent: 90, windowSeconds: 18_000, resetAt: firstReset),
+            observedAt: base.addingTimeInterval(4 * 60 * 60)
+        )
+        let secondReset = firstReset.addingTimeInterval(5 * 60 * 60)
+        history = history.appending(
+            window: UsageWindow(usedPercent: 20, windowSeconds: 18_000, resetAt: secondReset),
+            observedAt: firstReset.addingTimeInterval(10 * 60)
+        )
+
+        let breakdown = UsageStats.windowBreakdown(history, maximumWindows: 5)
+        XCTAssertEqual(breakdown.count, 2)
+        let completed = try! XCTUnwrap(breakdown.first)
+        XCTAssertTrue(completed.complete)
+        XCTAssertEqual(completed.finalPercent, 90)
+        XCTAssertGreaterThan(completed.peakBurnPercentPerHour, completed.averageBurnPercentPerHour)
+
+        let typical = try! XCTUnwrap(UsageStats.typicalUsedPercent(in: history, atElapsedFraction: 0.6))
+        XCTAssertGreaterThan(typical, 0)
+        XCTAssertNil(UsageStats.typicalUsedPercent(in: .empty(.fiveHour), atElapsedFraction: 0.5))
+        XCTAssertEqual(UsageStats.averageFinalPercent(history) ?? -1, 90, accuracy: 0.01)
+        XCTAssertGreaterThan(UsageStats.peakBurnPercentPerHour(history), 0)
+    }
+
+    func testResetWindowToleranceDedupesLowUsageAnnouncements() {
+        let reset = Date(timeIntervalSince1970: 2_000_000_000)
+        XCTAssertTrue(
+            UsageWindow.sameResetWindow(
+                leftReset: reset,
+                leftWindowSeconds: 18_000,
+                rightReset: reset.addingTimeInterval(60),
+                rightWindowSeconds: 18_000
+            )
+        )
+        XCTAssertFalse(
+            UsageWindow.sameResetWindow(
+                leftReset: reset,
+                leftWindowSeconds: 18_000,
+                rightReset: reset.addingTimeInterval(20 * 60),
+                rightWindowSeconds: 18_000
+            )
+        )
+        XCTAssertFalse(
+            UsageWindow.shouldAnnounceLowUsage(
+                lastAnnouncedReset: reset,
+                currentReset: reset.addingTimeInterval(1),
+                windowSeconds: 18_000
+            )
+        )
+        XCTAssertTrue(
+            UsageWindow.shouldAnnounceLowUsage(
+                lastAnnouncedReset: reset,
+                currentReset: reset.addingTimeInterval(20 * 60),
+                windowSeconds: 18_000
+            )
+        )
+    }
+
+    func testDiagnosticSanitizerRedactsCredentialsEmailsJWTsAndQueryParams() {
+        let jwt = "abcdefghijklmnop.qrstuvwxyzABCDE.FGHIJKLMNOP"
+        let input = "Authorization: Bearer top-secret "
+            + "access_token=\"access-secret\" refresh_token=refresh-secret "
+            + "Cookie: session=private-cookie email=user@example.com jwt=" + jwt + " "
+            + "https://example.com/callback?code=oauth-code&state=oauth-state"
+        let redacted = DiagnosticSanitizer.redact(input)
+        XCTAssertFalse(redacted.contains("top-secret"))
+        XCTAssertFalse(redacted.contains("access-secret"))
+        XCTAssertFalse(redacted.contains("refresh-secret"))
+        XCTAssertFalse(redacted.contains("private-cookie"))
+        XCTAssertFalse(redacted.contains("user@example.com"))
+        XCTAssertFalse(redacted.contains(jwt))
+        XCTAssertFalse(redacted.contains("oauth-code"))
+        XCTAssertFalse(redacted.contains("oauth-state"))
+        XCTAssertTrue(redacted.contains("[REDACTED]"))
+        XCTAssertEqual(
+            DiagnosticSanitizer.safeURL(
+                "https://example.com:8443/path/to/resource?token=secret#fragment"
+            ),
+            "https://example.com:8443/path/to/resource"
+        )
+        XCTAssertEqual(
+            DiagnosticSanitizer.redact("The authorization server returned an error."),
+            "The authorization server returned an error."
+        )
+    }
+}

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/ModelsAndFormattingTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/ModelsAndFormattingTests.swift
@@ -39,37 +39,72 @@ final class ModelsAndFormattingTests: XCTestCase {
             fetchedAt: now
         )
         XCTAssertEqual(snapshot.resetCreditsAvailable, 0)
-        // Relative-only five-hour reset (now+60) precedes weekly absolute reset (now+120).
         XCTAssertEqual(snapshot.nextReset(after: now), now.addingTimeInterval(60))
         XCTAssertTrue(snapshot.isStale(at: now.addingTimeInterval(61), maxAge: 60))
     }
 
-    func testNextResetUsesRelativeResetAfterSecondsWhenAbsoluteMissing() {
+    func testAdaptiveUsageModelsAndNextResetAcrossEveryLimit() {
         let now = Date(timeIntervalSince1970: 5_000)
+        let standard = UsageWindow(
+            usedPercent: 10,
+            windowSeconds: 18_000,
+            resetAfterSeconds: 600
+        )
+        let additional = UsageWindow(
+            usedPercent: 20,
+            windowSeconds: 3_600,
+            resetAfterSeconds: 120
+        )
+        let limit = UsageLimit(
+            id: " spark ",
+            meteredFeature: "codex_bengalfox",
+            primary: additional,
+            secondary: nil
+        )
         let snapshot = UsageSnapshot(
             planType: "plus",
             allowed: true,
             limitReached: false,
-            fiveHour: UsageWindow(
-                usedPercent: 10,
-                windowSeconds: 18_000,
-                resetAfterSeconds: 90,
-                resetAt: nil
-            ),
-            weekly: UsageWindow(
-                usedPercent: 20,
-                windowSeconds: 604_800,
-                resetAfterSeconds: 360,
-                resetAt: nil
-            ),
+            fiveHour: standard,
+            weekly: nil,
+            additionalLimits: [limit, UsageLimit(id: "empty", primary: nil, secondary: nil)],
+            usageCredits: UsageCredits(hasCredits: true, unlimited: false, balance: "10"),
             fetchedAt: now
         )
-        XCTAssertEqual(snapshot.nextReset(after: now), now.addingTimeInterval(90))
-        XCTAssertEqual(
-            snapshot.nextReset(after: now.addingTimeInterval(120)),
-            now.addingTimeInterval(360)
+
+        XCTAssertEqual(limit.id, "spark")
+        XCTAssertEqual(limit.displayName, "Codex Bengalfox")
+        XCTAssertEqual(snapshot.additionalLimits.count, 1)
+        XCTAssertEqual(snapshot.nextReset(after: now), now.addingTimeInterval(120))
+        XCTAssertTrue(snapshot.hasDisplayableData)
+    }
+
+    func testUsageCreditVisibilityThresholdAndNumericParsing() {
+        XCTAssertFalse(
+            UsageCredits(hasCredits: false, unlimited: false, balance: "100").shouldDisplay
         )
-        XCTAssertNil(snapshot.nextReset(after: now.addingTimeInterval(400)))
+        XCTAssertTrue(
+            UsageCredits(hasCredits: false, unlimited: true, balance: nil).shouldDisplay
+        )
+        XCTAssertTrue(
+            UsageCredits(hasCredits: true, unlimited: false, balance: nil).shouldDisplay
+        )
+        XCTAssertFalse(
+            UsageCredits(hasCredits: true, unlimited: false, balance: "-1").shouldDisplay
+        )
+        XCTAssertFalse(
+            UsageCredits(hasCredits: true, unlimited: false, balance: "0.0049").shouldDisplay
+        )
+        XCTAssertTrue(
+            UsageCredits(hasCredits: true, unlimited: false, balance: "0.005").shouldDisplay
+        )
+        XCTAssertEqual(
+            UsageCredits(hasCredits: true, unlimited: false, balance: "2,500.5").numericBalance,
+            Decimal(string: "2500.5")
+        )
+        XCTAssertTrue(
+            UsageCredits(hasCredits: true, unlimited: false, balance: "pending").shouldDisplay
+        )
     }
 
     func testSharedSnapshotIsSanitizedAndCodable() throws {
@@ -146,44 +181,6 @@ final class ModelsAndFormattingTests: XCTestCase {
             ),
             .stale
         )
-    }
-
-    func testUsageAndResetCreditsAutoHide() {
-        XCTAssertTrue(UsageCredits(hasCredits: true, unlimited: false, balance: "2500").shouldDisplay)
-        XCTAssertTrue(UsageCredits(hasCredits: true, unlimited: false, balance: "0.01").shouldDisplay)
-        XCTAssertTrue(UsageCredits(hasCredits: false, unlimited: true, balance: nil).shouldDisplay)
-        XCTAssertTrue(UsageCredits(hasCredits: true, unlimited: false, balance: nil).shouldDisplay)
-        XCTAssertTrue(UsageCredits(hasCredits: true, unlimited: false, balance: "12k credits").shouldDisplay)
-        XCTAssertFalse(UsageCredits(hasCredits: true, unlimited: false, balance: "0").shouldDisplay)
-        XCTAssertFalse(UsageCredits(hasCredits: true, unlimited: false, balance: "0.00").shouldDisplay)
-        XCTAssertFalse(UsageCredits(hasCredits: true, unlimited: false, balance: "0.004").shouldDisplay)
-        XCTAssertFalse(UsageCredits(hasCredits: true, unlimited: false, balance: "-12.5").shouldDisplay)
-        XCTAssertFalse(UsageCredits(hasCredits: false, unlimited: false, balance: "500").shouldDisplay)
-
-        XCTAssertTrue(ResetCreditsSnapshot.summary(availableCount: 2, fetchedAt: .now).shouldDisplay)
-        XCTAssertFalse(ResetCreditsSnapshot.summary(availableCount: 0, fetchedAt: .now).shouldDisplay)
-
-        let zeroResetsOnly = UsageSnapshot(
-            planType: "plus",
-            allowed: true,
-            limitReached: false,
-            fiveHour: nil,
-            weekly: nil,
-            resetCreditsAvailable: 0,
-            fetchedAt: Date(timeIntervalSince1970: 1)
-        )
-        XCTAssertFalse(zeroResetsOnly.hasDisplayableData)
-
-        let positiveResetsOnly = UsageSnapshot(
-            planType: "plus",
-            allowed: true,
-            limitReached: false,
-            fiveHour: nil,
-            weekly: nil,
-            resetCreditsAvailable: 3,
-            fetchedAt: Date(timeIntervalSince1970: 1)
-        )
-        XCTAssertTrue(positiveResetsOnly.hasDisplayableData)
     }
 
     func testResetOutcomeMessagesAndRoundTrip() throws {

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageHistoryAndPaceTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageHistoryAndPaceTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import XCTest
+@testable import CodexMeterCore
+
+final class UsageHistoryAndPaceTests: XCTestCase {
+    func testHistoryDedupesGroupsWindowsAndCalculatesBurn() {
+        let base = Date(timeIntervalSince1970: 2_000_000_000)
+        let reset = base.addingTimeInterval(4 * 60 * 60)
+        var history = UsageHistory.empty(.fiveHour)
+
+        history = history.appending(
+            window: window(used: 10, reset: reset),
+            observedAt: base
+        )
+        history = history.appending(
+            window: window(used: 10, reset: reset),
+            observedAt: base.addingTimeInterval(2 * 60)
+        )
+        XCTAssertEqual(history.samples.count, 1)
+        XCTAssertEqual(history.samples.first?.observedAt, base.addingTimeInterval(2 * 60))
+
+        history = history.appending(
+            window: window(used: 12, reset: reset),
+            observedAt: base.addingTimeInterval(10 * 60)
+        )
+        history = history.appending(
+            window: window(used: 20, reset: reset),
+            observedAt: base.addingTimeInterval(22 * 60)
+        )
+        XCTAssertEqual(history.currentWindowSamples.count, 3)
+        XCTAssertEqual(history.observedBurnRate, 10.0 / (20 * 60), accuracy: 0.000_000_1)
+
+        let nextReset = base.addingTimeInterval(24 * 60 * 60)
+        history = history.appending(
+            window: window(used: 3, reset: nextReset),
+            observedAt: base.addingTimeInterval(3 * 60 * 60)
+        )
+        XCTAssertEqual(history.completedWindowCount, 1)
+        XCTAssertEqual(history.currentWindowSamples.map(\.usedPercent), [3])
+        XCTAssertEqual(history.recentWindows(maximum: 1).count, 1)
+        XCTAssertEqual(history.recentWindows(maximum: 2).map(\.count), [3, 1])
+
+        func window(used: Int, reset: Date) -> UsageWindow {
+            UsageWindow(
+                usedPercent: used,
+                windowSeconds: 18_000,
+                resetAt: reset
+            )
+        }
+    }
+
+    func testHistoryIsBoundedAndCodable() throws {
+        let base = Date(timeIntervalSince1970: 2_000_000_000)
+        let reset = base.addingTimeInterval(10 * 24 * 60 * 60)
+        var history = UsageHistory.empty(.fiveHour)
+        for index in 0..<300 {
+            history = history.appending(
+                window: UsageWindow(
+                    usedPercent: index % 100,
+                    windowSeconds: 18_000,
+                    resetAt: reset
+                ),
+                observedAt: base.addingTimeInterval(TimeInterval(index * 60))
+            )
+        }
+        XCTAssertEqual(history.samples.count, 288)
+
+        let encoded = try JSONEncoder().encode(history)
+        XCTAssertEqual(try JSONDecoder().decode(UsageHistory.self, from: encoded), history)
+    }
+
+    func testPaceAssessmentUsesSensitivityAndRecentHistory() {
+        let observedAt = Date(timeIntervalSince1970: 2_000_000_000)
+        let reset = observedAt.addingTimeInterval(3 * 60 * 60)
+        let current = UsageWindow(
+            usedPercent: 50,
+            windowSeconds: 18_000,
+            resetAt: reset
+        )
+        let baseline = UsagePace.assess(
+            window: current,
+            observedAt: observedAt,
+            now: observedAt
+        )
+        XCTAssertTrue(baseline.isAvailable)
+
+        var history = UsageHistory.empty(.fiveHour)
+        history = history.appending(
+            window: UsageWindow(
+                usedPercent: 30,
+                windowSeconds: 18_000,
+                resetAt: reset
+            ),
+            observedAt: observedAt.addingTimeInterval(-20 * 60)
+        )
+        history = history.appending(window: current, observedAt: observedAt)
+        let trendAware = UsagePace.assess(
+            window: current,
+            history: history,
+            observedAt: observedAt,
+            now: observedAt
+        )
+        XCTAssertTrue(trendAware.isAvailable)
+        XCTAssertLessThan(trendAware.estimatedRemaining, baseline.estimatedRemaining)
+
+        let fast = UsageWindow(
+            usedPercent: 90,
+            windowSeconds: 18_000,
+            resetAt: observedAt.addingTimeInterval(60 * 60)
+        )
+        XCTAssertTrue(
+            UsagePace.assess(
+                window: fast,
+                observedAt: observedAt,
+                now: observedAt,
+                sensitivity: .balanced
+            ).isAccelerated
+        )
+        XCTAssertFalse(
+            UsagePace.assess(
+                window: fast,
+                observedAt: observedAt,
+                now: observedAt,
+                sensitivity: .off
+            ).isAccelerated
+        )
+        XCTAssertFalse(
+            UsagePace.assess(
+                window: UsageWindow(
+                    usedPercent: 1,
+                    windowSeconds: 18_000,
+                    resetAt: observedAt.addingTimeInterval(60 * 60)
+                ),
+                observedAt: observedAt,
+                now: observedAt
+            ).isAvailable
+        )
+    }
+
+    func testMostAcceleratedWindowSelectsTheMostUrgentAssessment() {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let snapshot = UsageSnapshot(
+            planType: "plus",
+            allowed: true,
+            limitReached: false,
+            fiveHour: UsageWindow(
+                usedPercent: 90,
+                windowSeconds: 18_000,
+                resetAt: now.addingTimeInterval(60 * 60)
+            ),
+            weekly: UsageWindow(
+                usedPercent: 20,
+                windowSeconds: 604_800,
+                resetAt: now.addingTimeInterval(4 * 24 * 60 * 60)
+            ),
+            fetchedAt: now
+        )
+
+        XCTAssertEqual(
+            UsagePace.mostAcceleratedWindow(in: snapshot, now: now),
+            .fiveHour
+        )
+
+        let monthlySnapshot = UsageSnapshot(
+            planType: "free",
+            allowed: true,
+            limitReached: false,
+            fiveHour: nil,
+            weekly: nil,
+            monthly: UsageWindow(
+                usedPercent: 90,
+                windowSeconds: 2_592_000,
+                resetAt: now.addingTimeInterval(20 * 24 * 60 * 60)
+            ),
+            fetchedAt: now
+        )
+        XCTAssertEqual(
+            UsagePace.mostAcceleratedWindow(in: monthlySnapshot, now: now),
+            .monthly
+        )
+        XCTAssertNil(
+            UsagePace.mostAcceleratedWindow(
+                in: snapshot,
+                now: now,
+                sensitivity: .off
+            )
+        )
+    }
+}

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageParserTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageParserTests.swift
@@ -49,6 +49,7 @@ final class UsageParserTests: XCTestCase {
         XCTAssertEqual(limit.secondary?.usedPercent, 0)
         XCTAssertEqual(limit.secondary?.remainingPercent, 100)
         XCTAssertEqual(snapshot.usageCredits?.balance, "2500.5")
+        XCTAssertTrue(snapshot.usageCredits?.shouldDisplay == true)
     }
 
     func testMainRateLimitTakesPrecedenceOverCloserAdditionalWindow() throws {
@@ -93,7 +94,116 @@ final class UsageParserTests: XCTestCase {
         XCTAssertFalse(snapshot.limitReached)
         XCTAssertNil(snapshot.fiveHour)
         XCTAssertNil(snapshot.weekly)
+        XCTAssertNil(snapshot.monthly)
         XCTAssertFalse(snapshot.hasDisplayableData)
+    }
+
+    func testMonthlyWindowClassifiesFreeTierAndCalendarDrift() throws {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let resetAt = Int(now.addingTimeInterval(14 * 86_400).timeIntervalSince1970)
+        let snapshot = try UsageParser.parse(
+            """
+            {
+              "plan_type": "free",
+              "rate_limit": {
+                "allowed": true,
+                "limit_reached": false,
+                "primary_window": {
+                  "used_percent": 28,
+                  "limit_window_seconds": 2592000,
+                  "reset_after_seconds": 1209600,
+                  "reset_at": \(resetAt)
+                }
+              }
+            }
+            """,
+            fetchedAt: now
+        )
+        XCTAssertEqual(snapshot.planType, "free")
+        XCTAssertNil(snapshot.fiveHour)
+        XCTAssertNil(snapshot.weekly)
+        XCTAssertEqual(snapshot.monthly?.usedPercent, 28)
+        XCTAssertEqual(snapshot.monthly?.windowSeconds, 2_592_000)
+        XCTAssertTrue(snapshot.hasDisplayableData)
+        XCTAssertTrue(snapshot.longWindowIsMonthly)
+        XCTAssertEqual(snapshot.longWindow, snapshot.monthly)
+        XCTAssertEqual(snapshot.nextReset(after: now), Date(timeIntervalSince1970: TimeInterval(resetAt)))
+
+        let encoded = try JSONEncoder().encode(snapshot)
+        let restored = try JSONDecoder().decode(UsageSnapshot.self, from: encoded)
+        XCTAssertEqual(restored.monthly?.usedPercent, 28)
+        XCTAssertEqual(restored.monthly?.windowSeconds, 2_592_000)
+
+        let shortMonth = try UsageParser.parse(
+            """
+            {"plan_type":"free","rate_limit":{"primary_window":{"used_percent":5,"limit_window_seconds":2419200}}}
+            """,
+            fetchedAt: now
+        )
+        XCTAssertNotNil(shortMonth.monthly)
+
+        let longMonth = try UsageParser.parse(
+            """
+            {"plan_type":"free","rate_limit":{"primary_window":{"used_percent":5,"limit_window_seconds":2678400}}}
+            """,
+            fetchedAt: now
+        )
+        XCTAssertNotNil(longMonth.monthly)
+
+        let pro = try UsageParser.parse(
+            """
+            {
+              "plan_type": "pro",
+              "rate_limit": {
+                "primary_window": {"used_percent": 10, "limit_window_seconds": 18000},
+                "secondary_window": {"used_percent": 72, "limit_window_seconds": 604800}
+              }
+            }
+            """,
+            fetchedAt: now
+        )
+        XCTAssertNotNil(pro.fiveHour)
+        XCTAssertNotNil(pro.weekly)
+        XCTAssertNil(pro.monthly)
+        XCTAssertFalse(pro.longWindowIsMonthly)
+        XCTAssertEqual(pro.longWindow, pro.weekly)
+
+        XCTAssertEqual(
+            AdaptiveRefreshPolicy.chooseMinutes(
+                snapshot: snapshot,
+                attentionScore: 0,
+                localHour: 12,
+                consecutiveFailures: 0,
+                now: now
+            ),
+            30
+        )
+
+        let lowMonthly = try UsageParser.parse(
+            """
+            {
+              "plan_type": "free",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 92,
+                  "limit_window_seconds": 2592000,
+                  "reset_at": \(Int(now.addingTimeInterval(3 * 86_400).timeIntervalSince1970))
+                }
+              }
+            }
+            """,
+            fetchedAt: now
+        )
+        XCTAssertEqual(
+            AdaptiveRefreshPolicy.chooseMinutes(
+                snapshot: lowMonthly,
+                attentionScore: 0,
+                localHour: 12,
+                consecutiveFailures: 0,
+                now: now
+            ),
+            5
+        )
     }
 
     func testWeeklyAndCreditsCanExistWithoutFiveHourWindow() throws {
@@ -121,7 +231,7 @@ final class UsageParserTests: XCTestCase {
         XCTAssertTrue(snapshot.hasDisplayableData)
     }
 
-    func testNoCreditsBalanceIsNotStandaloneUsageData() throws {
+    func testEmptyPurchasedCreditsAreNotStandaloneUsageData() throws {
         let snapshot = try UsageParser.parse(
             """
             {"credits":{"has_credits":false,"unlimited":false,"balance":"0"}}
@@ -129,7 +239,7 @@ final class UsageParserTests: XCTestCase {
             fetchedAt: fetchedAt
         )
         XCTAssertNotNil(snapshot.usageCredits)
-        XCTAssertNil(snapshot.usageCredits?.balance)
+        XCTAssertFalse(snapshot.usageCredits?.shouldDisplay == true)
         XCTAssertFalse(snapshot.hasDisplayableData)
     }
 

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageParserTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/UsageParserTests.swift
@@ -206,6 +206,30 @@ final class UsageParserTests: XCTestCase {
         )
     }
 
+    func testUnrecognizedSingleWindowStillDisplaysForGoStylePlans() throws {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let snapshot = try UsageParser.parse(
+            """
+            {
+              "plan_type": "go",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 41,
+                  "limit_window_seconds": 5184000
+                }
+              }
+            }
+            """,
+            fetchedAt: now
+        )
+        XCTAssertNil(snapshot.fiveHour)
+        XCTAssertNil(snapshot.weekly)
+        XCTAssertEqual(snapshot.monthly?.usedPercent, 41)
+        XCTAssertEqual(snapshot.monthly?.windowSeconds, 5_184_000)
+        XCTAssertTrue(snapshot.hasDisplayableData)
+        XCTAssertTrue(snapshot.longWindowIsMonthly)
+    }
+
     func testWeeklyAndCreditsCanExistWithoutFiveHourWindow() throws {
         let snapshot = try UsageParser.parse(
             """

--- a/ios/CodexMeterTests/LiveCodexServiceTests.swift
+++ b/ios/CodexMeterTests/LiveCodexServiceTests.swift
@@ -354,42 +354,34 @@ final class LiveCodexServiceTests: XCTestCase {
 
     func testNotificationDedupeKeysAreStablePerMetricAndWindow() {
         let reset = Date(timeIntervalSince1970: 1_800_000_000)
-        let fiveHourSeconds: Int64 = 18_000
-        let first = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour)
-        let duplicate = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour)
-        let otherMetric = NotificationDeduplication.lowUsageIdentifier(metric: .weekly)
+        let first = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour, resetDate: reset)
+        let duplicate = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour, resetDate: reset)
+        let otherMetric = NotificationDeduplication.lowUsageIdentifier(metric: .weekly, resetDate: reset)
+        let otherWindow = NotificationDeduplication.lowUsageIdentifier(
+            metric: .fiveHour,
+            resetDate: reset.addingTimeInterval(1)
+        )
 
         XCTAssertEqual(first, duplicate)
         XCTAssertNotEqual(first, otherMetric)
+        XCTAssertNotEqual(first, otherWindow)
         let token = NotificationDeduplication.windowToken(for: reset)
         XCTAssertFalse(
             NotificationDeduplication.shouldDeliverLowUsage(
                 lastDeliveredWindowToken: token,
-                resetDate: reset,
-                windowSeconds: fiveHourSeconds
-            )
-        )
-        // Small API reset drift must not re-arm the one-shot low-usage alert.
-        XCTAssertFalse(
-            NotificationDeduplication.shouldDeliverLowUsage(
-                lastDeliveredWindowToken: token,
-                resetDate: reset.addingTimeInterval(1),
-                windowSeconds: fiveHourSeconds
+                resetDate: reset
             )
         )
         XCTAssertFalse(
             NotificationDeduplication.shouldDeliverLowUsage(
                 lastDeliveredWindowToken: token,
-                resetDate: reset.addingTimeInterval(60),
-                windowSeconds: fiveHourSeconds
+                resetDate: reset.addingTimeInterval(1)
             )
         )
-        // A real next window (hours later) should notify again.
         XCTAssertTrue(
             NotificationDeduplication.shouldDeliverLowUsage(
                 lastDeliveredWindowToken: token,
-                resetDate: reset.addingTimeInterval(TimeInterval(fiveHourSeconds)),
-                windowSeconds: fiveHourSeconds
+                resetDate: reset.addingTimeInterval(20 * 60)
             )
         )
         XCTAssertNotEqual(
@@ -400,8 +392,14 @@ final class LiveCodexServiceTests: XCTestCase {
 
     func testNotificationCleanupRemovesOnlyObsoleteWindowIdentifiers() {
         let reset = Date(timeIntervalSince1970: 1_800_000_000)
-        let keptLow = NotificationDeduplication.lowUsageIdentifier(metric: .fiveHour)
-        let obsoleteLow = NotificationDeduplication.lowUsageIdentifier(metric: .weekly)
+        let keptLow = NotificationDeduplication.lowUsageIdentifier(
+            metric: .fiveHour,
+            resetDate: reset
+        )
+        let obsoleteLow = NotificationDeduplication.lowUsageIdentifier(
+            metric: .weekly,
+            resetDate: reset
+        )
         let keptReset = NotificationDeduplication.resetIdentifier(
             metric: .fiveHour,
             resetDate: reset

--- a/ios/CodexMeterTests/LiveCodexServiceTests.swift
+++ b/ios/CodexMeterTests/LiveCodexServiceTests.swift
@@ -57,6 +57,42 @@ final class LiveCodexServiceTests: XCTestCase {
         XCTAssertEqual(counts.read()["/backend-api/wham/rate-limit-reset-credits"], 1)
     }
 
+    func testMonthlyOnlyGoResponseSurvivesRefreshAndIsDisplayable() async throws {
+        CodexMeterURLProtocol.reset()
+        defer { CodexMeterURLProtocol.reset() }
+        let session = makeStubbedSession()
+        defer { session.invalidateAndCancel() }
+        let paths = makeCachePaths()
+        defer { paths.remove() }
+
+        CodexMeterURLProtocol.configure { request in
+            switch request.url?.path {
+            case "/backend-api/wham/usage":
+                return try .json(goMonthlyUsageResponse(used: 33))
+            case "/backend-api/wham/rate-limit-reset-credits":
+                return try .json(creditsResponse(count: 0))
+            default:
+                return StubbedHTTPResponse(statusCode: 500)
+            }
+        }
+
+        let service = makeLiveService(
+            session: session,
+            store: MemoryTokenStore(validTokens()),
+            paths: paths
+        )
+        let result = try await service.refresh()
+
+        XCTAssertEqual(result.usage.planType, "go")
+        XCTAssertNil(result.usage.fiveHour)
+        XCTAssertNil(result.usage.weekly)
+        XCTAssertEqual(result.usage.monthly?.usedPercent, 33)
+        XCTAssertEqual(result.usage.monthly?.windowSeconds, 2_592_000)
+        XCTAssertTrue(result.usage.longWindowIsMonthly)
+        XCTAssertTrue(result.usage.hasDisplayableData)
+        XCTAssertNotNil(result.usage.monthly?.resetAt)
+    }
+
     func testSecondUnauthorizedResponseIsNotRetriedAgain() async throws {
         CodexMeterURLProtocol.reset()
         defer { CodexMeterURLProtocol.reset() }

--- a/ios/CodexMeterTests/NotificationPlanningTests.swift
+++ b/ios/CodexMeterTests/NotificationPlanningTests.swift
@@ -103,6 +103,15 @@ final class NotificationPlanningTests: XCTestCase {
             weeklySuppressUntil: observed.addingTimeInterval(-1)
         )
         XCTAssertEqual(filtered, [.weekly])
+
+        let monthlyFiltered = CelebrationDetector.withoutUserResetRefills(
+            [.monthly],
+            observedAt: observed,
+            fiveHourSuppressUntil: nil,
+            weeklySuppressUntil: nil,
+            monthlySuppressUntil: observed.addingTimeInterval(3_600)
+        )
+        XCTAssertTrue(monthlyFiltered.isEmpty)
     }
 
     func testResetCreditsAddedOnlyOnIncrease() {
@@ -111,72 +120,7 @@ final class NotificationPlanningTests: XCTestCase {
         XCTAssertEqual(CelebrationDetector.resetCreditsAdded(previous: 3, current: 1), 0)
     }
 
-    func testAlertMetricIncludesSelectedWindowsOnly() {
-        XCTAssertTrue(AlertMetric.both.includes(.fiveHour))
-        XCTAssertTrue(AlertMetric.both.includes(.weekly))
-        XCTAssertFalse(AlertMetric.both.includes(.both))
-
-        XCTAssertTrue(AlertMetric.fiveHour.includes(.fiveHour))
-        XCTAssertFalse(AlertMetric.fiveHour.includes(.weekly))
-
-        XCTAssertTrue(AlertMetric.weekly.includes(.weekly))
-        XCTAssertFalse(AlertMetric.weekly.includes(.fiveHour))
-    }
-
-    func testMissingAppGroupMarksWidgetCacheUnavailableAndThrowsOnPublish() async {
-        let cache = WidgetSnapshotCache(
-            appGroupIdentifier: "group.com.bukovinafilip.CodexMeter.missing-for-tests"
-        )
-        XCTAssertFalse(cache.isAvailable)
-        do {
-            try await cache.publishSignedOut()
-            XCTFail("Expected App Group storage failure")
-        } catch let error as CodexServiceError {
-            XCTAssertEqual(error, .storage(WidgetSnapshotCache.unavailableMessage))
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-    }
-
-    func testPublishSignedOutClearsStaleSnapshotWhenSaveFails() async throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("widget-clear-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
-
-        let fileURL = directory.appendingPathComponent(SharedWidgetSnapshot.defaultFileName)
-        let cache = WidgetSnapshotCache(fileURL: fileURL)
-        let now = Date(timeIntervalSince1970: 1_900_000_000)
-        try await cache.publish(
-            mode: .live,
-            usage: UsageSnapshot(
-                planType: "plus",
-                allowed: true,
-                limitReached: false,
-                fiveHour: UsageWindow(usedPercent: 40, windowSeconds: 18_000, resetAt: now.addingTimeInterval(60)),
-                weekly: nil,
-                fetchedAt: now
-            ),
-            credits: .summary(availableCount: 1, fetchedAt: now),
-            now: now
-        )
-        XCTAssertNotNil(try await cache.load())
-
-        // Turn the snapshot path into a directory so the signed-out write fails.
-        try FileManager.default.removeItem(at: fileURL)
-        try FileManager.default.createDirectory(at: fileURL, withIntermediateDirectories: true)
-
-        do {
-            try await cache.publishSignedOut()
-            XCTFail("Expected signed-out publish to fail")
-        } catch {
-            // Expected — previous authenticated snapshot must still be wiped.
-        }
-        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
-        XCTAssertNil(try await cache.load())
-    }
-
-    func testAppSettingsDecodesMissing22FieldsWithDefaults() throws {
+    func testAppSettingsDecodesMissingFieldsWithCurrentDefaults() throws {
         let legacy = """
         {
           "appearance": "system",
@@ -190,6 +134,14 @@ final class NotificationPlanningTests: XCTestCase {
 
         let settings = try JSONDecoder().decode(AppSettings.self, from: legacy)
         XCTAssertEqual(settings.refreshMode, .automatic)
+        XCTAssertTrue(settings.showFiveHour)
+        XCTAssertTrue(settings.showWeekly)
+        XCTAssertTrue(settings.showAdditionalLimits)
+        XCTAssertTrue(settings.showUsageCredits)
+        XCTAssertTrue(settings.showUsageHistory)
+        XCTAssertTrue(settings.showResetCredits)
+        XCTAssertTrue(settings.dashboardOrder.isEmpty)
+        XCTAssertTrue(settings.dashboardHiddenSections.isEmpty)
         XCTAssertTrue(settings.creditIncreaseAlertsEnabled)
         XCTAssertTrue(settings.unexpectedRefillAlertsEnabled)
         XCTAssertTrue(settings.creditExpiryRemindersEnabled)

--- a/ios/CodexMeterTests/SettingsAndHistoryTests.swift
+++ b/ios/CodexMeterTests/SettingsAndHistoryTests.swift
@@ -1,0 +1,88 @@
+import CodexMeterCore
+import Foundation
+import XCTest
+@testable import CodexMeter
+
+final class SettingsAndHistoryTests: XCTestCase {
+    func testDashboardSettingsOrderVisibilityAndTransferRoundTrip() throws {
+        let spark = "limit:codex-spark"
+        var settings = AppSettings()
+        settings.setDashboardSectionVisible(DashboardSections.weekly, visible: false)
+        settings.setDashboardSectionVisible(spark, visible: false)
+        settings.setDashboardOrder([
+            DashboardSections.usageHistory,
+            spark,
+            DashboardSections.fiveHour,
+            DashboardSections.usageHistory
+        ])
+
+        XCTAssertFalse(settings.isDashboardSectionVisible(DashboardSections.weekly))
+        XCTAssertFalse(settings.isDashboardSectionVisible(spark))
+        XCTAssertEqual(
+            settings.dashboardOrder,
+            [DashboardSections.usageHistory, spark, DashboardSections.fiveHour]
+        )
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try SettingsTransferDocument.decode(data)
+        XCTAssertEqual(decoded, settings)
+
+        var shown = decoded
+        shown.setDashboardSectionVisible(spark, visible: true)
+        XCTAssertTrue(shown.showAdditionalLimits)
+        XCTAssertTrue(shown.isDashboardSectionVisible(spark))
+        XCTAssertFalse(shown.dashboardHiddenSections.contains(spark))
+    }
+
+    func testUsageHistoryStoreRecordsPersistsAndClearsBoundedSamples() async throws {
+        let fileURL = temporaryFileURL("usage-history.json")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let store = UsageHistoryStore(fileURL: fileURL)
+        let observedAt = Date(timeIntervalSince1970: 2_000_000_000)
+
+        let first = UsageSnapshot(
+            planType: "plus",
+            allowed: true,
+            limitReached: false,
+            fiveHour: UsageWindow(
+                usedPercent: 20,
+                windowSeconds: 18_000,
+                resetAt: observedAt.addingTimeInterval(3_600)
+            ),
+            weekly: UsageWindow(
+                usedPercent: 40,
+                windowSeconds: 604_800,
+                resetAt: observedAt.addingTimeInterval(300_000)
+            ),
+            fetchedAt: observedAt
+        )
+        let recorded = try await store.record(first)
+        XCTAssertEqual(recorded.fiveHour.samples.count, 1)
+        XCTAssertEqual(recorded.weekly.samples.count, 1)
+        XCTAssertTrue(recorded.monthly.samples.isEmpty)
+
+        let duplicate = UsageSnapshot(
+            planType: "plus",
+            allowed: true,
+            limitReached: false,
+            fiveHour: UsageWindow(
+                usedPercent: 20,
+                windowSeconds: 18_000,
+                resetAt: observedAt.addingTimeInterval(3_600)
+            ),
+            weekly: first.weekly,
+            fetchedAt: observedAt.addingTimeInterval(60)
+        )
+        let coalesced = try await store.record(duplicate)
+        XCTAssertEqual(coalesced.fiveHour.samples.count, 1)
+        XCTAssertEqual(coalesced.fiveHour.samples.first?.observedAt, duplicate.fetchedAt)
+
+        let reloaded = await UsageHistoryStore(fileURL: fileURL).load()
+        XCTAssertEqual(reloaded, coalesced)
+
+        try await store.clear()
+        let cleared = await store.load()
+        XCTAssertEqual(cleared, .empty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+}

--- a/ios/CodexMeterTests/TestSupport.swift
+++ b/ios/CodexMeterTests/TestSupport.swift
@@ -232,6 +232,24 @@ func usageResponse(used: Int = 40) -> [String: Any] {
     ]
 }
 
+func goMonthlyUsageResponse(used: Int = 28) -> [String: Any] {
+    [
+        "plan_type": "go",
+        "rate_limit": [
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": [
+                "used_percent": used,
+                "limit_window_seconds": 2_592_000,
+                "reset_after_seconds": 1_209_600
+            ]
+        ],
+        "rate_limit_reset_credits": [
+            "available_count": 0
+        ]
+    ]
+}
+
 func creditsResponse(count: Int = 1) -> [String: Any] {
     [
         "available_count": count,

--- a/ios/CodexMeterUITests/CodexMeterUITests.swift
+++ b/ios/CodexMeterUITests/CodexMeterUITests.swift
@@ -18,9 +18,31 @@ final class CodexMeterUITests: XCTestCase {
         XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["Mode"].exists)
         XCTAssertTrue(app.buttons["Leave Demo"].exists)
-        app.swipeUp()
+        for _ in 0..<6 where !app.buttons["Send test notification"].exists {
+            app.swipeUp()
+        }
         XCTAssertTrue(app.staticTexts["System permission"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons["Send test notification"].waitForExistence(timeout: 3))
+    }
+
+    func testEditDashboardVisibilityControlsIncludeLaterReleaseSections() throws {
+        let app = launchDemo()
+
+        app.buttons["Edit dashboard"].tap()
+        XCTAssertTrue(app.navigationBars["Edit dashboard"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.switches["Show 5-hour limit"].exists)
+        XCTAssertTrue(app.switches["Show Weekly limit"].exists)
+        XCTAssertTrue(app.switches["Show Monthly limit"].exists)
+        XCTAssertTrue(app.switches["Show Usage history"].exists)
+        XCTAssertTrue(app.switches["Show Reset credits"].exists)
+
+        app.switches["Show Weekly limit"].tap()
+        app.switches["Show Usage history"].tap()
+        app.buttons["Done"].tap()
+
+        XCTAssertTrue(app.navigationBars["Codex Meter"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.staticTexts["Weekly"].exists)
+        XCTAssertTrue(app.staticTexts["Reset credits"].exists)
     }
 
     func testSignedOutAndSignInPresentation() throws {
@@ -45,6 +67,9 @@ final class CodexMeterUITests: XCTestCase {
     func testResetRequiresIrreversibleConfirmation() throws {
         let app = launchDemo()
 
+        for _ in 0..<4 where !app.buttons["Use 1 reset"].exists {
+            app.swipeUp()
+        }
         XCTAssertTrue(app.buttons["Use 1 reset"].waitForExistence(timeout: 5))
         app.buttons["Use 1 reset"].tap()
         XCTAssertTrue(app.navigationBars["Codex reset"].waitForExistence(timeout: 3))

--- a/ios/CodexMeterWidgets/CodexMeterAccessoryWidgets.swift
+++ b/ios/CodexMeterWidgets/CodexMeterAccessoryWidgets.swift
@@ -5,10 +5,10 @@ private enum AccessoryMetric {
     case fiveHour
     case weekly
 
-    var title: LocalizedStringKey {
+    func title(in snapshot: WidgetDisplaySnapshot) -> LocalizedStringKey {
         switch self {
         case .fiveHour: "5h"
-        case .weekly: "Week"
+        case .weekly: LocalizedStringKey(snapshot.longWindowIsMonthly ? "Month" : "Week")
         }
     }
 
@@ -24,12 +24,16 @@ struct FiveHourAccessoryWidget: Widget {
     static let kind = "CodexMeter.Accessory.FiveHour"
 
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: Self.kind, provider: AccessoryWidgetTimelineProvider()) { entry in
-            AccessoryCircularUsageView(entry: entry, metric: .fiveHour)
+        AppIntentConfiguration(
+            kind: Self.kind,
+            intent: FiveHourAccessoryConfigurationIntent.self,
+            provider: FiveHourAccessoryTimelineProvider()
+        ) { entry in
+            ConfiguredAccessoryUsageView(entry: entry)
                 .containerBackground(for: .widget) { Color.clear }
         }
         .configurationDisplayName("Five-hour allowance")
-        .description("Your current five-hour Codex allowance.")
+        .description("A configurable circular Codex allowance dial.")
         .supportedFamilies([.accessoryCircular])
     }
 }
@@ -38,12 +42,16 @@ struct WeeklyAccessoryWidget: Widget {
     static let kind = "CodexMeter.Accessory.Weekly"
 
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: Self.kind, provider: AccessoryWidgetTimelineProvider()) { entry in
-            AccessoryCircularUsageView(entry: entry, metric: .weekly)
+        AppIntentConfiguration(
+            kind: Self.kind,
+            intent: WeeklyAccessoryConfigurationIntent.self,
+            provider: WeeklyAccessoryTimelineProvider()
+        ) { entry in
+            ConfiguredAccessoryUsageView(entry: entry)
                 .containerBackground(for: .widget) { Color.clear }
         }
         .configurationDisplayName("Weekly allowance")
-        .description("Your current weekly Codex allowance.")
+        .description("A configurable circular Codex allowance dial.")
         .supportedFamilies([.accessoryCircular])
     }
 }
@@ -52,33 +60,61 @@ struct DualAllowanceAccessoryWidget: Widget {
     static let kind = "CodexMeter.Accessory.Dual"
 
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: Self.kind, provider: AccessoryWidgetTimelineProvider()) { entry in
-            DualAccessoryUsageView(entry: entry)
+        AppIntentConfiguration(
+            kind: Self.kind,
+            intent: DualAccessoryConfigurationIntent.self,
+            provider: DualAccessoryTimelineProvider()
+        ) { entry in
+            ConfiguredAccessoryUsageView(entry: entry)
                 .containerBackground(for: .widget) { Color.clear }
         }
         .configurationDisplayName("Codex allowances")
-        .description("Five-hour and weekly usage with locally updating reset timers.")
-        .supportedFamilies([.accessoryRectangular, .accessoryInline])
+        .description("Both allowance windows or one focused metric with locally updating reset timers.")
+        .supportedFamilies([.accessoryCircular, .accessoryRectangular, .accessoryInline])
+    }
+}
+
+private struct ConfiguredAccessoryUsageView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: ConfiguredAccessoryWidgetEntry
+
+    @ViewBuilder
+    var body: some View {
+        if family == .accessoryCircular {
+            switch entry.allowance {
+            case .both:
+                DualAccessoryCircularUsageView(snapshot: entry.snapshot)
+            case .fiveHour:
+                AccessoryCircularUsageView(snapshot: entry.snapshot, metric: .fiveHour)
+            case .weekly:
+                AccessoryCircularUsageView(snapshot: entry.snapshot, metric: .weekly)
+            }
+        } else {
+            DualAccessoryUsageView(
+                snapshot: entry.snapshot,
+                allowance: entry.allowance
+            )
+        }
     }
 }
 
 private struct AccessoryCircularUsageView: View {
-    let entry: AccessoryWidgetEntry
+    let snapshot: WidgetDisplaySnapshot
     let metric: AccessoryMetric
 
     private var window: WidgetUsageWindow {
-        metric.window(in: entry.snapshot)
+        metric.window(in: snapshot)
     }
 
     var body: some View {
-        if entry.snapshot.mode == .signedOut {
+        if snapshot.mode == .signedOut {
             Image(systemName: "person.crop.circle.badge.exclamationmark")
                 .font(.title2)
                 .widgetURL(URL(string: "codexmeter://dashboard"))
                 .accessibilityLabel("Sign in to Codex Meter")
         } else {
             Gauge(value: window.usedPercent ?? 0, in: 0...100) {
-                Text(metric.title)
+                Text(metric.title(in: snapshot))
             } currentValueLabel: {
                 VStack(spacing: 0) {
                     Text(percentText(window.usedPercent, symbol: true))
@@ -93,18 +129,77 @@ private struct AccessoryCircularUsageView: View {
             .gaugeStyle(.accessoryCircularCapacity)
             .widgetAccentable()
             .widgetURL(URL(string: "codexmeter://dashboard"))
-            .accessibilityLabel(Text(metric.title))
+            .accessibilityLabel(Text(metric.title(in: snapshot)))
             .accessibilityValue(percentText(window.usedPercent, symbol: true))
         }
     }
 }
 
-private struct DualAccessoryUsageView: View {
-    @Environment(\.widgetFamily) private var family
-    let entry: AccessoryWidgetEntry
+private struct DualAccessoryCircularUsageView: View {
+    let snapshot: WidgetDisplaySnapshot
 
     var body: some View {
-        if entry.snapshot.mode == .signedOut {
+        if snapshot.mode == .signedOut {
+            Image(systemName: "person.crop.circle.badge.exclamationmark")
+                .font(.title2)
+                .widgetURL(URL(string: "codexmeter://dashboard"))
+                .accessibilityLabel("Sign in to Codex Meter")
+        } else {
+            ZStack {
+                Circle()
+                    .stroke(.primary.opacity(0.18), lineWidth: 4)
+                Circle()
+                    .trim(from: 0, to: progress(snapshot.fiveHour))
+                    .stroke(
+                        .primary,
+                        style: StrokeStyle(lineWidth: 4, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .widgetAccentable()
+
+                Circle()
+                    .stroke(.primary.opacity(0.10), lineWidth: 3)
+                    .padding(8)
+                Circle()
+                    .trim(from: 0, to: progress(snapshot.weekly))
+                    .stroke(
+                        .secondary,
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .padding(8)
+                    .widgetAccentable()
+
+                VStack(spacing: -1) {
+                    Text("5h \(percentText(snapshot.fiveHour.usedPercent, symbol: false))")
+                    Text("\(snapshot.longWindowIsMonthly ? "M" : "W") \(percentText(snapshot.weekly.usedPercent, symbol: false))")
+                }
+                .font(.system(size: 8, weight: .bold, design: .rounded))
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+            }
+            .padding(2)
+            .widgetURL(URL(string: "codexmeter://dashboard"))
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Both allowance windows")
+            .accessibilityValue(
+                "5-hour \(percentText(snapshot.fiveHour.usedPercent, symbol: true)) used, \(snapshot.longWindowTitle.lowercased()) \(percentText(snapshot.weekly.usedPercent, symbol: true)) used"
+            )
+        }
+    }
+
+    private func progress(_ window: WidgetUsageWindow) -> CGFloat {
+        CGFloat(min(max((window.usedPercent ?? 0) / 100, 0), 1))
+    }
+}
+
+private struct DualAccessoryUsageView: View {
+    @Environment(\.widgetFamily) private var family
+    let snapshot: WidgetDisplaySnapshot
+    let allowance: WidgetAllowance
+
+    var body: some View {
+        if snapshot.mode == .signedOut {
             Label("Open Codex Meter to sign in", systemImage: "person.crop.circle")
                 .widgetURL(URL(string: "codexmeter://dashboard"))
         } else if family == .accessoryInline {
@@ -114,16 +209,26 @@ private struct DualAccessoryUsageView: View {
         }
     }
 
+    @ViewBuilder
     private var inlineContent: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "gauge.with.dots.needle.33percent")
-            Text("5h \(percentText(entry.snapshot.fiveHour.usedPercent, symbol: true))")
-            if let reset = entry.snapshot.fiveHour.resetsAt, reset > .now {
-                Text(reset, style: .timer).monospacedDigit()
-            }
-            Text("· W \(percentText(entry.snapshot.weekly.usedPercent, symbol: true))")
-            if let reset = entry.snapshot.weekly.resetsAt, reset > .now {
-                Text(reset, style: .timer).monospacedDigit()
+        Group {
+            switch allowance {
+            case .both:
+                HStack(spacing: 4) {
+                    Image(systemName: "gauge.with.dots.needle.33percent")
+                    Text("5h \(percentText(snapshot.fiveHour.usedPercent, symbol: true))")
+                    if let reset = snapshot.fiveHour.resetsAt, reset > .now {
+                        Text(reset, style: .timer).monospacedDigit()
+                    }
+                    Text("· \(snapshot.longWindowIsMonthly ? "M" : "W") \(percentText(snapshot.weekly.usedPercent, symbol: true))")
+                    if let reset = snapshot.weekly.resetsAt, reset > .now {
+                        Text(reset, style: .timer).monospacedDigit()
+                    }
+                }
+            case .fiveHour:
+                inlineMetric(.fiveHour)
+            case .weekly:
+                inlineMetric(.weekly)
             }
         }
         .widgetAccentable()
@@ -131,12 +236,40 @@ private struct DualAccessoryUsageView: View {
         .accessibilityElement(children: .combine)
     }
 
+    @ViewBuilder
     private var rectangularContent: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            accessoryRow(title: "5 hours", window: entry.snapshot.fiveHour)
-            accessoryRow(title: "Weekly", window: entry.snapshot.weekly)
+        Group {
+            switch allowance {
+            case .both:
+                VStack(alignment: .leading, spacing: 5) {
+                    accessoryRow(title: "5 hours", window: snapshot.fiveHour)
+                    accessoryRow(title: LocalizedStringKey(snapshot.longWindowTitle), window: snapshot.weekly)
+                }
+            case .fiveHour:
+                accessoryRow(title: "5 hours", window: snapshot.fiveHour)
+                    .frame(maxHeight: .infinity, alignment: .center)
+            case .weekly:
+                accessoryRow(title: LocalizedStringKey(snapshot.longWindowTitle), window: snapshot.weekly)
+                    .frame(maxHeight: .infinity, alignment: .center)
+            }
         }
         .widgetURL(URL(string: "codexmeter://dashboard"))
+    }
+
+    private func inlineMetric(_ metric: AccessoryMetric) -> some View {
+        let window = metric.window(in: snapshot)
+        return HStack(spacing: 4) {
+            Image(systemName: "gauge.with.dots.needle.33percent")
+            switch metric {
+            case .fiveHour:
+                Text("5h \(percentText(window.usedPercent, symbol: true))")
+            case .weekly:
+                Text("\(snapshot.longWindowIsMonthly ? "M" : "W") \(percentText(window.usedPercent, symbol: true))")
+            }
+            if let reset = window.resetsAt, reset > .now {
+                Text(reset, style: .timer).monospacedDigit()
+            }
+        }
     }
 
     private func accessoryRow(

--- a/ios/CodexMeterWidgets/CodexMeterHomeWidget.swift
+++ b/ios/CodexMeterWidgets/CodexMeterHomeWidget.swift
@@ -13,7 +13,7 @@ struct CodexMeterHomeWidget: Widget {
             CodexMeterHomeWidgetView(entry: entry)
         }
         .configurationDisplayName("Codex Meter")
-        .description("See your five-hour and weekly Codex allowances and reset credits.")
+        .description("See both Codex allowance windows or focus on one responsive usage dial.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge, .systemExtraLarge])
     }
 }
@@ -24,6 +24,25 @@ struct CodexMeterHomeWidgetView: View {
 
     private var configuration: MeterWidgetConfigurationIntent {
         entry.configuration
+    }
+
+    private var focusedAllowance: FocusedAllowance? {
+        switch configuration.allowance {
+        case .both:
+            nil
+        case .fiveHour:
+            FocusedAllowance(
+                title: "5 hours",
+                longTitle: "Five-hour allowance",
+                window: entry.snapshot.fiveHour
+            )
+        case .weekly:
+            FocusedAllowance(
+                title: LocalizedStringKey(entry.snapshot.longWindowTitle),
+                longTitle: LocalizedStringKey("\(entry.snapshot.longWindowTitle) allowance"),
+                window: entry.snapshot.weekly
+            )
+        }
     }
 
     private var destination: URL {
@@ -70,19 +89,30 @@ struct CodexMeterHomeWidgetView: View {
     private var smallLayout: some View {
         VStack(spacing: 8) {
             compactHeader
-            HStack(spacing: 9) {
+            if let focusedAllowance {
                 UsageRing(
-                    title: "5 hours",
-                    window: entry.snapshot.fiveHour,
+                    title: focusedAllowance.title,
+                    window: focusedAllowance.window,
                     configuration: configuration,
-                    compact: true
+                    prominent: true,
+                    showsReset: false
                 )
-                UsageRing(
-                    title: "Weekly",
-                    window: entry.snapshot.weekly,
-                    configuration: configuration,
-                    compact: true
-                )
+                .frame(maxWidth: 94)
+            } else {
+                HStack(spacing: 9) {
+                    UsageRing(
+                        title: "5 hours",
+                        window: entry.snapshot.fiveHour,
+                        configuration: configuration,
+                        compact: true
+                    )
+                    UsageRing(
+                        title: LocalizedStringKey(entry.snapshot.longWindowTitle),
+                        window: entry.snapshot.weekly,
+                        configuration: configuration,
+                        compact: true
+                    )
+                }
             }
         }
     }
@@ -90,30 +120,55 @@ struct CodexMeterHomeWidgetView: View {
     private var mediumLayout: some View {
         VStack(spacing: 8) {
             compactHeader
-            HStack(alignment: .top, spacing: 10) {
-                UsageRing(
-                    title: "5 hours",
-                    window: entry.snapshot.fiveHour,
-                    configuration: configuration,
-                    compact: true
-                )
-                UsageRing(
-                    title: "Weekly",
-                    window: entry.snapshot.weekly,
-                    configuration: configuration,
-                    compact: true
-                )
-                CountdownMetricTile(
-                    date: entry.snapshot.nextReset,
-                    title: "Next reset",
-                    configuration: configuration
-                )
-                RoundMetricTile(
-                    symbol: "bolt.fill",
-                    value: "\(entry.snapshot.creditCount)",
-                    title: "Credits",
-                    configuration: configuration
-                )
+            if let focusedAllowance {
+                HStack(alignment: .center, spacing: 12) {
+                    UsageRing(
+                        title: focusedAllowance.title,
+                        window: focusedAllowance.window,
+                        configuration: configuration,
+                        prominent: true,
+                        showsReset: false
+                    )
+                    .frame(maxWidth: 108)
+
+                    CountdownMetricTile(
+                        date: focusedAllowance.window.resetsAt,
+                        title: "Next reset",
+                        configuration: configuration
+                    )
+                    RoundMetricTile(
+                        symbol: "bolt.fill",
+                        value: "\(entry.snapshot.creditCount)",
+                        title: "Credits",
+                        configuration: configuration
+                    )
+                }
+            } else {
+                HStack(alignment: .top, spacing: 10) {
+                    UsageRing(
+                        title: "5 hours",
+                        window: entry.snapshot.fiveHour,
+                        configuration: configuration,
+                        compact: true
+                    )
+                    UsageRing(
+                        title: LocalizedStringKey(entry.snapshot.longWindowTitle),
+                        window: entry.snapshot.weekly,
+                        configuration: configuration,
+                        compact: true
+                    )
+                    CountdownMetricTile(
+                        date: entry.snapshot.nextReset,
+                        title: "Next reset",
+                        configuration: configuration
+                    )
+                    RoundMetricTile(
+                        symbol: "bolt.fill",
+                        value: "\(entry.snapshot.creditCount)",
+                        title: "Credits",
+                        configuration: configuration
+                    )
+                }
             }
         }
     }
@@ -122,7 +177,36 @@ struct CodexMeterHomeWidgetView: View {
         VStack(alignment: .leading, spacing: extraLarge ? 16 : 11) {
             detailedHeader
 
-            if extraLarge {
+            if let focusedAllowance {
+                MeterSurface(configuration: configuration) {
+                    HStack(alignment: .center, spacing: extraLarge ? 26 : 18) {
+                        UsageRing(
+                            title: focusedAllowance.title,
+                            window: focusedAllowance.window,
+                            configuration: configuration,
+                            prominent: true,
+                            showsReset: false
+                        )
+                        .frame(maxWidth: extraLarge ? 190 : 145)
+
+                        VStack(alignment: .leading, spacing: extraLarge ? 16 : 11) {
+                            BatteryUsageRow(
+                                title: focusedAllowance.longTitle,
+                                window: focusedAllowance.window,
+                                configuration: configuration
+                            )
+                            Divider()
+                            Label(
+                                "\(entry.snapshot.creditCount) credits",
+                                systemImage: "bolt.fill"
+                            )
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } else if extraLarge {
                 HStack(spacing: 14) {
                     MeterSurface(configuration: configuration) {
                         BatteryUsageRow(
@@ -133,7 +217,7 @@ struct CodexMeterHomeWidgetView: View {
                     }
                     MeterSurface(configuration: configuration) {
                         BatteryUsageRow(
-                            title: "Weekly allowance",
+                            title: LocalizedStringKey("\(entry.snapshot.longWindowTitle) allowance"),
                             window: entry.snapshot.weekly,
                             configuration: configuration
                         )
@@ -201,7 +285,7 @@ struct CodexMeterHomeWidgetView: View {
     private var footer: some View {
         HStack(spacing: 12) {
             Label {
-                if let nextReset = entry.snapshot.nextReset {
+                if let nextReset = configuration.allowance.nextReset(in: entry.snapshot) {
                     Text(nextReset, style: .timer)
                         .monospacedDigit()
                 } else {
@@ -218,3 +302,8 @@ struct CodexMeterHomeWidgetView: View {
     }
 }
 
+private struct FocusedAllowance {
+    let title: LocalizedStringKey
+    let longTitle: LocalizedStringKey
+    let window: WidgetUsageWindow
+}

--- a/ios/CodexMeterWidgets/Localizable.xcstrings
+++ b/ios/CodexMeterWidgets/Localizable.xcstrings
@@ -13,6 +13,12 @@
     "5 hours" : {
 
     },
+    "5-hour %@ used, weekly %@ used" : {
+
+    },
+    "5-hour only" : {
+
+    },
     "5h" : {
 
     },
@@ -31,7 +37,13 @@
     "94%" : {
 
     },
+    "A configurable circular Codex allowance dial." : {
+
+    },
     "Accent" : {
+
+    },
+    "Allowance" : {
 
     },
     "Appearance" : {
@@ -40,7 +52,22 @@
     "Blue" : {
 
     },
+    "Both allowance windows" : {
+
+    },
+    "Both allowance windows or one focused metric with locally updating reset timers." : {
+
+    },
+    "Both windows" : {
+
+    },
     "Cached" : {
+
+    },
+    "Choose which Codex allowance this circular widget shows." : {
+
+    },
+    "Choose which allowance appears, how the widget looks, and what happens when you tap it." : {
 
     },
     "Choose how the widget looks and what happens when you tap it." : {
@@ -55,7 +82,16 @@
     "Codex Meter" : {
 
     },
+    "Configure Codex allowances" : {
+
+    },
     "Configure Codex Meter" : {
+
+    },
+    "Configure five-hour allowance" : {
+
+    },
+    "Configure weekly allowance" : {
 
     },
     "Confirm reset" : {
@@ -133,10 +169,16 @@
     "See your five-hour and weekly Codex allowances and reset credits." : {
 
     },
+    "See both Codex allowance windows or focus on one responsive usage dial." : {
+
+    },
     "Show" : {
 
     },
     "Show percent symbol" : {
+
+    },
+    "Show both allowance windows or focus this accessory widget on one." : {
 
     },
     "Sign in or explore demo" : {
@@ -173,6 +215,12 @@
 
     },
     "Weekly allowance" : {
+
+    },
+    "Weekly only" : {
+
+    },
+    "W %@" : {
 
     },
     "Your current five-hour Codex allowance." : {

--- a/ios/CodexMeterWidgets/WidgetComponents.swift
+++ b/ios/CodexMeterWidgets/WidgetComponents.swift
@@ -78,6 +78,8 @@ struct UsageRing: View {
     let window: WidgetUsageWindow
     let configuration: MeterWidgetConfigurationIntent
     var compact = false
+    var prominent = false
+    var showsReset = true
 
     private var displayPercent: Double? {
         switch configuration.usageDisplay {
@@ -94,20 +96,20 @@ struct UsageRing: View {
         VStack(spacing: compact ? 3 : 6) {
             ZStack {
                 Circle()
-                    .stroke(.primary.opacity(0.10), lineWidth: compact ? 6 : 8)
+                    .stroke(.primary.opacity(0.10), lineWidth: ringWidth)
                 Circle()
                     .trim(from: 0, to: progress)
                     .stroke(
                         configuration.accent.color,
                         style: StrokeStyle(
-                            lineWidth: compact ? 6 : 8,
+                            lineWidth: ringWidth,
                             lineCap: .round
                         )
                     )
                     .rotationEffect(.degrees(-90))
                     .widgetAccentable()
                 Text(percentText(displayPercent, symbol: configuration.showsPercentSymbol))
-                    .font(compact ? .caption2.bold() : .headline.bold())
+                    .font(valueFont)
                     .minimumScaleFactor(0.65)
                     .lineLimit(1)
             }
@@ -118,7 +120,7 @@ struct UsageRing: View {
                 .fontWeight(.semibold)
                 .lineLimit(1)
 
-            if !compact, let resetsAt = window.resetsAt, resetsAt > .now {
+            if !compact, showsReset, let resetsAt = window.resetsAt, resetsAt > .now {
                 Text(resetsAt, style: .timer)
                     .font(.caption2.monospacedDigit())
                     .foregroundStyle(.secondary)
@@ -130,6 +132,20 @@ struct UsageRing: View {
         .accessibilityValue(
             Text(accessibilityPercent(displayPercent, display: configuration.usageDisplay))
         )
+    }
+
+    private var ringWidth: CGFloat {
+        if prominent {
+            return 10
+        }
+        return compact ? 6 : 8
+    }
+
+    private var valueFont: Font {
+        if prominent {
+            return .title2.bold()
+        }
+        return compact ? .caption2.bold() : .headline.bold()
     }
 }
 

--- a/ios/CodexMeterWidgets/WidgetConfiguration.swift
+++ b/ios/CodexMeterWidgets/WidgetConfiguration.swift
@@ -86,6 +86,23 @@ enum WidgetUsageDisplay: String, AppEnum, Sendable {
     ]
 }
 
+enum WidgetAllowance: String, AppEnum, Sendable {
+    case both
+    case fiveHour
+    case weekly
+
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Allowance")
+    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .both: "Both windows",
+        .fiveHour: "5-hour only",
+        .weekly: "Weekly / Monthly only"
+    ]
+
+    var isSingleMetric: Bool {
+        self != .both
+    }
+}
+
 enum WidgetTapAction: String, AppEnum, Sendable {
     case open
     case refresh
@@ -112,7 +129,10 @@ enum WidgetTapAction: String, AppEnum, Sendable {
 
 struct MeterWidgetConfigurationIntent: WidgetConfigurationIntent, Sendable {
     static let title: LocalizedStringResource = "Configure Codex Meter"
-    static let description = IntentDescription("Choose how the widget looks and what happens when you tap it.")
+    static let description = IntentDescription("Choose which allowance appears, how the widget looks, and what happens when you tap it.")
+
+    @Parameter(title: "Allowance", default: .both)
+    var allowance: WidgetAllowance
 
     @Parameter(title: "Appearance", default: .system)
     var appearance: WidgetAppearance
@@ -135,6 +155,7 @@ struct MeterWidgetConfigurationIntent: WidgetConfigurationIntent, Sendable {
     init() {}
 
     init(
+        allowance: WidgetAllowance = .both,
         appearance: WidgetAppearance = .system,
         accent: WidgetAccent = .blue,
         surfaceOpacity: WidgetSurfaceOpacity = .soft,
@@ -142,6 +163,7 @@ struct MeterWidgetConfigurationIntent: WidgetConfigurationIntent, Sendable {
         showsPercentSymbol: Bool = true,
         tapAction: WidgetTapAction = .open
     ) {
+        self.allowance = allowance
         self.appearance = appearance
         self.accent = accent
         self.surfaceOpacity = surfaceOpacity
@@ -155,3 +177,44 @@ extension MeterWidgetConfigurationIntent {
     static let preview = MeterWidgetConfigurationIntent()
 }
 
+struct FiveHourAccessoryConfigurationIntent: WidgetConfigurationIntent, Sendable {
+    static let title: LocalizedStringResource = "Configure five-hour allowance"
+    static let description = IntentDescription("Choose which Codex allowance this circular widget shows.")
+
+    @Parameter(title: "Allowance", default: .fiveHour)
+    var allowance: WidgetAllowance
+
+    init() {}
+
+    init(allowance: WidgetAllowance = .fiveHour) {
+        self.allowance = allowance
+    }
+}
+
+struct WeeklyAccessoryConfigurationIntent: WidgetConfigurationIntent, Sendable {
+    static let title: LocalizedStringResource = "Configure weekly allowance"
+    static let description = IntentDescription("Choose which Codex allowance this circular widget shows.")
+
+    @Parameter(title: "Allowance", default: .weekly)
+    var allowance: WidgetAllowance
+
+    init() {}
+
+    init(allowance: WidgetAllowance = .weekly) {
+        self.allowance = allowance
+    }
+}
+
+struct DualAccessoryConfigurationIntent: WidgetConfigurationIntent, Sendable {
+    static let title: LocalizedStringResource = "Configure Codex allowances"
+    static let description = IntentDescription("Show both allowance windows or focus this accessory widget on one.")
+
+    @Parameter(title: "Allowance", default: .both)
+    var allowance: WidgetAllowance
+
+    init() {}
+
+    init(allowance: WidgetAllowance = .both) {
+        self.allowance = allowance
+    }
+}

--- a/ios/CodexMeterWidgets/WidgetPreviews.swift
+++ b/ios/CodexMeterWidgets/WidgetPreviews.swift
@@ -11,13 +11,14 @@ import WidgetKit
     )
 }
 
-#Preview("Medium · Stale", as: .systemMedium) {
+#Preview("Medium · Weekly focus", as: .systemMedium) {
     CodexMeterHomeWidget()
 } timeline: {
     MeterWidgetEntry(
         date: .now,
         snapshot: .stalePreview,
         configuration: MeterWidgetConfigurationIntent(
+            allowance: .weekly,
             appearance: .dark,
             accent: .purple,
             surfaceOpacity: .strong,
@@ -28,13 +29,14 @@ import WidgetKit
     )
 }
 
-#Preview("Large · Fresh", as: .systemLarge) {
+#Preview("Large · Five-hour focus", as: .systemLarge) {
     CodexMeterHomeWidget()
 } timeline: {
     MeterWidgetEntry(
         date: .now,
         snapshot: .preview,
         configuration: MeterWidgetConfigurationIntent(
+            allowance: .fiveHour,
             accent: .teal,
             surfaceOpacity: .solid
         )
@@ -79,24 +81,49 @@ import WidgetKit
 #Preview("Five-hour Lock Screen", as: .accessoryCircular) {
     FiveHourAccessoryWidget()
 } timeline: {
-    AccessoryWidgetEntry(date: .now, snapshot: .preview)
+    ConfiguredAccessoryWidgetEntry(
+        date: .now,
+        snapshot: .preview,
+        allowance: .fiveHour
+    )
 }
 
 #Preview("Weekly Lock Screen", as: .accessoryCircular) {
     WeeklyAccessoryWidget()
 } timeline: {
-    AccessoryWidgetEntry(date: .now, snapshot: .stalePreview)
+    ConfiguredAccessoryWidgetEntry(
+        date: .now,
+        snapshot: .stalePreview,
+        allowance: .weekly
+    )
+}
+
+#Preview("Both Circular", as: .accessoryCircular) {
+    DualAllowanceAccessoryWidget()
+} timeline: {
+    ConfiguredAccessoryWidgetEntry(
+        date: .now,
+        snapshot: .preview,
+        allowance: .both
+    )
 }
 
 #Preview("Dual Lock Screen", as: .accessoryRectangular) {
     DualAllowanceAccessoryWidget()
 } timeline: {
-    AccessoryWidgetEntry(date: .now, snapshot: .preview)
+    ConfiguredAccessoryWidgetEntry(
+        date: .now,
+        snapshot: .preview,
+        allowance: .both
+    )
 }
 
-#Preview("Dual Inline", as: .accessoryInline) {
+#Preview("Weekly Inline", as: .accessoryInline) {
     DualAllowanceAccessoryWidget()
 } timeline: {
-    AccessoryWidgetEntry(date: .now, snapshot: .preview)
+    ConfiguredAccessoryWidgetEntry(
+        date: .now,
+        snapshot: .preview,
+        allowance: .weekly
+    )
 }
-

--- a/ios/CodexMeterWidgets/WidgetSnapshotStore.swift
+++ b/ios/CodexMeterWidgets/WidgetSnapshotStore.swift
@@ -40,8 +40,17 @@ struct WidgetDisplaySnapshot: Sendable, Equatable {
     let plan: String?
     let fiveHour: WidgetUsageWindow
     let weekly: WidgetUsageWindow
+    let longWindowIsMonthly: Bool
     let creditCount: Int
     let freshness: WidgetSnapshotFreshness
+
+    var longWindowTitle: String {
+        longWindowIsMonthly ? "Monthly" : "Weekly"
+    }
+
+    var longWindowShortTitle: String {
+        longWindowIsMonthly ? "Mo" : "Wk"
+    }
 
     var nextReset: Date? {
         [fiveHour.resetsAt, weekly.resetsAt]
@@ -57,6 +66,7 @@ struct WidgetDisplaySnapshot: Sendable, Equatable {
         plan: nil,
         fiveHour: .init(usedPercent: nil, durationSeconds: 18_000, resetsAt: nil),
         weekly: .init(usedPercent: nil, durationSeconds: 604_800, resetsAt: nil),
+        longWindowIsMonthly: false,
         creditCount: 0,
         freshness: .empty
     )
@@ -68,6 +78,7 @@ struct WidgetDisplaySnapshot: Sendable, Equatable {
         plan: nil,
         fiveHour: .init(usedPercent: nil, durationSeconds: 18_000, resetsAt: nil),
         weekly: .init(usedPercent: nil, durationSeconds: 604_800, resetsAt: nil),
+        longWindowIsMonthly: false,
         creditCount: 0,
         freshness: .empty
     )
@@ -87,6 +98,7 @@ struct WidgetDisplaySnapshot: Sendable, Equatable {
             durationSeconds: 604_800,
             resetsAt: .now.addingTimeInterval(234_000)
         ),
+        longWindowIsMonthly: false,
         creditCount: 3,
         freshness: .fresh
     )
@@ -106,6 +118,7 @@ struct WidgetDisplaySnapshot: Sendable, Equatable {
             durationSeconds: 604_800,
             resetsAt: .now.addingTimeInterval(340_000)
         ),
+        longWindowIsMonthly: false,
         creditCount: 1,
         freshness: .stale
     )
@@ -181,10 +194,11 @@ private extension WidgetDisplaySnapshot {
                 defaultDuration: 18_000
             ),
             weekly: Self.window(
-                from: shared.weekly,
+                from: shared.longWindow,
                 fetchedAt: shared.fetchedAt,
-                defaultDuration: 604_800
+                defaultDuration: shared.longWindowIsMonthly ? 2_592_000 : 604_800
             ),
+            longWindowIsMonthly: shared.longWindowIsMonthly,
             creditCount: max(0, shared.resetCreditsAvailable ?? 0),
             freshness: mode == .signedOut ? .empty : freshness
         )

--- a/ios/CodexMeterWidgets/WidgetTimeline.swift
+++ b/ios/CodexMeterWidgets/WidgetTimeline.swift
@@ -44,53 +44,165 @@ struct MeterWidgetTimelineProvider: AppIntentTimelineProvider {
         let normalReload = now.addingTimeInterval(
             snapshot.freshness == .stale ? 5 * 60 : 15 * 60
         )
-        let resetReload = snapshot.nextReset.map { $0.addingTimeInterval(10) }
+        let resetReload = configuration.allowance
+            .nextReset(in: snapshot, after: now)
+            .map { $0.addingTimeInterval(10) }
         let reloadDate = resetReload.map { min($0, normalReload) } ?? normalReload
         return Timeline(entries: [entry], policy: .after(reloadDate))
     }
 }
 
-struct AccessoryWidgetEntry: TimelineEntry, Sendable {
+struct ConfiguredAccessoryWidgetEntry: TimelineEntry, Sendable {
     let date: Date
     let snapshot: WidgetDisplaySnapshot
+    let allowance: WidgetAllowance
 }
 
-struct AccessoryWidgetTimelineProvider: TimelineProvider {
+private func accessoryTimeline(
+    snapshot: WidgetDisplaySnapshot,
+    allowance: WidgetAllowance,
+    now: Date
+) -> Timeline<ConfiguredAccessoryWidgetEntry> {
+    let normalReload = now.addingTimeInterval(
+        snapshot.freshness == .stale ? 5 * 60 : 15 * 60
+    )
+    let resetReload = allowance
+        .nextReset(in: snapshot, after: now)
+        .map { $0.addingTimeInterval(10) }
+    let reloadDate = resetReload.map { min($0, normalReload) } ?? normalReload
+    return Timeline(
+        entries: [
+            ConfiguredAccessoryWidgetEntry(
+                date: now,
+                snapshot: snapshot,
+                allowance: allowance
+            )
+        ],
+        policy: .after(reloadDate)
+    )
+}
+
+struct FiveHourAccessoryTimelineProvider: AppIntentTimelineProvider {
     private let store = WidgetSnapshotStore()
 
-    func placeholder(in context: Context) -> AccessoryWidgetEntry {
-        AccessoryWidgetEntry(date: .now, snapshot: .preview)
-    }
-
-    func getSnapshot(
-        in context: Context,
-        completion: @escaping (AccessoryWidgetEntry) -> Void
-    ) {
-        completion(
-            AccessoryWidgetEntry(
-                date: .now,
-                snapshot: context.isPreview ? .preview : store.load()
-            )
+    func placeholder(in context: Context) -> ConfiguredAccessoryWidgetEntry {
+        ConfiguredAccessoryWidgetEntry(
+            date: .now,
+            snapshot: .preview,
+            allowance: .fiveHour
         )
     }
 
-    func getTimeline(
-        in context: Context,
-        completion: @escaping (Timeline<AccessoryWidgetEntry>) -> Void
-    ) {
+    func snapshot(
+        for configuration: FiveHourAccessoryConfigurationIntent,
+        in context: Context
+    ) async -> ConfiguredAccessoryWidgetEntry {
+        ConfiguredAccessoryWidgetEntry(
+            date: .now,
+            snapshot: context.isPreview ? .preview : store.load(),
+            allowance: configuration.allowance
+        )
+    }
+
+    func timeline(
+        for configuration: FiveHourAccessoryConfigurationIntent,
+        in context: Context
+    ) async -> Timeline<ConfiguredAccessoryWidgetEntry> {
         let now = Date.now
         let snapshot = store.load()
-        let normalReload = now.addingTimeInterval(
-            snapshot.freshness == .stale ? 5 * 60 : 15 * 60
-        )
-        let resetReload = snapshot.nextReset.map { $0.addingTimeInterval(10) }
-        let reloadDate = resetReload.map { min($0, normalReload) } ?? normalReload
-        completion(
-            Timeline(
-                entries: [AccessoryWidgetEntry(date: now, snapshot: snapshot)],
-                policy: .after(reloadDate)
-            )
+        return accessoryTimeline(
+            snapshot: snapshot,
+            allowance: configuration.allowance,
+            now: now
         )
     }
 }
 
+struct WeeklyAccessoryTimelineProvider: AppIntentTimelineProvider {
+    private let store = WidgetSnapshotStore()
+
+    func placeholder(in context: Context) -> ConfiguredAccessoryWidgetEntry {
+        ConfiguredAccessoryWidgetEntry(
+            date: .now,
+            snapshot: .preview,
+            allowance: .weekly
+        )
+    }
+
+    func snapshot(
+        for configuration: WeeklyAccessoryConfigurationIntent,
+        in context: Context
+    ) async -> ConfiguredAccessoryWidgetEntry {
+        ConfiguredAccessoryWidgetEntry(
+            date: .now,
+            snapshot: context.isPreview ? .preview : store.load(),
+            allowance: configuration.allowance
+        )
+    }
+
+    func timeline(
+        for configuration: WeeklyAccessoryConfigurationIntent,
+        in context: Context
+    ) async -> Timeline<ConfiguredAccessoryWidgetEntry> {
+        let now = Date.now
+        let snapshot = store.load()
+        return accessoryTimeline(
+            snapshot: snapshot,
+            allowance: configuration.allowance,
+            now: now
+        )
+    }
+}
+
+struct DualAccessoryTimelineProvider: AppIntentTimelineProvider {
+    private let store = WidgetSnapshotStore()
+
+    func placeholder(in context: Context) -> ConfiguredAccessoryWidgetEntry {
+        ConfiguredAccessoryWidgetEntry(
+            date: .now,
+            snapshot: .preview,
+            allowance: .both
+        )
+    }
+
+    func snapshot(
+        for configuration: DualAccessoryConfigurationIntent,
+        in context: Context
+    ) async -> ConfiguredAccessoryWidgetEntry {
+        ConfiguredAccessoryWidgetEntry(
+            date: .now,
+            snapshot: context.isPreview ? .preview : store.load(),
+            allowance: configuration.allowance
+        )
+    }
+
+    func timeline(
+        for configuration: DualAccessoryConfigurationIntent,
+        in context: Context
+    ) async -> Timeline<ConfiguredAccessoryWidgetEntry> {
+        let now = Date.now
+        let snapshot = store.load()
+        return accessoryTimeline(
+            snapshot: snapshot,
+            allowance: configuration.allowance,
+            now: now
+        )
+    }
+}
+
+extension WidgetAllowance {
+    func nextReset(
+        in snapshot: WidgetDisplaySnapshot,
+        after date: Date = .now
+    ) -> Date? {
+        let candidates: [Date?] = switch self {
+        case .both:
+            [snapshot.fiveHour.resetsAt, snapshot.weekly.resetsAt]
+        case .fiveHour:
+            [snapshot.fiveHour.resetsAt]
+        case .weekly:
+            [snapshot.weekly.resetsAt]
+        }
+        return candidates.compactMap { $0 }.filter { $0 > date }.min()
+    }
+}

--- a/ios/EULA.md
+++ b/ios/EULA.md
@@ -1,0 +1,25 @@
+# Codex Meter End User License Agreement
+
+Last updated: July 20, 2026
+
+Codex Meter is licensed through Apple’s App Store under the
+[Apple Standard End User License Agreement](https://www.apple.com/legal/internet-services/itunes/dev/stdeula/).
+That agreement governs the license to use the app. The notices below do not
+replace or modify Apple’s Standard EULA.
+
+## App-specific notices
+
+- Codex Meter is an independent, unofficial client and is not affiliated with,
+  sponsored by, or endorsed by OpenAI.
+- The app connects directly to OpenAI services using the user’s authorization.
+  OpenAI services remain subject to OpenAI’s terms and policies.
+- Private or undocumented service routes may change, become unavailable, or
+  require the app to be updated.
+- Redeeming a reset credit changes the user’s OpenAI account and may be
+  irreversible. The app displays a confirmation before sending the request.
+- Usage values and reset times are informational and depend on data supplied by
+  OpenAI.
+- Open-source notices and applicable licenses are available inside the app.
+
+For questions about the iOS app, contact
+[Filip Bukovina](https://github.com/FBukovina) through GitHub.

--- a/ios/PRIVACY.md
+++ b/ios/PRIVACY.md
@@ -1,30 +1,61 @@
 # Codex Meter Privacy Policy
 
-Last updated: July 12, 2026
+Last updated: July 30, 2026
 
-Codex Meter does not operate an account system, analytics service, advertising
-network, or application relay server.
+Codex Meter is designed so the iOS developer does not collect user data. The
+app has no analytics, advertising, tracking, developer-operated account system,
+or application relay server.
 
-When you choose to sign in, the app opens an OpenAI-controlled authentication
-page and exchanges the resulting device authorization directly with OpenAI.
-OAuth access, refresh, and identity tokens are stored in the Apple Keychain on
-your device and are not included in backups or synchronized through iCloud.
+## Authentication and OpenAI services
 
-The app sends authenticated requests directly to OpenAI and ChatGPT only to:
+When the user chooses to sign in, Codex Meter uses OpenAI’s device
+authorization service. Authenticated requests travel directly between the
+device and OpenAI to load Codex allowance, reset times, reset-credit inventory,
+and to redeem a reset credit after confirmation.
 
-- load your Codex allowance and reset times;
-- load your earned reset-credit inventory; and
-- redeem a reset credit after you explicitly confirm the action.
+OpenAI may process information under its own privacy policy and terms. Codex
+Meter does not receive a copy on a developer-controlled server. See the
+[OpenAI Privacy Policy](https://openai.com/policies/privacy-policy/).
 
-The app stores the last successful response locally so information remains
-visible offline. Its widget extension receives only a sanitized snapshot with
-percentages, reset dates, plan label, update time, and reset-credit count. It
-never receives OAuth credentials, account identifiers, or reset-credit IDs.
+## Information stored on the device
 
-You can remove all locally stored credentials and cached account data by using
-Sign Out in Settings. The app also attempts to revoke the refresh token with
-OpenAI, but local deletion succeeds even if the network is unavailable.
+- OAuth access, refresh, and identity tokens are stored in Apple Keychain.
+- The last successful usage response is cached locally for offline display.
+- Bounded five-hour and weekly percentage samples are stored locally to draw
+  burn charts and improve pace estimates. They contain no tokens or account
+  identifiers and can be cleared independently in the app.
+- Notification and appearance preferences remain on the device.
+- Widgets receive only percentages, reset dates, plan label, update time, and
+  reset-credit count.
 
-Demo mode is entirely local and does not contact OpenAI.
+Widgets never receive OAuth credentials, account identifiers, or reset-credit
+IDs.
+
+## Notifications and diagnostics
+
+Notifications are scheduled locally after permission is granted. Codex Meter
+does not include a crash-reporting or telemetry SDK and does not transmit app
+interaction, advertising, or diagnostic data to the developer.
+
+## Retention, deletion, and choices
+
+Local cache data remains until it is replaced or the user signs out. Local burn
+history can also be cleared at any time without signing out. Choosing Sign Out
+removes credentials, cached account data, burn history, pending background work,
+and scheduled notifications from the device. The app also attempts to revoke
+the OpenAI refresh token; local deletion succeeds even when the network is
+unavailable. Settings exports are created only when requested and contain
+preferences—not credentials or usage samples.
+
+Demo mode is entirely local and does not contact OpenAI. Notification
+permission is optional.
+
+## Children, changes, and contact
+
+Codex Meter is not directed to children and does not knowingly collect personal
+information from children. Material changes will be posted with a revised date.
+
+For privacy or support questions, contact
+[Filip Bukovina](https://github.com/FBukovina) through GitHub.
 
 Codex Meter is unofficial and is not affiliated with or endorsed by OpenAI.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,17 +1,21 @@
 # Codex Meter for iPhone and iPad
 
 Native SwiftUI client for viewing the Codex allowance attached to a signed-in
-ChatGPT account. It shows the short and weekly usage windows, reset times,
-earned reset credits, local notifications, and WidgetKit widgets.
+ChatGPT account. It shows adaptive standard and model-specific usage windows,
+Free-tier monthly limits, purchased usage credits, reset times, earned reset
+credits, local burn history, notifications, and WidgetKit widgets.
 
 This directory is the **iOS** package of the Codex Meter monorepo. The Android
 application lives under [`../android/`](../android/). Behavior is aligned with
 the Android app where platform APIs allow; it does not include Samsung One UI,
-Now Bar / Live Update monitors, or Android in-app APK updates.
+Wear OS tiles/complications, Now Bar / Live Update monitors, or Android in-app
+APK updates.
 
-Portable notification features from Android 2.1/2.2 are included: unexpected
-refill alerts, independent reset-credit increase alerts, and configurable
-reset-credit expiry reminders.
+Portable behavior through Android 2.8.0 is included: adaptive refresh, additional
+limit parsing, Free-tier monthly windows, reorderable dashboard sections,
+scrubbable on-device burn charts with insights and plan-value estimates,
+usage-history customize, usage-credit and reset-credit auto-hiding, diagnostic
+log export, and widgets that follow the weekly or monthly long window.
 
 ## Requirements
 


### PR DESCRIPTION
## What

Bring the iOS client up to portable Android **2.8.0** behavior. The in-tree `ios/` app was still on the earlier 2.4/2.5 surface; this ports every iOS-relevant change from 2.6.0 through 2.8.0.

### 2.8.0
- **Free-tier monthly Codex windows**: when a paid plan expires to Free, the ~30-day window is parsed and shown on the dashboard, history, widgets, alerts, celebrations, and adaptive refresh instead of failing with “no recognizable Codex usage data” and leaving a stale Pro badge.
- **Usage-history Customize**: chart guide, previous-window list, insight rows, and value estimates can be shown or hidden individually; the guide starts hidden.
- **Opt-in diagnostics**: unlock via About header taps, then export sanitized JSONL logs. Credentials, emails, JWTs, and OAuth query params are redacted.

### 2.7.0 (portable)
- Scrubbable usage-history analytics with per-window insights and plan-value estimates.

### 2.6.8–2.6.10 (portable)
- Reset-credit cards auto-hide when inventory is empty or unknown.
- Usage history stays off the dashboard until a 5-hour, weekly, or monthly window exists.
- Low-usage alerts no longer re-fire when OpenAI’s reset timestamp drifts inside the same window.

### 2.6.0–2.6.7 (already needed on iOS)
- Adaptive refresh, additional-limit parsing, reorderable dashboard sections, on-device burn history, and usage-credit auto-hiding.

Android-only surfaces are unchanged: Wear OS, Now Bar / Live Updates, in-app APK updates, and the alpha channel.

## Why

Android 2.8.0 shipped today. Without this, iOS still cannot display Free-tier monthly limits and is missing the history/diagnostics work that landed after 2.5.0.

## Impact

- iOS marketing version is **2.8.0**.
- Existing paid-plan 5-hour/weekly accounts keep the same cards; monthly appears only when OpenAI reports that window.
- Settings transfer now includes dashboard visibility and history-highlight overrides. Credentials are still never exported.
- Diagnostics stay off until the user unlocks them from About.

## Checks

- `swift test --package-path ios/CodexMeterCore` — 43 tests passed
- `xcodebuild -project ios/CodexMeter.xcodeproj -scheme CodexMeter -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — succeeded
- App unit tests on iPhone 17e simulator — passed

## Notes

This is an iOS-only change against `main` because 2.8.0 is already the stable Android release and iOS has no alpha update channel.