### PR TITLE
Add iOS CI on GitHub macOS runners

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,119 @@
+name: iOS CI
+
+on:
+  pull_request:
+    branches: [main, alpha]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  core-tests:
+    name: CodexMeterCore package tests
+    runs-on: macos-26
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: ios
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Show Swift toolchain
+        shell: bash
+        run: swift --version
+
+      - name: Run CodexMeterCore tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          swift test --package-path CodexMeterCore
+
+  app-build-and-test:
+    name: App build and simulator tests
+    runs-on: macos-26
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: ios
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Show Xcode version
+        shell: bash
+        run: xcodebuild -version
+
+      - name: Select iPhone simulator
+        id: simulator
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcrun simctl list devices available
+          DEVICE="iPhone 17e"
+          if ! xcrun simctl list devices available | grep -Fq "$DEVICE ("; then
+            DEVICE="$(xcrun simctl list devices available \
+              | sed -nE 's/^[[:space:]]+(iPhone [A-Za-z0-9 ]*[A-Za-z0-9]) \(.*/\1/p' \
+              | head -n 1)"
+          fi
+          if [[ -z "$DEVICE" ]]; then
+            echo "::error::No available iPhone simulator on this runner image"
+            exit 1
+          fi
+          echo "Using simulator: $DEVICE"
+          echo "device=$DEVICE" >> "$GITHUB_OUTPUT"
+
+      - name: Build app for generic iOS Simulator
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v xcbeautify >/dev/null 2>&1; then
+            xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
+              -destination 'generic/platform=iOS Simulator' \
+              -derivedDataPath DerivedData \
+              CODE_SIGNING_ALLOWED=NO build \
+              | xcbeautify --renderer github-actions
+          else
+            xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
+              -destination 'generic/platform=iOS Simulator' \
+              -derivedDataPath DerivedData \
+              CODE_SIGNING_ALLOWED=NO build
+          fi
+
+      - name: Run unit and UI tests on simulator
+        shell: bash
+        env:
+          DEVICE_NAME: ${{ steps.simulator.outputs.device }}
+        run: |
+          set -euo pipefail
+          if command -v xcbeautify >/dev/null 2>&1; then
+            xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
+              -destination "platform=iOS Simulator,name=$DEVICE_NAME" \
+              -derivedDataPath DerivedData \
+              -resultBundlePath TestResults.xcresult \
+              -parallel-testing-enabled NO test \
+              | xcbeautify --renderer github-actions
+          else
+            xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
+              -destination "platform=iOS Simulator,name=$DEVICE_NAME" \
+              -derivedDataPath DerivedData \
+              -resultBundlePath TestResults.xcresult \
+              -parallel-testing-enabled NO test
+          fi
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-test-results
+          path: ios/TestResults.xcresult
+          if-no-files-found: ignore
+          retention-days: 3

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -94,19 +94,24 @@ jobs:
           DEVICE_NAME: ${{ steps.simulator.outputs.device }}
         run: |
           set -euo pipefail
+          # -retry-tests-on-failure absorbs shared-runner simulator jank in the
+          # UI tests; deterministic failures still fail after 3 iterations, and
+          # pass-on-retry results stay visible in the xcresult bundle.
           if command -v xcbeautify >/dev/null 2>&1; then
             xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
               -destination "platform=iOS Simulator,name=$DEVICE_NAME" \
               -derivedDataPath DerivedData \
               -resultBundlePath TestResults.xcresult \
-              -parallel-testing-enabled NO test \
+              -parallel-testing-enabled NO \
+              -retry-tests-on-failure -test-iterations 3 test \
               | xcbeautify --renderer github-actions
           else
             xcodebuild -project CodexMeter.xcodeproj -scheme CodexMeter \
               -destination "platform=iOS Simulator,name=$DEVICE_NAME" \
               -derivedDataPath DerivedData \
               -resultBundlePath TestResults.xcresult \
-              -parallel-testing-enabled NO test
+              -parallel-testing-enabled NO \
+              -retry-tests-on-failure -test-iterations 3 test
           fi
 
       - name: Upload test results on failure

--- a/ios/CodexMeter.xcodeproj/xcshareddata/xcschemes/CodexMeter.xcscheme
+++ b/ios/CodexMeter.xcodeproj/xcshareddata/xcschemes/CodexMeter.xcscheme
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2650"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "81D08CD130041D77000759C6"
+               BuildableName = "CodexMeter.app"
+               BlueprintName = "CodexMeter"
+               ReferencedContainer = "container:CodexMeter.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A70000000000000000000003"
+               BuildableName = "CodexMeterTests.xctest"
+               BlueprintName = "CodexMeterTests"
+               ReferencedContainer = "container:CodexMeter.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A70000000000000000000002"
+               BuildableName = "CodexMeterUITests.xctest"
+               BlueprintName = "CodexMeterUITests"
+               ReferencedContainer = "container:CodexMeter.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "81D08CD130041D77000759C6"
+            BuildableName = "CodexMeter.app"
+            BlueprintName = "CodexMeter"
+            ReferencedContainer = "container:CodexMeter.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "81D08CD130041D77000759C6"
+            BuildableName = "CodexMeter.app"
+            BlueprintName = "CodexMeter"
+            ReferencedContainer = "container:CodexMeter.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/CodexMeterUITests/CodexMeterUITests.swift
+++ b/ios/CodexMeterUITests/CodexMeterUITests.swift
@@ -18,10 +18,16 @@ final class CodexMeterUITests: XCTestCase {
         XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["Mode"].exists)
         XCTAssertTrue(app.buttons["Leave Demo"].exists)
-        for _ in 0..<6 where !app.buttons["Send test notification"].exists {
+        // Assert in scroll order: "System permission" sits above "Send test
+        // notification" in the Notifications section, and scrolling straight to
+        // the button can cull the earlier row out of the lazy Form hierarchy.
+        for _ in 0..<6 where !app.staticTexts["System permission"].exists {
             app.swipeUp()
         }
         XCTAssertTrue(app.staticTexts["System permission"].waitForExistence(timeout: 3))
+        for _ in 0..<6 where !app.buttons["Send test notification"].exists {
+            app.swipeUp()
+        }
         XCTAssertTrue(app.buttons["Send test notification"].waitForExistence(timeout: 3))
     }
 

--- a/ios/CodexMeterUITests/CodexMeterUITests.swift
+++ b/ios/CodexMeterUITests/CodexMeterUITests.swift
@@ -73,9 +73,7 @@ final class CodexMeterUITests: XCTestCase {
     func testResetRequiresIrreversibleConfirmation() throws {
         let app = launchDemo()
 
-        for _ in 0..<4 where !app.buttons["Use 1 reset"].exists {
-            app.swipeUp()
-        }
+        scrollDashboard(untilHittable: app.buttons["Use 1 reset"], in: app)
         XCTAssertTrue(app.buttons["Use 1 reset"].waitForExistence(timeout: 5))
         app.buttons["Use 1 reset"].tap()
         XCTAssertTrue(app.navigationBars["Codex reset"].waitForExistence(timeout: 3))
@@ -117,5 +115,24 @@ final class CodexMeterUITests: XCTestCase {
         app.launchArguments = ["-ui-testing-demo", "-ui-testing-reset-settings"]
         app.launch()
         return app
+    }
+
+    /// Scrolls the dashboard with short drags from alternating anchor points.
+    /// The usage-history chart scrubs via DragGesture(minimumDistance: 0), so
+    /// it swallows any scroll gesture that starts inside its plot area. The two
+    /// anchors are farther apart than the plot is tall, so the chart can never
+    /// capture two consecutive attempts and scrolling always makes progress.
+    private func scrollDashboard(
+        untilHittable element: XCUIElement,
+        in app: XCUIApplication,
+        maxAttempts: Int = 10
+    ) {
+        let anchors: [CGFloat] = [0.85, 0.45]
+        for attempt in 0..<maxAttempts where !element.isHittable {
+            let dy = anchors[attempt % anchors.count]
+            let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: dy))
+            let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: dy - 0.35))
+            start.press(forDuration: 0.05, thenDragTo: end)
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated iOS CI workflow that builds and tests the SwiftUI app on GitHub-hosted **macOS runners** (`macos-26`, default Xcode 26.6 with the iOS 26 SDK this project targets), plus the shared Xcode scheme CI needs and two UI-test robustness fixes that real runner executions exposed.

### `.github/workflows/ios-ci.yml`

Triggers on pull requests to `main`/`alpha` that touch `ios/**` (or the workflow itself) and on manual dispatch, so Android-only PRs never spin up macOS runners. Two jobs, both on `macos-26`:

- **CodexMeterCore package tests** — `swift test --package-path CodexMeterCore`, the same fast check documented in `AGENTS.md` and `ios/README.md`.
- **App build and simulator tests** — the two `xcodebuild` invocations documented in `ios/README.md`: a generic iOS Simulator build with `CODE_SIGNING_ALLOWED=NO`, then the full `CodexMeterTests` + `CodexMeterUITests` suite with `-parallel-testing-enabled NO`. The simulator is picked at runtime (prefers iPhone 17e per the README, falls back to the first available iPhone). `-retry-tests-on-failure -test-iterations 3` absorbs shared-runner simulator jank, and the `.xcresult` bundle is uploaded as an artifact on failure.

Superseded PR runs are auto-cancelled via a concurrency group, and `xcbeautify` (preinstalled on the image) renders inline GitHub annotations.

### `ios/CodexMeter.xcodeproj/xcshareddata/xcschemes/CodexMeter.xcscheme`

The repo had no shared scheme, so `xcodebuild -scheme CodexMeter` failed on any fresh checkout (schemes only auto-generate when the project is opened in the Xcode GUI). This commits a shared scheme wired to the existing target GUIDs: app target for build/run/archive, both test bundles as testables.

### `ios/CodexMeterUITests/CodexMeterUITests.swift`

Two flakes surfaced by real runner executions, both scroll-mechanics bugs in the tests (not app bugs):

- `testDemoDashboardAndSettings` scrolled straight to "Send test notification" and then asserted "System permission", which sits above it in the Notifications section — the lazy Form can cull the earlier row off the top. Now asserts in scroll order.
- `testResetRequiresIrreversibleConfirmation` used blind `swipeUp()` calls; the usage-history chart scrubs via `DragGesture(minimumDistance: 0)`, so any swipe starting inside its plot area gets swallowed and the scroll never progresses. New `scrollDashboard(untilHittable:)` helper drags from two alternating anchors spaced farther apart than the plot height, so the chart can never capture consecutive attempts.

## Testing

Verified end-to-end on this PR with three real `macos-26` runner executions:

- Final run fully green: CodexMeterCore package tests pass in 45s; app build + all 25 unit tests + all 6 UI tests pass in 7m47s on iPhone 17e / Xcode 26.6, **with zero retries used**.
- The two intermediate runs each caught one of the UI-test flakes fixed above (all 25 unit tests passed in every run).
- Existing Android `Build Codex Meter APK` workflow still passes; `actionlint` + shellcheck clean (only false-positive `macos-26` label warnings from the linter's stale hardcoded label list).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d687685-6c16-42bf-8fa2-76dcffc56994?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d687685-6c16-42bf-8fa2-76dcffc56994&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

