### PR TITLE
Show API reset timelines even at 100% remaining

### DIFF
--- a/android/run-tests.sh
+++ b/android/run-tests.sh
@@ -642,6 +642,9 @@ grep -q 'resetPaint.setColor(foreground);' \
   "$ROOT/app/src/main/java/dev/bennett/codexmeter/UsageWaveView.java"
 grep -q 'showsResetCountdown' \
   "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java"
+grep -q 'testResetCountdownFollowsApiTimeline' "$ROOT/tests/ParserSelfTest.java"
+! grep -q 'remainingPercent() <= 99' \
+  "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java"
 grep -q 'testUsagePace' "$ROOT/tests/ParserSelfTest.java"
 grep -q 'UsagePace.mostAcceleratedWindow' "$ROOT/tests/ParserSelfTest.java"
 test -f "$ROOT/shared/src/main/java/dev/bennett/codexmeter/UsagePace.java"

--- a/android/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java
+++ b/android/shared/src/main/java/dev/bennett/codexmeter/UsageWindow.java
@@ -23,11 +23,12 @@ public final class UsageWindow {
     }
 
     /**
-     * Full windows keep drifting the reset clock without real consumption.
-     * Hide countdown/reset labels until remaining drops to 99% or less.
+     * Whether OpenAI reported a reset timeline for this window.
+     * Unused windows with no {@code reset_at} / {@code reset_after_seconds} stay blank.
+     * A 100% remaining window that still includes a timeline is shown as-is.
      */
     public boolean showsResetCountdown() {
-        return remainingPercent() <= 99;
+        return resetAtEpochSeconds > 0L || resetAfterSeconds > 0L;
     }
 
     public long resetAtMillis() {

--- a/android/tests/ParserSelfTest.java
+++ b/android/tests/ParserSelfTest.java
@@ -29,7 +29,7 @@ public final class ParserSelfTest {
         testCelebrationDetection();
         testResetCreditExpiryReminders();
         testResetCreditExpiryOrdering();
-        testFullWindowHidesResetCountdown();
+        testResetCountdownFollowsApiTimeline();
         testLowUsageAlertDedup();
         testUsageHistory();
         testUsagePace();
@@ -90,16 +90,24 @@ public final class ParserSelfTest {
         System.out.println("Diagnostic sanitizer strips credentials, identity, and URL queries.");
     }
 
-    private static void testFullWindowHidesResetCountdown() {
-        UsageWindow full = new UsageWindow(0, 18000L, 600L, 2000000000L);
-        UsageWindow almostFull = new UsageWindow(1, 18000L, 600L, 2000000000L);
-        UsageWindow used = new UsageWindow(37, 18000L, 600L, 2000000000L);
-        check(full.remainingPercent() == 100, "full window remaining");
-        check(!full.showsResetCountdown(), "100% remaining hides drifting reset countdown");
-        check(almostFull.remainingPercent() == 99, "1% used is 99% remaining");
-        check(almostFull.showsResetCountdown(), "99% remaining still shows reset countdown");
-        check(used.showsResetCountdown(), "partial usage shows reset countdown");
-        System.out.println("Reset-countdown demo: hide at 100% remaining, show again at 99% or less.");
+    private static void testResetCountdownFollowsApiTimeline() {
+        UsageWindow unusedNoReset = new UsageWindow(0, 18000L, 0L, 0L);
+        UsageWindow unusedWithResetAt = new UsageWindow(0, 18000L, 0L, 2000000000L);
+        UsageWindow unusedWithResetAfter = new UsageWindow(0, 18000L, 600L, 0L);
+        UsageWindow usedNoReset = new UsageWindow(37, 18000L, 0L, 0L);
+        UsageWindow usedWithReset = new UsageWindow(37, 18000L, 600L, 2000000000L);
+        check(unusedNoReset.remainingPercent() == 100, "unused window remaining");
+        check(!unusedNoReset.showsResetCountdown(),
+                "unused window without API reset stays blank");
+        check(unusedWithResetAt.showsResetCountdown(),
+                "100% remaining still shows API reset_at");
+        check(unusedWithResetAfter.showsResetCountdown(),
+                "100% remaining still shows API reset_after");
+        check(!usedNoReset.showsResetCountdown(),
+                "used window without API reset stays blank");
+        check(usedWithReset.showsResetCountdown(),
+                "used window with API reset shows countdown");
+        System.out.println("Reset countdown follows the API timeline, including at 100% remaining.");
     }
 
     private static void testLowUsageAlertDedup() {
@@ -515,6 +523,19 @@ public final class ParserSelfTest {
                 "Wear reset label uses observation-based reset-after fallback");
         check(WearGlanceFormat.nextResetRelativeText(fallbackTimed, now).contains("h"),
                 "Wear fallback reset countdown remains finite");
+        UsageSnapshot unused = new UsageSnapshot("demo", true, false,
+                new UsageWindow(0, 18000L, 0L, 0L),
+                new UsageWindow(0, 604800L, 0L, 0L), now);
+        check("--".equals(WearGlanceFormat.nextResetWindowLabel(unused, now)),
+                "unused windows without API reset have no next-reset label");
+        check("No reset yet".equals(WearGlanceFormat.nextResetLongText(unused, now)),
+                "unused windows without API reset show no reset timeframe");
+        UsageSnapshot unusedWithReset = new UsageSnapshot("demo", true, false,
+                new UsageWindow(0, 18000L, 0L,
+                        (now + TimeUnit.HOURS.toMillis(3)) / 1000L),
+                null, now);
+        check("5h reset".equals(WearGlanceFormat.nextResetWindowLabel(unusedWithReset, now)),
+                "100% remaining still surfaces an API reset timeline");
         UsageSnapshot account = new UsageSnapshot("plus", true, true, five, weekly, 2, now);
         check("Limit reached".equals(WearGlanceFormat.accountStatus(account)),
                 "Wear account status surfaces a reached limit");

--- a/android/wear/src/main/java/dev/bennett/codexmeter/CodexTileLayouts.java
+++ b/android/wear/src/main/java/dev/bennett/codexmeter/CodexTileLayouts.java
@@ -367,7 +367,7 @@ final class CodexTileLayouts {
     }
 
     private static String resetCopy(UsageWindow window, long observedAtMillis, long nowMillis) {
-        if (window == null) return "Reset unavailable";
+        if (window == null || !window.showsResetCountdown()) return "Reset unavailable";
         long resetAt = window.effectiveResetAtMillis(observedAtMillis);
         if (resetAt <= nowMillis) return "Resets soon";
         long minutes = Math.max(1L,

--- a/ios/CodexMeter/Views/UsageMeterCard.swift
+++ b/ios/CodexMeter/Views/UsageMeterCard.swift
@@ -46,7 +46,8 @@ struct UsageMeterCard: View {
                         .contentTransition(.numericText())
                 }
 
-                if let window, let resetAt = window.effectiveResetDate(relativeTo: fetchedAt) {
+                if let window, window.showsResetCountdown,
+                   let resetAt = window.effectiveResetDate(relativeTo: fetchedAt) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Resets in")
                             .font(.caption)
@@ -58,8 +59,8 @@ struct UsageMeterCard: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                } else {
-                    Text(window == nil ? "Waiting for data" : "Reset time unavailable")
+                } else if window == nil {
+                    Text("Waiting for data")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/Models.swift
@@ -25,6 +25,13 @@ public struct UsageWindow: Codable, Sendable, Equatable {
         min(100, max(0, 100 - usedPercent))
     }
 
+    /// Whether OpenAI reported a reset timeline for this window.
+    /// Unused windows with no `reset_at` / `reset_after_seconds` stay blank.
+    /// A 100% remaining window that still includes a timeline is shown as-is.
+    public var showsResetCountdown: Bool {
+        resetAt != nil || resetAfterSeconds > 0
+    }
+
     public func effectiveResetDate(relativeTo referenceDate: Date) -> Date? {
         if let resetAt {
             return resetAt

--- a/ios/CodexMeterCore/Sources/CodexMeterCore/UsageFormat.swift
+++ b/ios/CodexMeterCore/Sources/CodexMeterCore/UsageFormat.swift
@@ -59,7 +59,7 @@ public enum UsageFormat {
         locale: Locale = .current,
         uses24HourClock: Bool = false
     ) -> String {
-        guard let window, display != .hidden else {
+        guard let window, display != .hidden, window.showsResetCountdown else {
             return ""
         }
         guard let resetAt = window.effectiveResetDate(relativeTo: fetchedAt) else {

--- a/ios/CodexMeterCore/Tests/CodexMeterCoreTests/ModelsAndFormattingTests.swift
+++ b/ios/CodexMeterCore/Tests/CodexMeterCoreTests/ModelsAndFormattingTests.swift
@@ -20,6 +20,7 @@ final class ModelsAndFormattingTests: XCTestCase {
         XCTAssertEqual(fiveHour.remainingPercent, 0)
         XCTAssertEqual(fiveHour.windowSeconds, 0)
         XCTAssertEqual(fiveHour.effectiveResetDate(relativeTo: now), now.addingTimeInterval(60))
+        XCTAssertTrue(fiveHour.showsResetCountdown)
         XCTAssertTrue(fiveHour.hasRemainingAllowance(atOrBelow: 10))
         XCTAssertNil(
             UsageWindow(
@@ -208,6 +209,33 @@ final class ModelsAndFormattingTests: XCTestCase {
         XCTAssertEqual(ResetConsumeOutcome(code: "future_code"), .unknown("future_code"))
     }
 
+    func testResetCountdownFollowsApiTimeline() {
+        let unusedNoReset = UsageWindow(usedPercent: 0, windowSeconds: 18_000)
+        let unusedWithResetAt = UsageWindow(
+            usedPercent: 0,
+            windowSeconds: 18_000,
+            resetAt: Date(timeIntervalSince1970: 2_000_000_000)
+        )
+        let unusedWithResetAfter = UsageWindow(
+            usedPercent: 0,
+            windowSeconds: 18_000,
+            resetAfterSeconds: 600
+        )
+        let usedNoReset = UsageWindow(usedPercent: 37, windowSeconds: 18_000)
+        let usedWithReset = UsageWindow(
+            usedPercent: 37,
+            windowSeconds: 18_000,
+            resetAfterSeconds: 600,
+            resetAt: Date(timeIntervalSince1970: 2_000_000_000)
+        )
+        XCTAssertEqual(unusedNoReset.remainingPercent, 100)
+        XCTAssertFalse(unusedNoReset.showsResetCountdown)
+        XCTAssertTrue(unusedWithResetAt.showsResetCountdown)
+        XCTAssertTrue(unusedWithResetAfter.showsResetCountdown)
+        XCTAssertFalse(usedNoReset.showsResetCountdown)
+        XCTAssertTrue(usedWithReset.showsResetCountdown)
+    }
+
     func testUsageFormattingMatchesUpstreamLabelsAndDurations() {
         XCTAssertEqual(UsageFormat.planLabel(" pro-lite "), "Pro 5x")
         XCTAssertEqual(UsageFormat.planLabel("pro_20x"), "Pro 20x")
@@ -228,6 +256,28 @@ final class ModelsAndFormattingTests: XCTestCase {
             "in 1h 5m"
         )
         XCTAssertEqual(UsageFormat.relative(until: now.addingTimeInterval(59), from: now), "now")
+        XCTAssertEqual(
+            UsageFormat.reset(
+                UsageWindow(usedPercent: 0, windowSeconds: 18_000),
+                display: .relative,
+                fetchedAt: now,
+                now: now
+            ),
+            ""
+        )
+        XCTAssertEqual(
+            UsageFormat.reset(
+                UsageWindow(
+                    usedPercent: 0,
+                    windowSeconds: 18_000,
+                    resetAfterSeconds: 600
+                ),
+                display: .relative,
+                fetchedAt: now,
+                now: now
+            ),
+            "Resets in 10m"
+        )
         XCTAssertEqual(UsageFormat.updated(fetchedAt: now, now: now), "Updated just now")
         XCTAssertEqual(
             UsageFormat.updated(fetchedAt: now, now: now.addingTimeInterval(25 * 3_600)),

--- a/ios/CodexMeterWidgets/WidgetSnapshotStore.swift
+++ b/ios/CodexMeterWidgets/WidgetSnapshotStore.swift
@@ -224,7 +224,7 @@ private extension WidgetDisplaySnapshot {
         return WidgetUsageWindow(
             usedPercent: Double(window.usedPercent),
             durationSeconds: TimeInterval(window.windowSeconds),
-            resetsAt: window.resetAfterSeconds > 0 || window.resetAt != nil ? effectiveReset : nil
+            resetsAt: window.showsResetCountdown ? effectiveReset : nil
         )
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stop hiding the usage-reset countdown just because a window is still at 100% remaining.

OpenAI already reports `reset_at` / `reset_after_seconds` when a window has a real timeline. This change shows that timeline whenever it is present, including at 100% remaining, and leaves unused windows blank when those fields are absent.

## What changed
- Android `UsageWindow.showsResetCountdown()` now keys off the API reset fields instead of `remainingPercent() <= 99`.
- Wear tile reset copy no longer says "Resets soon" for unused windows with no reported timeline.
- iOS uses the same rule for dashboard cards, formatted reset strings, and widget snapshots.

## Behavior
- Genuinely unused window, no reset fields: no reset timeframe.
- 100% remaining, but API sent a timeline: show it.
- Any other usage percentage: same rule — show only if the API provided a reset.

## Testing
- `./run-tests.sh` passed, including the new `testResetCountdownFollowsApiTimeline` cases (unused/no timeline stays blank; 100% remaining with `reset_at` or `reset_after_seconds` shows the countdown).
- `swift test --package-path ios/CodexMeterCore` was not run here: this Linux VM has no Swift toolchain. iOS tests were added in `ModelsAndFormattingTests`.
- `./build.sh` could not run in this VM: Android SDK is not installed (`ANDROID_HOME` points at a missing `~/android-sdk`). The changed logic is pure Java/Swift and is covered by `run-tests.sh`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e45c986-1100-4956-b661-b88628d06bd9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e45c986-1100-4956-b661-b88628d06bd9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

